### PR TITLE
allow count & offset parameters in all() method

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -164,9 +164,15 @@ export default class Resource {
     if (typeof params === 'function') {
       cb = params; // eslint-disable-line no-param-reassign
     }
-
+    
+    // offset and count parameters should be passed as queryParameters, so they have a special treatment.
+    var idOverride = "", tempParams = [];
+    if (data.offset>=0) tempParams.push("offset=" + data.offset);
+    if (data.count>=0) tempParams.push("count=" + data.count);
+    if (tempParams.length>0) idOverride = '?' + tempParams.join('&');
+    
     return this.getClient()
-      .get(this.getResourceUrl(), { params })
+      .get(this.getResourceUrl() + idOverride, { params })
       .then(response => {
         const resourceName = this.getResourceName();
         const list = List.buildResourceList({


### PR DESCRIPTION
this is a bugfix in order to let count & offset to work.

in src/resource.js

--> we need to load payments in batches but there was a bug that offset + count was not passed to the api. This is what we used at LessonUp to be able to iterate. 