### PR TITLE
Adding `embed` param to Orders.create method

### DIFF
--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -39,7 +39,7 @@ export default class Resource<R, T extends R> {
     this.network = {
       post: async <S extends T | true = T>(url: string, data: any, query: Record<string, any> = {}): Promise<S> => {
         try {
-          var response: AxiosResponse = await httpClient.post(url, data);
+          var response: AxiosResponse = await httpClient.post(`${url}${stringifyQuery(query)}`, data);
         } catch (error) {
           if (error.response != undefined) {
             throw ApiError.createFromResponse(error.response);

--- a/src/resources/orders/OrdersResource.ts
+++ b/src/resources/orders/OrdersResource.ts
@@ -65,7 +65,7 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
     const { embed, ...data } = parameters;
-    const query = include != undefined ? { embed } : undefined;
+    const query = embed != undefined ? { embed } : undefined;
     return this.network.post(this.getResourceUrl(), data, query);
   }
 

--- a/src/resources/orders/OrdersResource.ts
+++ b/src/resources/orders/OrdersResource.ts
@@ -64,7 +64,9 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   public create(parameters: CreateParameters): void;
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
-    return this.network.post(this.getResourceUrl(), parameters);
+    const { embed, ...data } = parameters;
+    const query = include != undefined ? { embed } : undefined;
+    return this.network.post(this.getResourceUrl(), data, query);
   }
 
   /**

--- a/src/resources/orders/parameters.ts
+++ b/src/resources/orders/parameters.ts
@@ -40,6 +40,7 @@ export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billi
    * only.
    */
   shopperCountryMustMatchBillingCountry?: boolean;
+  embed?: OrderEmbed[];
   profileId?: string;
   testmode?: boolean;
 };

--- a/src/resources/orders/parameters.ts
+++ b/src/resources/orders/parameters.ts
@@ -40,7 +40,7 @@ export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billi
    * only.
    */
   shopperCountryMustMatchBillingCountry?: boolean;
-  embed?: OrderEmbed[];
+  embed?: OrderEmbed.payments[];
   profileId?: string;
   testmode?: boolean;
 };


### PR DESCRIPTION
According to the Documentation page - `embed` query param could be passed to fetch the payment data of the newly created Order.
  
https://docs.mollie.com/reference/v2/orders-api/create-order#embedding-of-related-resources

Besides that, `query` param in `post` method (added [here](https://github.com/mollie/mollie-api-node/pull/172/files)) was not used at all.