### PR TITLE
Two small fixes in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
   - Fixes #69.
 
 #### v2.0.0 - 2018-08-09
-  - Migrated to the v2 API. Refer to the [migration guide](/docs/migration_v3_x.md) for a complete list of changes
+  - Migrated to the v2 API. Refer to the [migration guide](https://docs.mollie.com/migrating-v1-to-v2) for a complete list of changes
 
 #### v1.3.7 - 2018-06-01
   - Update bundled cacert.pem file.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,4 @@
-# Migrating from v2.3.3 to v3.0.0
+# Migrating from v2.3.2 to v3.0.0
 
 ## Initialization
 


### PR DESCRIPTION
Is this the correct migration guide link? Please check.