### PR TITLE
Change webhook call from 'GET' to 'POST'

### DIFF
--- a/examples/02-webhook-verification.js
+++ b/examples/02-webhook-verification.js
@@ -15,7 +15,7 @@ const mollieClient = mollie({ apiKey: 'test_buC3bBQfSQhd4dDUeMctJjDCn3GhP4' });
  * contain the value tr_7r4n54c710n. You should use that id to actively fetch the payment to
  * find out about its status.
  */
-app.get('/webhook', (req, res) => {
+app.post('/webhook', (req, res) => {
   mollieClient.payments
     .get(req.body.id)
     .then(payment => {


### PR DESCRIPTION
Hi,

I was testing the API and I came across a small mistake in the way the webhook is called in the example file. Shouldn't the method be 'POST'? If you try with 'GET' you get a 404.

Thanks,
Tania