### PR TITLE
Use Node.js' querystring instead of the external qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "lodash": "^4.17.15",
-    "qs": "^6.7.0"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.5.5",
@@ -53,7 +52,6 @@
     "@types/jest": "^24.0.16",
     "@types/lodash": "^4.14.136",
     "@types/node": "^12.6.9",
-    "@types/qs": "^6.5.3",
     "@typescript-eslint/eslint-plugin": "^2.1.0",
     "axios-mock-adapter": "^1.17.0",
     "babel-jest": "^24.8.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default {
   input: join('src', 'createMollieClient.ts'),
   external: [
     // These Node.js interenals are external to our bundles…
-    ...['fs', 'https', 'path', 'url'],
+    ...['fs', 'https', 'path', 'querystring', 'url'],
     // …as are the dependencies listed in our package.json.
     ...Object.keys(require('./package.json').dependencies),
   ],

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,14 +1,18 @@
 import { AxiosInstance, AxiosResponse } from 'axios';
 import { parse as parseUrl } from 'url';
+import { stringify as stringifyToQueryString } from 'querystring';
 import ApiError from '../errors/ApiError';
 import getEntries from '../plumbing/getEntries';
 import List from '../data/list/List';
-import querystring from 'qs';
 import Maybe from '../types/Maybe';
 
 function stringifyQuery(input: Record<string, any>): string {
-  return querystring.stringify(
-    getEntries(input).reduce<Record<string, any>>((result, [key, value]) => {
+  const entries = getEntries(input);
+  if (entries.length == 0) {
+    return '';
+  }
+  return `?${stringifyToQueryString(
+    entries.reduce<Record<string, any>>((result, [key, value]) => {
       if (Array.isArray(value)) {
         result[key] = value.join();
       } /* if (Array.isArray(value) == false) */ else {
@@ -16,8 +20,7 @@ function stringifyQuery(input: Record<string, any>): string {
       }
       return result;
     }, {}),
-    { addQueryPrefix: true },
-  );
+  )}`;
 }
 
 export default class Resource<R, T extends R> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1031,11 +1031,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
-"@types/qs@^6.5.3":
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.3.tgz#1c3b71b091eaeaf5924538006b7f70603ce63d38"
-  integrity sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==
-
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
@@ -4892,11 +4887,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-qs@^6.7.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
-  integrity sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION
We have been using the external [`qs`](https://www.npmjs.com/package/qs) library since 2.0.0, although Node.js provides an alternative out-of-the-box. (This works in Node.js 6 as well. It was introduced in Node.js 0.1.25, to be exact).