### PR TITLE
remove @beta from installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ To use the Mollie API client, the following things are required:
 Using [npm](https://npmjs.org/):
 
 ```sh
-npm install @mollie/api-client@beta --save
+npm install @mollie/api-client --save
 ```
 
 Or using [yarn](https://yarnpkg.com/):
 
 ```sh
-yarn add @mollie/api-client@beta
+yarn add @mollie/api-client
 ```
 
 This will add `@mollie/api-client` to your project's dependencies.


### PR DESCRIPTION
Running `npm view @mollie/api-client versions` results in this:

[
  '2.0.0',        '2.0.1',
  '2.0.3',        '2.1.0',
  '2.1.1',        '2.1.2',
  '2.2.0',        '2.3.0',
  '2.3.1',        '2.3.2',
  '3.0.0-beta.1', '3.0.0',
  '3.1.0'
]

It should be safe to remove the `@beta` part from the installation instructions.