### PR TITLE
Accept every parameter when fetching a list of resources

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -213,24 +213,23 @@ export default class Resource {
   public async list(prms?: any, cb?: ResourceCallback): Promise<List<Model>> {
     const params = cloneDeep(prms);
     try {
-      const query: any = {};
+      let query: any = {};
+
       if (isPlainObject(params)) {
         if (typeof params.include === 'string' || Array.isArray(params.include)) {
           query.include = Array.isArray(params.include) ? params.include.join(';') : params.include;
           delete params.include;
         }
+
         if (typeof params.embed === 'string' || Array.isArray(params.embed)) {
           query.embed = Array.isArray(params.embed) ? params.embed.join(';') : params.embed;
           delete params.embed;
         }
-        if (typeof params.limit === 'number' || typeof params.limit === 'string') {
-          query.limit = params.limit;
-          delete params.limit;
-        }
-        if (typeof params.from === 'string') {
-          query.from = params.from;
-          delete params.from;
-        }
+
+        query = {
+          ...query,
+          ...params,
+        };
       }
 
       const response: AxiosResponse = await this.getClient().get(`${this.getResourceUrl()}${qs.stringify(query, { addQueryPrefix: true })}`);


### PR DESCRIPTION
One of our merchants noticed that the Klarna methods would never appear when fetching methods using the Node.js API client, while they did show up when making the API request using manually.

The reason they would not show up is because only a few of the parameters that are passed in to `Resource.list` method were actually sent to the API. The Klarna payment methods, for example, only show up when passing the option `resource: "orders"` to the Methods API.

This PR allows passing in all parameters to the API, except for the ones that require some **special 🌈** treatment (`include` & `embed`). We shouldn't care about validation for these parameters in the API client, since that's already done in the API itself.