### PR TITLE
Fix embedding multiple resources

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -10,7 +10,7 @@ function stringifyQuery(input: Record<string, any>): string {
   return querystring.stringify(
     getEntries(input).reduce<Record<string, any>>((result, [key, value]) => {
       if (Array.isArray(value)) {
-        result[key] = value.join(';');
+        result[key] = value.join();
       } /* if (Array.isArray(value) == false) */ else {
         result[key] = value;
       }


### PR DESCRIPTION
We've been joining the embed arguments with a `;` [for a year now](https://github.com/mollie/mollie-api-node/blob/695b23c55f10bc4eaa72fed32602d9e394ce3450/src/resource.ts#L141), but [it looks like](https://github.com/mollie/api-documentation/blob/master/source/reference/v2/orders-api/get-order.rst#example) it should have been joined with a `,` all along.

This fixes #144.