### PR TITLE
apiEndpoint option

### DIFF
--- a/tests/wireMockClient.ts
+++ b/tests/wireMockClient.ts
@@ -1,16 +1,16 @@
-import createMollieClient, { MollieClient } from '..';
+import createMollieClient, { MollieClient, MollieOptions } from '..';
 import { AxiosInstance } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {} from 'jest-bluster';
 
-export default function wireMockClient(versionStrings?: string | string[]): { adapter: MockAdapter; client: MollieClient } {
+export default function wireMockClient(options?: Omit<MollieOptions, 'accessToken' | 'adapter' | 'apiKey'>): { adapter: MockAdapter; client: MollieClient } {
   const adapter = new MockAdapter((undefined as unknown) as AxiosInstance);
   return {
     adapter,
     client: createMollieClient({
       apiKey: 'mock-api-key',
       adapter: adapter.adapter(),
-      versionStrings,
+      ...options,
     }),
   };
 }


### PR DESCRIPTION
Added `apiEndpoint` property to the options passed to `createMollieClient`.

I did not add any documentation, as I feel this feature doesn't require any extra discoverability. This is a feature which will not be of interest to the average user.

Fixes #164.