### PR TITLE
Added Giropay and EPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Mollie API client for Node #
 
-Accepting [iDEAL](https://www.mollie.com/en/payments/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/en/payments/bancontact/), [SOFORT Banking](https://www.mollie.com/en/payments/sofort/), [Creditcard](https://www.mollie.com/en/payments/credit-card/), [SEPA Bank transfer](https://www.mollie.com/en/payments/bank-transfer/), [SEPA Direct debit](https://www.mollie.com/en/payments/direct-debit), [Bitcoin](https://www.mollie.com/en/payments/bitcoin/), [PayPal](https://www.mollie.com/en/payments/paypal/), [Belfius Direct Net](https://www.mollie.com/en/payments/belfius/), [paysafecard](https://www.mollie.com/en/payments/paysafecard/), [ING Home’Pay](https://www.mollie.com/en/payments/ing-homepay), [Giftcards](https://www.mollie.com/en/payments/gift-cards), [Giropay](https://www.mollie.com/en/payments/giropay) and [eps](https://www.mollie.com/en/payments/eps) online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
+Accepting [iDEAL](https://www.mollie.com/en/payments/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/en/payments/bancontact/), [SOFORT Banking](https://www.mollie.com/en/payments/sofort/), [Creditcard](https://www.mollie.com/en/payments/credit-card/), [SEPA Bank transfer](https://www.mollie.com/en/payments/bank-transfer/), [SEPA Direct debit](https://www.mollie.com/en/payments/direct-debit/), [Bitcoin](https://www.mollie.com/en/payments/bitcoin/), [PayPal](https://www.mollie.com/en/payments/paypal/), [Belfius Direct Net](https://www.mollie.com/en/payments/belfius/), [KBC/CBC](https://www.mollie.com/en/payments/kbc-cbc/), [paysafecard](https://www.mollie.com/en/payments/paysafecard/), [ING Home'Pay](https://www.mollie.com/en/payments/ing-homepay/), [Giftcards](https://www.mollie.com/en/payments/gift-cards/), [Giropay](https://www.mollie.com/en/payments/giropay/) and [EPS](https://www.mollie.com/en/payments/eps/) online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
 
 ## Requirements ##
 To use the Mollie API client, the following things are required:
@@ -88,7 +88,7 @@ Copyright (c) 2013-2018, Mollie B.V.
 Contact: [www.mollie.com](https://www.mollie.com) — info@mollie.com — +31 20-612 88 55
 
 + [More information about iDEAL via Mollie](https://www.mollie.com/en/payments/ideal/)
-+ [More information about credit card via Mollie](https://www.mollie.com/en/payments/credit-card/)
++ [More information about Credit card via Mollie](https://www.mollie.com/en/payments/credit-card/)
 + [More information about Bancontact/Mister Cash via Mollie](https://www.mollie.com/en/payments/bancontact/)
 + [More information about SOFORT Banking via Mollie](https://www.mollie.com/en/payments/sofort/)
 + [More information about SEPA Bank transfer via Mollie](https://www.mollie.com/en/payments/bank-transfer/)
@@ -96,8 +96,9 @@ Contact: [www.mollie.com](https://www.mollie.com) — info@mollie.com — +31 20
 + [More information about Bitcoin via Mollie](https://www.mollie.com/en/payments/bitcoin/)
 + [More information about PayPal via Mollie](https://www.mollie.com/en/payments/paypal/)
 + [More information about Belfius Direct Net via Mollie](https://www.mollie.com/en/payments/belfius/)
++ [More information about KBC/CBC via Mollie](https://www.mollie.com/en/payments/kbc-cbc/)
 + [More information about paysafecard via Mollie](https://www.mollie.com/en/payments/paysafecard/)
-+ [More information about ING Home’Pay via Mollie](https://www.mollie.com/en/payments/ing-homepay)
-+ [More information about Giftcards via Mollie](https://www.mollie.com/en/payments/gift-cards)
-+ [More information about Giropay via Mollie](https://www.mollie.com/en/payments/giropay)
-+ [More information about eps via Mollie](https://www.mollie.com/en/payments/eps)
++ [More information about ING Home’Pay via Mollie](https://www.mollie.com/en/payments/ing-homepay/)
++ [More information about Giftcards via Mollie](https://www.mollie.com/en/payments/gift-cards/)
++ [More information about Giropay via Mollie](https://www.mollie.com/en/payments/giropay/)
++ [More information about EPS via Mollie](https://www.mollie.com/en/payments/eps/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Mollie API client for Node #
 
-Accepting [iDEAL](https://www.mollie.com/en/payments/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/en/payments/bancontact/), [SOFORT Banking](https://www.mollie.com/en/payments/sofort/), [Creditcard](https://www.mollie.com/en/payments/credit-card/), [SEPA Bank transfer](https://www.mollie.com/en/payments/bank-transfer/), [SEPA Direct debit](https://www.mollie.com/en/payments/direct-debit), [Bitcoin](https://www.mollie.com/en/payments/bitcoin/), [PayPal](https://www.mollie.com/en/payments/paypal/), [Belfius Direct Net](https://www.mollie.com/en/payments/belfius/), [paysafecard](https://www.mollie.com/en/payments/paysafecard/), [ING Home’Pay](https://www.mollie.com/en/payments/ing-homepay), [Giftcards](https://www.mollie.com/en/payments/gift-cards), Giropay and eps online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
+Accepting [iDEAL](https://www.mollie.com/en/payments/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/en/payments/bancontact/), [SOFORT Banking](https://www.mollie.com/en/payments/sofort/), [Creditcard](https://www.mollie.com/en/payments/credit-card/), [SEPA Bank transfer](https://www.mollie.com/en/payments/bank-transfer/), [SEPA Direct debit](https://www.mollie.com/en/payments/direct-debit), [Bitcoin](https://www.mollie.com/en/payments/bitcoin/), [PayPal](https://www.mollie.com/en/payments/paypal/), [Belfius Direct Net](https://www.mollie.com/en/payments/belfius/), [paysafecard](https://www.mollie.com/en/payments/paysafecard/), [ING Home’Pay](https://www.mollie.com/en/payments/ing-homepay), [Giftcards](https://www.mollie.com/en/payments/gift-cards), [Giropay](https://www.mollie.com/en/payments/giropay) and [eps](https://www.mollie.com/en/payments/eps) online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
 
 ## Requirements ##
 To use the Mollie API client, the following things are required:
@@ -99,5 +99,5 @@ Contact: [www.mollie.com](https://www.mollie.com) — info@mollie.com — +31 20
 + [More information about paysafecard via Mollie](https://www.mollie.com/en/payments/paysafecard/)
 + [More information about ING Home’Pay via Mollie](https://www.mollie.com/en/payments/ing-homepay)
 + [More information about Giftcards via Mollie](https://www.mollie.com/en/payments/gift-cards)
-+ More information about Giropay via Mollie
-+ More information about eps via Mollie
++ [More information about Giropay via Mollie](https://www.mollie.com/en/payments/giropay)
++ [More information about eps via Mollie](https://www.mollie.com/en/payments/eps)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Mollie API client for Node #
 
-Accepting [iDEAL](https://www.mollie.com/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/mistercash/), [SOFORT Banking](https://www.mollie.com/sofort/), [Creditcard](https://www.mollie.com/creditcard/), [SEPA Bank transfer](https://www.mollie.com/overboeking/), [SEPA Direct debit](https://www.mollie.com/directdebit/), [Bitcoin](https://www.mollie.com/bitcoin/), [PayPal](https://www.mollie.com/paypal/), [Belfius Direct Net](https://www.mollie.com/belfiusdirectnet/), [paysafecard](https://www.mollie.com/paysafecard/) and [ING Home’Pay](https://www.mollie.com/ing-homepay) online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
+Accepting [iDEAL](https://www.mollie.com/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/mistercash/), [SOFORT Banking](https://www.mollie.com/sofort/), [Creditcard](https://www.mollie.com/creditcard/), [SEPA Bank transfer](https://www.mollie.com/overboeking/), [SEPA Direct debit](https://www.mollie.com/directdebit/), [Bitcoin](https://www.mollie.com/bitcoin/), [PayPal](https://www.mollie.com/paypal/), [Belfius Direct Net](https://www.mollie.com/belfiusdirectnet/), [paysafecard](https://www.mollie.com/paysafecard/), [ING Home’Pay](https://www.mollie.com/ing-homepay), Giropay and eps online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
 
 ## Requirements ##
 To use the Mollie API client, the following things are required:
@@ -98,3 +98,5 @@ Contact: [www.mollie.com](https://www.mollie.com) — info@mollie.com — +31 20
 + [More information about Belfius Direct Net via Mollie](https://www.mollie.com/belfiusdirectnet/)
 + [More information about paysafecard via Mollie](https://www.mollie.com/paysafecard/)
 + [More information about ING Home’Pay via Mollie](https://www.mollie.com/ing-homepay)
++ More information about Giropay via Mollie
++ More information about eps via Mollie

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Mollie API client for Node #
 
-Accepting [iDEAL](https://www.mollie.com/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/mistercash/), [SOFORT Banking](https://www.mollie.com/sofort/), [Creditcard](https://www.mollie.com/creditcard/), [SEPA Bank transfer](https://www.mollie.com/overboeking/), [SEPA Direct debit](https://www.mollie.com/directdebit/), [Bitcoin](https://www.mollie.com/bitcoin/), [PayPal](https://www.mollie.com/paypal/), [Belfius Direct Net](https://www.mollie.com/belfiusdirectnet/), [paysafecard](https://www.mollie.com/paysafecard/), [ING Home’Pay](https://www.mollie.com/ing-homepay), Giropay and eps online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
+Accepting [iDEAL](https://www.mollie.com/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/mistercash/), [SOFORT Banking](https://www.mollie.com/sofort/), [Creditcard](https://www.mollie.com/creditcard/), [SEPA Bank transfer](https://www.mollie.com/overboeking/), [SEPA Direct debit](https://www.mollie.com/directdebit/), [Bitcoin](https://www.mollie.com/bitcoin/), [PayPal](https://www.mollie.com/paypal/), [Belfius Direct Net](https://www.mollie.com/belfiusdirectnet/), [paysafecard](https://www.mollie.com/paysafecard/), [ING Home’Pay](https://www.mollie.com/ing-homepay), [Giftcards](https://www.mollie.com/gift-cards), Giropay and eps online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
 
 ## Requirements ##
 To use the Mollie API client, the following things are required:
@@ -98,5 +98,6 @@ Contact: [www.mollie.com](https://www.mollie.com) — info@mollie.com — +31 20
 + [More information about Belfius Direct Net via Mollie](https://www.mollie.com/belfiusdirectnet/)
 + [More information about paysafecard via Mollie](https://www.mollie.com/paysafecard/)
 + [More information about ING Home’Pay via Mollie](https://www.mollie.com/ing-homepay)
++ [More information about Giftcards via Mollie](https://www.mollie.com/gift-cards)
 + More information about Giropay via Mollie
 + More information about eps via Mollie

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Mollie API client for Node #
 
-Accepting [iDEAL](https://www.mollie.com/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/mistercash/), [SOFORT Banking](https://www.mollie.com/sofort/), [Creditcard](https://www.mollie.com/creditcard/), [SEPA Bank transfer](https://www.mollie.com/overboeking/), [SEPA Direct debit](https://www.mollie.com/directdebit/), [Bitcoin](https://www.mollie.com/bitcoin/), [PayPal](https://www.mollie.com/paypal/), [Belfius Direct Net](https://www.mollie.com/belfiusdirectnet/), [paysafecard](https://www.mollie.com/paysafecard/), [ING Home’Pay](https://www.mollie.com/ing-homepay), [Giftcards](https://www.mollie.com/gift-cards), Giropay and eps online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
+Accepting [iDEAL](https://www.mollie.com/en/payments/ideal/), [Bancontact/Mister Cash](https://www.mollie.com/en/payments/bancontact/), [SOFORT Banking](https://www.mollie.com/en/payments/sofort/), [Creditcard](https://www.mollie.com/en/payments/credit-card/), [SEPA Bank transfer](https://www.mollie.com/en/payments/bank-transfer/), [SEPA Direct debit](https://www.mollie.com/en/payments/direct-debit), [Bitcoin](https://www.mollie.com/en/payments/bitcoin/), [PayPal](https://www.mollie.com/en/payments/paypal/), [Belfius Direct Net](https://www.mollie.com/en/payments/belfius/), [paysafecard](https://www.mollie.com/en/payments/paysafecard/), [ING Home’Pay](https://www.mollie.com/en/payments/ing-homepay), [Giftcards](https://www.mollie.com/en/payments/gift-cards), Giropay and eps online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
 
 ## Requirements ##
 To use the Mollie API client, the following things are required:
@@ -78,7 +78,7 @@ mollie.payments.get(
 
 ## Want to help us make our API client even better? ##
 
-Want to help us make our API client even better? We take [pull requests](https://github.com/mollie/mollie-api-node/pulls?utf8=%E2%9C%93&q=is%3Apr), sure. But how would you like to contribute to a [technology oriented organization](https://www.mollie.com/nl/blog/post/werken-bij-mollie-sfeer-kansen-en-mogelijkheden/)? Mollie is hiring developers and system engineers. [Check out our vacancies](https://www.mollie.com/nl/jobs) or [get in touch](mailto:personeel@mollie.com).
+Want to help us make our API client even better? We take [pull requests](https://github.com/mollie/mollie-api-node/pulls?utf8=%E2%9C%93&q=is%3Apr), sure. But how would you like to contribute to a [technology oriented organization](https://www.mollie.com/nl/blog/post/werken-bij-mollie-sfeer-kansen-en-mogelijkheden/)? Mollie is hiring developers and system engineers. [Check out our vacancies](https://jobs.mollie.com/) or [get in touch](mailto:personeel@mollie.com).
 
 ## License ##
 [BSD (Berkeley Software Distribution) License](https://opensource.org/licenses/bsd-license.php).
@@ -87,17 +87,17 @@ Copyright (c) 2013-2018, Mollie B.V.
 ## Support ##
 Contact: [www.mollie.com](https://www.mollie.com) — info@mollie.com — +31 20-612 88 55
 
-+ [More information about iDEAL via Mollie](https://www.mollie.com/ideal/)
-+ [More information about credit card via Mollie](https://www.mollie.com/creditcard/)
-+ [More information about Bancontact/Mister Cash via Mollie](https://www.mollie.com/mistercash/)
-+ [More information about SOFORT Banking via Mollie](https://www.mollie.com/sofort/)
-+ [More information about SEPA Bank transfer via Mollie](https://www.mollie.com/banktransfer/)
-+ [More information about SEPA Direct debit via Mollie](https://www.mollie.com/directdebit/)
-+ [More information about Bitcoin via Mollie](https://www.mollie.com/bitcoin/)
-+ [More information about PayPal via Mollie](https://www.mollie.com/paypal/)
-+ [More information about Belfius Direct Net via Mollie](https://www.mollie.com/belfiusdirectnet/)
-+ [More information about paysafecard via Mollie](https://www.mollie.com/paysafecard/)
-+ [More information about ING Home’Pay via Mollie](https://www.mollie.com/ing-homepay)
-+ [More information about Giftcards via Mollie](https://www.mollie.com/gift-cards)
++ [More information about iDEAL via Mollie](https://www.mollie.com/en/payments/ideal/)
++ [More information about credit card via Mollie](https://www.mollie.com/en/payments/credit-card/)
++ [More information about Bancontact/Mister Cash via Mollie](https://www.mollie.com/en/payments/bancontact/)
++ [More information about SOFORT Banking via Mollie](https://www.mollie.com/en/payments/sofort/)
++ [More information about SEPA Bank transfer via Mollie](https://www.mollie.com/en/payments/bank-transfer/)
++ [More information about SEPA Direct debit via Mollie](https://www.mollie.com/en/payments/direct-debit/)
++ [More information about Bitcoin via Mollie](https://www.mollie.com/en/payments/bitcoin/)
++ [More information about PayPal via Mollie](https://www.mollie.com/en/payments/paypal/)
++ [More information about Belfius Direct Net via Mollie](https://www.mollie.com/en/payments/belfius/)
++ [More information about paysafecard via Mollie](https://www.mollie.com/en/payments/paysafecard/)
++ [More information about ING Home’Pay via Mollie](https://www.mollie.com/en/payments/ing-homepay)
++ [More information about Giftcards via Mollie](https://www.mollie.com/en/payments/gift-cards)
 + More information about Giropay via Mollie
 + More information about eps via Mollie

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "recurring",
     "charges",
     "inghomepay",
+    "giftcard",
+    "giftcards",
     "giropay",
     "eps"
   ],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "subscriptions",
     "recurring",
     "charges",
-    "inghomepay"
+    "inghomepay",
+    "giropay","
+    "eps"
   ],
   "dependencies": {
     "underscore": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "recurring",
     "charges",
     "inghomepay",
-    "giropay","
+    "giropay",
     "eps"
   ],
   "dependencies": {

--- a/src/lib/mollie/api/object/method.coffee
+++ b/src/lib/mollie/api/object/method.coffee
@@ -29,19 +29,22 @@
   @link        https://www.mollie.nl
 ###
 module.exports = class Method
-	this.IDEAL             = "ideal";
-	this.CREDITCARD        = "creditcard";
-	this.MISTERCASH        = "mistercash";
-	this.SOFORT            = "sofort";
 	this.BANKTRANSFER      = "banktransfer";
-	this.DIRECTDEBIT       = "directdebit";
-	this.BITCOIN           = "bitcoin";
-	this.PAYPAL            = "paypal";
 	this.BELFIUS           = "belfius";
+	this.BITCOIN           = "bitcoin";
+	this.CREDITCARD        = "creditcard";
+	this.DIRECTDEBIT       = "directdebit";
+	this.EPS               = "eps";
+	this.GIFTCARD          = "giftcard";
+	this.GIROPAY           = "giropay";
+	this.IDEAL             = "ideal";
+	this.INGHOMEPAY        = "inghomepay";
+	this.KBC               = "kbc";
+	this.MISTERCASH        = "mistercash";
+	this.PAYPAL            = "paypal";
 	this.PAYSAFECARD       = "paysafecard";
 	this.PODIUMCADEAUKAART = "podiumcadeaukaart";
-	this.KBC               = "kbc";
-	this.INGHOMEPAY        = "inghomepay";
+	this.SOFORT            = "sofort";
 
 	constructor: () ->
 		this.resource    = "method";


### PR DESCRIPTION
While I was at it, I figured it couldn't hurt to alphabetically sort the payment method constants. Furthermore, I added the `giftcard` method, as it was missing.

I updated the README to include the appropriate text for the new payment methods, but as the links to the respective payment methods are not present yet, I could not add links yet.