### PR TITLE
Add subscriptions_payments api

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,8 @@
   ],
   "rules": {
     "prefer-rest-params": "off",
-    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_$", "varsIgnorePattern": "^_$" }],
-    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_$", "varsIgnorePattern": "^_$" }],
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_+$", "varsIgnorePattern": "^_+$" }],
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_+$", "varsIgnorePattern": "^_+$" }],
     "@typescript-eslint/explicit-function-return-type": "off"
   },
   "settings": {

--- a/examples/subscriptions/list-payments.js
+++ b/examples/subscriptions/list-payments.js
@@ -1,5 +1,5 @@
 /**
- * @docs https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+ * @docs https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
  */
 const { createMollieClient } = require('@mollie/api-client');
 

--- a/examples/subscriptions/list-payments.js
+++ b/examples/subscriptions/list-payments.js
@@ -1,0 +1,16 @@
+/**
+ * @docs https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+ */
+const { createMollieClient } = require('@mollie/api-client');
+
+const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+(async () => {
+  try {
+    const payments = await mollieClient.subscriptions_payments.list({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
+
+    console.log(payments);
+  } catch (error) {
+    console.warn(error);
+  }
+})();

--- a/examples/subscriptions/list-payments.ts
+++ b/examples/subscriptions/list-payments.ts
@@ -1,0 +1,16 @@
+/**
+ * @docs https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+ */
+import createMollieClient, { List, Payment } from '@mollie/api-client';
+
+const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+(async () => {
+  try {
+    const payments: List<Payment> = await mollieClient.subscriptions_payments.list({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
+
+    console.log(payments);
+  } catch (error) {
+    console.warn(error);
+  }
+})();

--- a/examples/subscriptions/list-payments.ts
+++ b/examples/subscriptions/list-payments.ts
@@ -1,5 +1,5 @@
 /**
- * @docs https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+ * @docs https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
  */
 import createMollieClient, { List, Payment } from '@mollie/api-client';
 

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -29,6 +29,7 @@ import PermissionsResource from './resources/permissions/PermissionResource';
 import ProfilesResource from './resources/profiles/ProfilesResource';
 import RefundsResource from './resources/refunds/RefundsResource';
 import SubscriptionsResource from './resources/subscriptions/SubscriptionsResource';
+import SubscriptionsPaymentsResource from './resources/subscriptions/payments/SubscriptionsPaymentsResource';
 
 export type MollieOptions = AxiosRequestConfig & {
   /**
@@ -151,6 +152,7 @@ export default function createMollieClient(options: MollieOptions) {
 
     // Subscriptions API
     subscription: new SubscriptionsResource(httpClient),
+    subscriptions_payments: new SubscriptionsPaymentsResource(httpClient),
     customers_subscriptions: new CustomersSubscriptionsResource(httpClient),
 
     // Orders API

--- a/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
+++ b/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
@@ -1,0 +1,61 @@
+import { ListParameters } from './parameters';
+import { PaymentData } from '../../../data/payments/data';
+import ApiError from '../../../errors/ApiError';
+import Callback from '../../../types/Callback';
+import List from '../../../data/list/List';
+import ParentedResource from '../../ParentedResource';
+import Payment, { injectPrototypes } from '../../../data/payments/Payment';
+import checkId from '../../../plumbing/checkId';
+import renege from '../../../plumbing/renege';
+
+export default class SubscriptionsPaymentsResource extends ParentedResource<PaymentData, Payment> {
+  protected getResourceUrl(customerId: string, subscriptionId: string): string {
+    return `customers/${customerId}/subscriptions/${subscriptionId}/payments`;
+  }
+
+  protected injectPrototypes = injectPrototypes;
+
+  /**
+   * Get all of a subscription's payments.
+   *
+   * @since 3.0.0
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
+   */
+  public all: SubscriptionsPaymentsResource['list'] = this.list;
+  /**
+   * Get all of a subscription's payments.
+   *
+   * @since 3.0.0
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
+   */
+  public page: SubscriptionsPaymentsResource['list'] = this.list;
+
+  /**
+   * Get all of a subscription's payments.
+   *
+   * @since 3.0.0
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
+   */
+  public list(parameters: ListParameters): Promise<List<Payment>>;
+  public list(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public list(parameters: ListParameters) {
+    if (renege(this, this.list, ...arguments)) return;
+    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
+    const incomingParams = parameters || {};
+    const customerId = this.getParentId(incomingParams.customerId);
+    const subscriptionId = this.getParentId(incomingParams.subscriptionId);
+    if (!checkId(customerId, 'customer')) {
+      throw new ApiError('The customer id is invalid');
+    }
+
+    if (!checkId(subscriptionId, 'subscription')) {
+      throw new ApiError('The subscription id is invalid');
+    }
+
+    const { customerId: _, subscriptionId: __, ...query } = incomingParams;
+    return this.network.list(this.getResourceUrl(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, incomingParams));
+  }
+}

--- a/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
+++ b/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
@@ -16,26 +16,9 @@ export default class SubscriptionsPaymentsResource extends ParentedResource<Paym
   protected injectPrototypes = injectPrototypes;
 
   /**
-   * Get all of a subscription's payments.
+   * Retrieve all payments of a specific subscriptions of a customer.
    *
-   * @since 3.0.0
-   *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
-   */
-  public all: SubscriptionsPaymentsResource['list'] = this.list;
-  /**
-   * Get all of a subscription's payments.
-   *
-   * @since 3.0.0
-   *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
-   */
-  public page: SubscriptionsPaymentsResource['list'] = this.list;
-
-  /**
-   * Get all of a subscription's payments.
-   *
-   * @since 3.0.0
+   * @since 3.3.0
    *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
    */
@@ -43,19 +26,15 @@ export default class SubscriptionsPaymentsResource extends ParentedResource<Paym
   public list(parameters: ListParameters, callback: Callback<List<Payment>>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const incomingParams = parameters || {};
-    const customerId = this.getParentId(incomingParams.customerId);
-    const subscriptionId = this.getParentId(incomingParams.subscriptionId);
+    const customerId = this.getParentId(parameters.customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-
+    const { subscriptionId } = parameters;
     if (!checkId(subscriptionId, 'subscription')) {
       throw new ApiError('The subscription id is invalid');
     }
-
-    const { customerId: _, subscriptionId: __, ...query } = incomingParams;
-    return this.network.list(this.getResourceUrl(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, incomingParams));
+    const { customerId: _, subscriptionId: __, ...query } = parameters;
+    return this.network.list(this.getResourceUrl(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/resources/subscriptions/payments/parameters.ts
+++ b/src/resources/subscriptions/payments/parameters.ts
@@ -1,7 +1,9 @@
 import { CommonListParameters } from '../../../types/parameters';
+
 interface ContextParameters {
   testmode?: boolean;
   customerId: string;
   subscriptionId: string;
 }
+
 export type ListParameters = ContextParameters & CommonListParameters;

--- a/src/resources/subscriptions/payments/parameters.ts
+++ b/src/resources/subscriptions/payments/parameters.ts
@@ -1,0 +1,7 @@
+import { CommonListParameters } from '../../../types/parameters';
+interface ContextParameters {
+  testmode?: boolean;
+  customerId: string;
+  subscriptionId: string;
+}
+export type ListParameters = ContextParameters & CommonListParameters;

--- a/tests/unit/resources/subscriptions/payments.test.ts
+++ b/tests/unit/resources/subscriptions/payments.test.ts
@@ -1,0 +1,151 @@
+import wireMockClient from '../../../wireMockClient';
+
+test('listSubscriptionPayments', async () => {
+  const { adapter, client } = wireMockClient();
+
+  adapter.onGet('/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K/payments').reply(200, {
+    _embedded: {
+      payments: [
+        {
+          resource: 'payment',
+          id: 'tr_DtKxVP2AgW',
+          mode: 'test',
+          createdAt: '2018-09-19T12:49:52+00:00',
+          amount: {
+            value: '10.00',
+            currency: 'EUR',
+          },
+          description: 'Payment no 1',
+          method: 'directdebit',
+          metadata: null,
+          status: 'pending',
+          isCancelable: true,
+          expiresAt: '2019-09-19T12:49:52+00:00',
+          locale: 'nl_NL',
+          profileId: 'pfl_rH9rQtedgS',
+          customerId: 'cst_8wmqcHMN4U',
+          mandateId: 'mdt_aGQNkteF6w',
+          subscriptionId: 'sub_8JfGzs6v3K',
+          sequenceType: 'recurring',
+          redirectUrl: null,
+          webhookUrl: 'https://example.org/webhook',
+          settlementAmount: {
+            value: '10.00',
+            currency: 'EUR',
+          },
+          details: {
+            transferReference: 'SD67-6850-2204-6029',
+            creditorIdentifier: 'NL08ZZZ502057730000',
+            consumerName: 'Customer A',
+            consumerAccount: 'NL50INGB0006588912',
+            consumerBic: 'INGBNL2A',
+            dueDate: '2018-09-21',
+            signatureDate: '2018-09-19',
+          },
+          _links: {
+            self: {
+              href: 'https://api.mollie.com/v2/payments/tr_DtKxVP2AgW',
+              type: 'application/hal+json',
+            },
+            checkout: null,
+            customer: {
+              href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U',
+              type: 'application/hal+json',
+            },
+            mandate: {
+              href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/mandates/mdt_aGQNkteF6w',
+              type: 'application/hal+json',
+            },
+            subscription: {
+              href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K',
+              type: 'application/hal+json',
+            },
+          },
+        },
+        {
+          resource: 'payment',
+          id: 'tr_DtKxVP2AgD',
+          mode: 'test',
+          createdAt: '2018-09-19T12:49:52+00:00',
+          amount: {
+            value: '10.00',
+            currency: 'EUR',
+          },
+          description: 'Payment no 2',
+          method: 'directdebit',
+          metadata: null,
+          status: 'paid',
+          isCancelable: true,
+          expiresAt: '2019-09-19T12:49:52+00:00',
+          locale: 'nl_NL',
+          profileId: 'pfl_rH9rQtedgS',
+          customerId: 'cst_8wmqcHMN4U',
+          mandateId: 'mdt_aGQNkteF6w',
+          subscriptionId: 'sub_8JfGzs6v3K',
+          sequenceType: 'recurring',
+          redirectUrl: null,
+          webhookUrl: 'https://example.org/webhook',
+          settlementAmount: {
+            value: '10.00',
+            currency: 'EUR',
+          },
+          details: {
+            transferReference: 'SD67-6850-2204-6029',
+            creditorIdentifier: 'NL08ZZZ502057730000',
+            consumerName: 'Customer A',
+            consumerAccount: 'NL50INGB0006588912',
+            consumerBic: 'INGBNL2A',
+            dueDate: '2018-09-21',
+            signatureDate: '2018-09-19',
+          },
+          _links: {
+            self: {
+              href: 'https://api.mollie.com/v2/payments/tr_DtKxVP2AgD',
+              type: 'application/hal+json',
+            },
+            checkout: null,
+            customer: {
+              href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U',
+              type: 'application/hal+json',
+            },
+            mandate: {
+              href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/mandates/mdt_aGQNkteF6w',
+              type: 'application/hal+json',
+            },
+            subscription: {
+              href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K',
+              type: 'application/hal+json',
+            },
+          },
+        },
+      ],
+    },
+    _links: {
+      documentation: {
+        href: 'https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments',
+        type: 'text/html',
+      },
+      self: {
+        href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K/payments?limit=50',
+        type: 'application/hal+json',
+      },
+      previous: null,
+      next: null,
+    },
+    count: 2,
+  });
+
+  const payments = await bluster(client.subscriptions_payments.list.bind(client.subscriptions_payments))({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
+
+  expect(payments.length).toBe(2);
+
+  expect(payments.links.documentation).toEqual({
+    href: 'https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments',
+    type: 'text/html',
+  });
+
+  expect(payments.links.self).toEqual({
+    href: 'https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions/sub_8JfGzs6v3K/payments?limit=50',
+    type: 'application/hal+json',
+  });
+});


### PR DESCRIPTION
I added functionalities for this endpoint in NodeJS SDK: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments . We need to use it for one of our clients and I really appreciate if you can review and release a new version ASAP.