### PR TITLE
Adressing some stability issues

### DIFF
--- a/lib/mollie/api/client.js
+++ b/lib/mollie/api/client.js
@@ -107,7 +107,8 @@
         });
       });
       request.write(JSON.stringify(data));
-      return request.end();
+      request.end();
+      return request;
     };
 
     return Client;

--- a/lib/mollie/api/client.js
+++ b/lib/mollie/api/client.js
@@ -103,7 +103,19 @@
           return body += data.toString();
         });
         return response.on("end", function() {
-          return callback(JSON.parse(body));
+          var e, parsedBody;
+          if (body.length) {
+            parsedBody = {};
+            try {
+              parsedBody = JSON.parse(body);
+            } catch (_error) {
+              e = _error;
+              console.log(e);
+            }
+            return callback(parsedBody);
+          } else {
+            return callback({});
+          }
         });
       });
       request.write(JSON.stringify(data));

--- a/lib/mollie/api/resource/base.js
+++ b/lib/mollie/api/resource/base.js
@@ -67,6 +67,12 @@
           }
           return callback(_this.copy(body, new _this.constructor.object));
         };
+      })(this)).on("error", (function(_this) {
+        return function(error) {
+          return callback({
+            error: error
+          });
+        };
       })(this));
     };
 
@@ -77,6 +83,12 @@
             return callback(body);
           }
           return callback(_this.copy(body, new _this.constructor.object));
+        };
+      })(this)).on("error", (function(_this) {
+        return function(error) {
+          return callback({
+            error: error
+          });
         };
       })(this));
     };
@@ -89,6 +101,12 @@
           }
           return callback(_this.copy(body, new _this.constructor.object));
         };
+      })(this)).on("error", (function(_this) {
+        return function(error) {
+          return callback({
+            error: error
+          });
+        };
       })(this));
     };
 
@@ -99,6 +117,12 @@
             return callback(body);
           }
           return callback(_this.copy(body, new _this.constructor.object));
+        };
+      })(this)).on("error", (function(_this) {
+        return function(error) {
+          return callback({
+            error: error
+          });
         };
       })(this));
     };
@@ -118,6 +142,12 @@
             list.push(_this.copy(body.data[item], new _this.constructor.object));
           }
           return callback(list);
+        };
+      })(this)).on("error", (function(_this) {
+        return function(error) {
+          return callback({
+            error: error
+          });
         };
       })(this));
     };

--- a/src/lib/mollie/api/client.coffee
+++ b/src/lib/mollie/api/client.coffee
@@ -93,3 +93,5 @@ module.exports = class Client
 
 		request.write(JSON.stringify(data));
 		request.end();
+
+		return request;

--- a/src/lib/mollie/api/client.coffee
+++ b/src/lib/mollie/api/client.coffee
@@ -87,7 +87,17 @@ module.exports = class Client
 				body += data.toString();
 			);
 			response.on("end", ->
-				callback(JSON.parse(body))
+        if body.length
+          parsedBody = {}
+          try
+              parsedBody = JSON.parse(body)
+          catch e
+              console.log(e)
+
+          callback(parsedBody)
+        else
+          callback({})
+
 			);
 		);
 

--- a/src/lib/mollie/api/resource/base.coffee
+++ b/src/lib/mollie/api/resource/base.coffee
@@ -51,7 +51,9 @@ module.exports = class Base
 				if (body.error)
 					return callback(body);
 				callback(this.copy(body, new this.constructor.object));
-		);
+		).on("error", (error) => 
+            callback(error: error)
+        );
 
 	get: (id, callback) ->
 		this.api.callRest(
@@ -59,7 +61,9 @@ module.exports = class Base
 				if (body.error)
 					return callback(body);
 				callback(this.copy(body, new this.constructor.object));
-		);
+		).on("error", (error) => 
+            callback(error: error)
+        );
 
 	update: (id, data, callback) ->
 		this.api.callRest(
@@ -67,7 +71,9 @@ module.exports = class Base
 				if (body.error)
 					return callback(body);
 				callback(this.copy(body, new this.constructor.object));
-		);
+		).on("error", (error) => 
+            callback(error: error)
+        );
 
 	delete: (id, callback) ->
 		this.api.callRest(
@@ -75,7 +81,9 @@ module.exports = class Base
 				if (body.error)
 					return callback(body);
 				callback(this.copy(body, new this.constructor.object));
-		);
+		).on("error", (error) => 
+            callback(error: error)
+        );
 
 	all: (callback) ->
 		this.api.callRest(
@@ -92,7 +100,9 @@ module.exports = class Base
 					list.push(this.copy(body.data[item], new this.constructor.object));
 
 				callback(list);
-		);
+		).on("error", (error) => 
+            callback(error: error)
+        );
 
 	getResourceName: () ->
 		if (this.constructor.resource.indexOf("_") >= 0)


### PR DESCRIPTION
I needed issue #1 fixed for a project I'm  working, so I adressed this while trying to maintain compatibility with current installations. At the moment any uncaught HTTP error causes node to exit non gracefully. The proposed change:
- Return an object with the error key set to the resulting HTTP error. instead of crashing. Any callback checking the error within object should handle this correctly.

Also:
The delete endpoint on the mandates API returns an empty response body, also causing the application to crash. Adressed by checking the body length and parsing the JSON string within a Try/catch statement (the latter is extraneous, perhaps).

