### PR TITLE
Pass include (payments.create) in the query string instead of the body

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -27,7 +27,7 @@ function stringifyQuery(input: Record<string, any>): string {
 
 export default class Resource<R, T extends R> {
   protected readonly network: {
-    post: <S extends T | true = T>(url: string, data: any) => Promise<S>;
+    post: <S extends T | true = T>(url: string, data: any, query?: Record<string, any>) => Promise<S>;
     get: (url: string, query?: Record<string, any>) => Promise<T>;
     list: (url: string, resourceName: string, query?: Record<string, any>) => Promise<Omit<List<T>, 'nextPage' | 'previousPage'>>;
     patch: (url: string, data: any) => Promise<T>;
@@ -37,7 +37,7 @@ export default class Resource<R, T extends R> {
   constructor(protected readonly httpClient: AxiosInstance) {
     /* eslint-disable no-var */
     this.network = {
-      post: async <S extends T | true = T>(url: string, data: any): Promise<S> => {
+      post: async <S extends T | true = T>(url: string, data: any, query: Record<string, any> = {}): Promise<S> => {
         try {
           var response: AxiosResponse = await httpClient.post(url, data);
         } catch (error) {

--- a/src/resources/payments/PaymentsResource.ts
+++ b/src/resources/payments/PaymentsResource.ts
@@ -1,5 +1,5 @@
 import { CancelParameters, CreateParameters, GetParameters, ListParameters, UpdateParameters } from './parameters';
-import { PaymentData } from '../../data/payments/data';
+import { PaymentData, PaymentInclude } from '../../data/payments/data';
 import ApiError from '../../errors/ApiError';
 import Callback from '../../types/Callback';
 import List from '../../data/list/List';
@@ -55,7 +55,12 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
   public create(parameters: CreateParameters, callback: Callback<Payment>): void;
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
-    return this.network.post(this.getResourceUrl(), parameters);
+    const { include, ...data } = parameters;
+    let query: { include: PaymentInclude[] | PaymentInclude } | undefined = undefined;
+    if (include != undefined) {
+      query = { include };
+    }
+    return this.network.post(this.getResourceUrl(), data, query);
   }
 
   /**

--- a/src/resources/payments/PaymentsResource.ts
+++ b/src/resources/payments/PaymentsResource.ts
@@ -1,5 +1,5 @@
 import { CancelParameters, CreateParameters, GetParameters, ListParameters, UpdateParameters } from './parameters';
-import { PaymentData, PaymentInclude } from '../../data/payments/data';
+import { PaymentData } from '../../data/payments/data';
 import ApiError from '../../errors/ApiError';
 import Callback from '../../types/Callback';
 import List from '../../data/list/List';
@@ -56,10 +56,7 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
     const { include, ...data } = parameters;
-    let query: { include: PaymentInclude[] | PaymentInclude } | undefined = undefined;
-    if (include != undefined) {
-      query = { include };
-    }
+    const query = include != undefined ? { include } : undefined;
     return this.network.post(this.getResourceUrl(), data, query);
   }
 


### PR DESCRIPTION
[According to the documentation](https://docs.mollie.com/reference/v2/payments-api/create-payment#qr-codes), the `include` property should be included in the query string instead of the body.

Fixes #168.