### PR TITLE
add paypal mandate method

### DIFF
--- a/src/types/mandate/index.ts
+++ b/src/types/mandate/index.ts
@@ -44,6 +44,7 @@ export interface IMandateDetailsCreditCard {
 export enum MandateMethod {
   directdebit = 'directdebit',
   creditcard = 'creditcard',
+  paypal = 'paypal',
 }
 
 export enum MandateStatus {


### PR DESCRIPTION
I saw, that paypal as mandate method was missing in the typescript types, but it is available according to the docs: https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription