### PR TITLE
stringifyQuery fix

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -15,7 +15,9 @@ function stringifyQuery(input: Record<string, any>): string {
     entries.reduce<Record<string, any>>((result, [key, value]) => {
       if (Array.isArray(value)) {
         result[key] = value.join();
-      } /* if (Array.isArray(value) == false) */ else {
+      } else if (/* Array.isArray(value) == false && */ typeof value == 'object') {
+        getEntries(value).forEach(([innerKey, innerValue]) => (result[`${key}[${innerKey}]`] = innerValue));
+      } /* if (typeof value != 'object') */ else {
         result[key] = value;
       }
       return result;

--- a/tests/unit/networking.test.ts
+++ b/tests/unit/networking.test.ts
@@ -1,4 +1,36 @@
+import { MethodInclude } from '../..';
 import wireMockClient from '../wireMockClient';
+
+test('queryString', async () => {
+  const { adapter, client } = wireMockClient();
+
+  adapter.onGet('/methods?include=issuers%2Cpricing&amount%5Bvalue%5D=10.00&amount%5Bcurrency%5D=SEK').reply(200, {
+    _embedded: {
+      methods: [],
+    },
+    count: 0,
+    _links: {
+      documentation: {
+        href: 'https://docs.mollie.com/reference/v2/methods-api/list-methods',
+        type: 'text/html',
+      },
+      self: {
+        href: 'https://api.mollie.com/v2/methods?include=issuers%2Cpricing&amount%5Bvalue%5D=10.00&amount%5Bcurrency%5D=SEK',
+        type: 'application/hal+json',
+      },
+    },
+  });
+
+  const methods = await bluster(client.methods.all.bind(client.methods))({
+    include: [MethodInclude.issuers, MethodInclude.pricing],
+    amount: {
+      value: '10.00',
+      currency: 'SEK',
+    },
+  });
+
+  expect(methods.links.self.href).toBe('https://api.mollie.com/v2/methods?include=issuers%2Cpricing&amount%5Bvalue%5D=10.00&amount%5Bcurrency%5D=SEK');
+});
 
 test('defaults', async () => {
   const { adapter, client } = wireMockClient();


### PR DESCRIPTION
In commit 886de38650d120e0be2a85e97e676e5cf9d87597, we switched from [an external alternative](https://www.npmjs.com/package/qs) to [Node.js' querystring module](https://nodejs.org/api/querystring.html).

Unbeknownst to me, said external alternative has special logic for nested objects on which we rely [in a specific endpoint](https://docs.mollie.com/reference/v2/methods-api/list-all-methods). This commit adds that special logic to our codebase.

Additionally, I added a test to verify the behaviour of `stringifyQuery` with objects.

Fixes #165.