### PR TITLE
Add parameters to orders.update

### DIFF
--- a/src/resources/orders/parameters.ts
+++ b/src/resources/orders/parameters.ts
@@ -47,7 +47,7 @@ export interface GetParameters {
   embed?: OrderEmbed[];
 }
 
-export type UpdateParameters = PickOptional<OrderData, 'billingAddress' | 'shippingAddress'> & {
+export type UpdateParameters = PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'webhookUrl'> & {
   orderNumber?: string;
   testmode?: boolean;
 };


### PR DESCRIPTION
[According to the documentation](https://docs.mollie.com/reference/v2/orders-api/update-order), it is possible to update the redirect and webhook URLs for orders. Therefore, the associated properties are now included in the parameters type.

Fixes #169.