### PR TITLE
Convert amount from number to string in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const mollie = require('@mollie/api-client')({ apiKey: 'test_dHar4XY7LxsDOtmnkVt
 ```javascript
 mollie.payments.create({
   amount: {
-    value:    10.00,
+    value:    "10.00",
     currency: 'EUR'
   },
   description: 'My first API payment',


### PR DESCRIPTION
Hi! I'm trying out this package and I spotted a small mistake in the docs:

## What this pullrequest does:

- Corrects a small mistake in the README example. The amount is a number instead of a string which will make the API respond with a 422.
