### PR TITLE
Refactor networking

### DIFF
--- a/src/NetworkClient.ts
+++ b/src/NetworkClient.ts
@@ -1,0 +1,188 @@
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import https from 'https';
+import { SecureContextOptions } from 'tls';
+import { stringify as stringifyToQueryString } from 'querystring';
+import ApiError from './errors/ApiError';
+import List from './data/list/List';
+import Maybe from './types/Maybe';
+import Options from './Options';
+import getEntries from './plumbing/getEntries';
+
+/**
+ * Like `[].map` but with support for non-array inputs, in which case this function behaves as if an array was passed
+ * with the input as its sole element.
+ */
+function map<T, U>(input: Maybe<T | T[]>, callback: (value: T, index: number) => U, context?: any): U[] {
+  if (Array.isArray(input)) {
+    return input.map(callback, context);
+  }
+  if (undefined != input) {
+    return [callback.call(context, input, 0)];
+  }
+  return [];
+}
+/**
+ * Converts `'rockenberg commerce'` to `'rockenbergCommerce'`.
+ */
+const camelCase = (() => {
+  // (Converts any character after a word boundary to upper case, except for the first character in the string.)
+  const firstIteration = [/(?!^)\b\w/g, (character: string) => character.toUpperCase()] as const;
+  // (Removes all whitespace.)
+  const secondIteration = [/\s+/g, ''] as const;
+  return function camelCase(input: string) {
+    return input.replace(...firstIteration).replace(...secondIteration);
+  };
+})();
+/**
+ * Converts `{ id: 5 }` to `'?id=5'`.
+ */
+function stringifyQuery(input: Record<string, any>): string {
+  const entries = getEntries(input);
+  if (entries.length == 0) {
+    return '';
+  }
+  return `?${stringifyToQueryString(
+    entries.reduce<Record<string, any>>((result, [key, value]) => {
+      if (Array.isArray(value)) {
+        result[key] = value.join();
+      } else if (/* Array.isArray(value) == false && */ typeof value == 'object') {
+        getEntries(value).forEach(([innerKey, innerValue]) => (result[`${key}[${innerKey}]`] = innerValue));
+      } /* if (typeof value != 'object') */ else {
+        result[key] = value;
+      }
+      return result;
+    }, {}),
+  )}`;
+}
+/**
+ * Composes a `User-Agent` header value which looks something like
+ * `'Node/10.0.0 Mollie/3.0.0 RockenbergCommerce/1.16.0'`.
+ */
+function composeUserAgent(nodeVersion: string, libraryVersion: string, versionStrings: Options['versionStrings']) {
+  return [
+    `Node/${nodeVersion}`,
+    `Mollie/${libraryVersion}`,
+    ...map(versionStrings, versionString => {
+      //                platform /version
+      const matches = /^([^\/]+)\/([^\/\s]+)$/.exec(versionString);
+      if (matches == null) {
+        if (-1 == versionString.indexOf('/') || versionString.indexOf('/') != versionString.lastIndexOf('/')) {
+          throw new Error('Invalid version string. It needs to consist of a name and version separated by a forward slash, e.g. RockenbergCommerce/3.1.12');
+        }
+        throw new Error('Invalid version string. The version may not contain any whitespace.');
+      }
+      const platform = camelCase(matches[1]);
+      const version = matches[2];
+      return `${platform}/${version}`;
+    }),
+  ].join(' ');
+}
+/**
+ * This class is essentially a wrapper around axios. It simplifies communication with the Mollie server over the
+ * network.
+ */
+export default class NetworkClient {
+  protected readonly axiosInstance: AxiosInstance;
+  constructor({
+    apiKey,
+    accessToken,
+    versionStrings,
+    apiEndpoint = 'https://api.mollie.com:443/v2/',
+    caCertificates,
+    libraryVersion,
+    nodeVersion,
+    ...axiosOptions
+  }: Options & { caCertificates?: SecureContextOptions['ca']; libraryVersion: string; nodeVersion: string }) {
+    axiosOptions.headers = { ...axiosOptions.headers };
+    // Compose the headers set in the sent requests.
+    axiosOptions.headers['User-Agent'] = composeUserAgent(nodeVersion, libraryVersion, versionStrings);
+    if (apiKey != undefined) {
+      axiosOptions.headers['Authorization'] = `Bearer ${apiKey}`;
+    } /* if (accessToken != undefined) */ else {
+      axiosOptions.headers['Authorization'] = `Bearer ${accessToken}`;
+      axiosOptions.headers['User-Agent'] += ' OAuth/2.0';
+    }
+    axiosOptions.headers['Accept'] = 'application/json';
+    axiosOptions.headers['Accept-Encoding'] = 'gzip';
+    axiosOptions.headers['Content-Type'] = 'application/json';
+    // Create the axios instance.
+    this.axiosInstance = axios.create({
+      ...axiosOptions,
+      baseURL: apiEndpoint,
+      httpsAgent: new https.Agent({
+        ca: caCertificates,
+      }),
+    });
+  }
+  /* eslint-disable no-var */
+  async post<R>(url: string, data: any, query: Record<string, any> = {}): Promise<R | true> {
+    try {
+      var response: AxiosResponse = await this.axiosInstance.post(`${url}${stringifyQuery(query)}`, data);
+    } catch (error) {
+      if (error.response != undefined) {
+        throw ApiError.createFromResponse(error.response);
+      }
+      throw new ApiError(error.message);
+    }
+    if (response.status == 204) {
+      return true;
+    }
+    return response.data;
+  }
+  async get<R>(url: string, query: Record<string, any> = {}): Promise<R> {
+    try {
+      var response: AxiosResponse = await this.axiosInstance.get(`${url}${stringifyQuery(query)}`);
+    } catch (error) {
+      if (error.response != undefined) {
+        throw ApiError.createFromResponse(error.response);
+      }
+      throw new ApiError(error.message);
+    }
+    return response.data;
+  }
+  async list<R>(url: string, resourceName: string, query: Record<string, any> = {}): Promise<Array<R> & Pick<List<R>, 'links' | 'count'>> {
+    try {
+      var response: AxiosResponse = await this.axiosInstance.get(`${url}${stringifyQuery(query)}`);
+    } catch (error) {
+      if (error.response != undefined) {
+        throw ApiError.createFromResponse(error.response);
+      }
+      throw new ApiError(error.message);
+    }
+    try {
+      var { _embedded: embedded, _links: links, count } = response.data;
+    } catch (error) {
+      throw new ApiError('Received unexpected response from the server');
+    }
+    return Object.assign(Array.from<R>(embedded[resourceName]), {
+      links,
+      count,
+    });
+  }
+  async patch<R>(url: string, data: any): Promise<R> {
+    try {
+      var response: AxiosResponse = await this.axiosInstance.patch(url, data);
+    } catch (error) {
+      if (error.response != undefined) {
+        throw ApiError.createFromResponse(error.response);
+      }
+      throw new ApiError(error.message);
+    }
+    return response.data;
+  }
+  async delete<R>(url: string, context?: any): Promise<R | true> {
+    try {
+      var response: AxiosResponse = await this.axiosInstance.delete(url, { data: context });
+    } catch (error) {
+      if (error.response != undefined) {
+        throw ApiError.createFromResponse(error.response);
+      }
+      throw new ApiError(error.message);
+    }
+    if (response.status == 204) {
+      return true;
+    }
+    return response.data as R;
+  }
+  /* eslint-enable no-var */
+}

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,0 +1,33 @@
+import { AxiosRequestConfig } from 'axios';
+import Xor from './types/Xor';
+
+type Options = Xor<
+  {
+    /**
+     * The Mollie API key, starting with `'test_'` or `'live_'`.
+     */
+    apiKey: string;
+  },
+  {
+    /**
+     * OAuth access token, starting with `'access_''.
+     */
+    accessToken: string;
+  }
+> & {
+  /**
+   * One or an array of version strings of the software you are using, such as `'RockenbergCommerce/3.1.12'`.
+   */
+  versionStrings?: string | string[];
+  /**
+   * The headers set in the requests sent to the Mollie API. `Authorization`, `User-Agent`, `Accept-Encoding`, and
+   * `Content-Type` are set by this library directly, setting them here has no effect.
+   */
+  headers?: Record<string, string>;
+  /**
+   * The URL of the root of the Mollie API. Default: `'https://api.mollie.com:443/v2/'`.
+   */
+  apiEndpoint?: string;
+} & Pick<AxiosRequestConfig, 'adapter' | 'proxy' | 'socketPath' | 'timeout'>;
+
+export default Options;

--- a/src/TransformingNetworkClient.ts
+++ b/src/TransformingNetworkClient.ts
@@ -1,0 +1,33 @@
+import NetworkClient from './NetworkClient';
+
+/**
+ * This class wraps around a `NetworkClient`, and transforms objects returned by the Mollie server.
+ */
+export default class TransformingNetworkClient<R, T> {
+  constructor(protected readonly networkClient: NetworkClient, protected readonly transform: (input: R) => T) {}
+  async post<U extends T | true = T | true>(...passingArguments: Parameters<NetworkClient['post']>): Promise<U> {
+    const response = await this.networkClient.post<R>(...passingArguments);
+    if (response == true) {
+      return true as U;
+    }
+    return this.transform(response) as U;
+  }
+  get(...passingArguments: Parameters<NetworkClient['get']>) {
+    return this.networkClient.get<R>(...passingArguments).then(this.transform);
+  }
+  async list(...passingArguments: Parameters<NetworkClient['list']>) {
+    const response = await this.networkClient.list<R>(...passingArguments);
+    const { count, links } = response;
+    return Object.assign(response.map(this.transform), { count, links });
+  }
+  patch(...passingArguments: Parameters<NetworkClient['patch']>) {
+    return this.networkClient.patch<R>(...passingArguments).then(this.transform);
+  }
+  async delete<U extends T | true = T | true>(...passingArguments: Parameters<NetworkClient['delete']>): Promise<U> {
+    const response = await this.networkClient.delete<R>(...passingArguments);
+    if (response == true) {
+      return true as U;
+    }
+    return this.transform(response) as U;
+  }
+}

--- a/src/resources/ParentedResource.ts
+++ b/src/resources/ParentedResource.ts
@@ -8,10 +8,7 @@ export default class ParentedResource<R, T extends R> extends Resource<R, T> {
    * Returns the passed parent identifier, or `defaultParentId` as set by `withParent` if the former is `undefined`.
    */
   protected getParentId(input: Maybe<string>): Maybe<string> {
-    if (input == undefined) {
-      return this.defaultParentId;
-    }
-    return input;
+    return input ?? this.defaultParentId;
   }
 
   /**

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,123 +1,14 @@
-import { AxiosInstance, AxiosResponse } from 'axios';
 import { parse as parseUrl } from 'url';
-import { stringify as stringifyToQueryString } from 'querystring';
-import ApiError from '../errors/ApiError';
-import getEntries from '../plumbing/getEntries';
 import List from '../data/list/List';
 import Maybe from '../types/Maybe';
-
-function stringifyQuery(input: Record<string, any>): string {
-  const entries = getEntries(input);
-  if (entries.length == 0) {
-    return '';
-  }
-  return `?${stringifyToQueryString(
-    entries.reduce<Record<string, any>>((result, [key, value]) => {
-      if (Array.isArray(value)) {
-        result[key] = value.join();
-      } else if (/* Array.isArray(value) == false && */ typeof value == 'object') {
-        getEntries(value).forEach(([innerKey, innerValue]) => (result[`${key}[${innerKey}]`] = innerValue));
-      } /* if (typeof value != 'object') */ else {
-        result[key] = value;
-      }
-      return result;
-    }, {}),
-  )}`;
-}
+import TransformingNetworkClient from '../TransformingNetworkClient';
 
 export default class Resource<R, T extends R> {
-  protected readonly network: {
-    post: <S extends T | true = T>(url: string, data: any, query?: Record<string, any>) => Promise<S>;
-    get: (url: string, query?: Record<string, any>) => Promise<T>;
-    list: (url: string, resourceName: string, query?: Record<string, any>) => Promise<Omit<List<T>, 'nextPage' | 'previousPage'>>;
-    patch: (url: string, data: any) => Promise<T>;
-    delete: <S extends T | true>(url: string, context?: any) => Promise<S>;
-  };
-
-  constructor(protected readonly httpClient: AxiosInstance) {
-    /* eslint-disable no-var */
-    this.network = {
-      post: async <S extends T | true = T>(url: string, data: any, query: Record<string, any> = {}): Promise<S> => {
-        try {
-          var response: AxiosResponse = await httpClient.post(`${url}${stringifyQuery(query)}`, data);
-        } catch (error) {
-          if (error.response != undefined) {
-            throw ApiError.createFromResponse(error.response);
-          }
-          throw new ApiError(error.message);
-        }
-        if (response.status == 204) {
-          return true as S;
-        }
-        return this.injectPrototypes(response.data) as S;
-      },
-      get: async (url: string, query: Record<string, any> = {}): Promise<T> => {
-        try {
-          var response: AxiosResponse = await httpClient.get(`${url}${stringifyQuery(query)}`);
-        } catch (error) {
-          if (error.response != undefined) {
-            throw ApiError.createFromResponse(error.response);
-          }
-          throw new ApiError(error.message);
-        }
-        return this.injectPrototypes(response.data);
-      },
-      list: async (url: string, resourceName: string, query: Record<string, any> = {}): Promise<Omit<List<T>, 'nextPage' | 'previousPage'>> => {
-        try {
-          var response: AxiosResponse = await httpClient.get(`${url}${stringifyQuery(query)}`);
-        } catch (error) {
-          if (error.response != undefined) {
-            throw ApiError.createFromResponse(error.response);
-          }
-          throw new ApiError(error.message);
-        }
-        try {
-          var { _embedded: embedded, _links: links, count } = response.data;
-        } catch (error) {
-          throw new ApiError('Received unexpected response from the server');
-        }
-        return Object.assign(embedded[resourceName].map(this.injectPrototypes), {
-          links,
-          count,
-        });
-      },
-      patch: async (url: string, data: any): Promise<T> => {
-        try {
-          var response: AxiosResponse = await httpClient.patch(url, data);
-        } catch (error) {
-          if (error.response != undefined) {
-            throw ApiError.createFromResponse(error.response);
-          }
-          throw new ApiError(error.message);
-        }
-        return this.injectPrototypes(response.data);
-      },
-      delete: async <S extends T | true>(url: string, context?: any): Promise<S> => {
-        try {
-          var response: AxiosResponse = await httpClient.delete(url, { data: context });
-        } catch (error) {
-          if (error.response != undefined) {
-            throw ApiError.createFromResponse(error.response);
-          }
-          throw new ApiError(error.message);
-        }
-        if (response.status == 204) {
-          return true as S;
-        }
-        return this.injectPrototypes(response.data) as S;
-      },
-    };
-    /* eslint-enable no-var */
-  }
-
+  constructor(protected readonly networkClient: TransformingNetworkClient<R, T>) {}
   /**
    * Injects `nextPage`, `nextPageCursor`, `previousPage`, and `previousPageCursor` into the passed list.
    */
-  protected injectPaginationHelpers<P>(
-    input: Omit<List<T>, 'nextPage' | 'nextPageCursor' | 'previousPage' | 'previousPageCursor'>,
-    list: (parameters: P) => Promise<List<T>>,
-    selfParameters: P,
-  ): List<T> {
+  protected injectPaginationHelpers<P>(input: Array<T> & Pick<List<T>, 'count' | 'links'>, list: (parameters: P) => Promise<List<T>>, selfParameters: P): List<T> {
     const { links } = input;
     let nextPage: Maybe<() => Promise<List<T>>>;
     let nextPageCursor: Maybe<string>;
@@ -145,12 +36,5 @@ export default class Resource<R, T extends R> {
       previousPage,
       previousPageCursor,
     }) as List<T>;
-  }
-
-  /**
-   * Injects prototypes ‒ where necessary ‒ into the response received from the Mollie server.
-   */
-  protected injectPrototypes(input: R): T {
-    return input as T;
   }
 }

--- a/src/resources/chargebacks/ChargebacksResource.ts
+++ b/src/resources/chargebacks/ChargebacksResource.ts
@@ -2,15 +2,19 @@ import { ListParameters } from './parameters';
 import Callback from '../../types/Callback';
 import Chargeback, { ChargebackData, injectPrototypes } from '../../data/chargebacks/Chargeback';
 import List from '../../data/list/List';
+import NetworkClient from '../../NetworkClient';
 import ParentedResource from '../ParentedResource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class ChargebacksResource extends ParentedResource<ChargebackData, Chargeback> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'chargebacks';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * List chargebacks
@@ -40,6 +44,6 @@ export default class ChargebacksResource extends ParentedResource<ChargebackData
   public list(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(), 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/resources/customers/CustomersResource.ts
+++ b/src/resources/customers/CustomersResource.ts
@@ -3,16 +3,20 @@ import ApiError from '../../errors/ApiError';
 import Callback from '../../types/Callback';
 import Customer, { CustomerData, injectPrototypes } from '../../data/customers/Customer';
 import List from '../../data/list/List';
+import NetworkClient from '../../NetworkClient';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 
 export default class CustomersResource extends Resource<CustomerData, Customer> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'customers';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * List Customers.
@@ -56,7 +60,7 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   public create(parameters: CreateParameters, callback: Callback<Customer>): void;
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
-    return this.network.post(this.getResourceUrl(), parameters);
+    return this.networkClient.post<Customer>(this.getResourceUrl(), parameters);
   }
 
   /**
@@ -73,7 +77,7 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
     if (!checkId(id, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    return this.network.get(`${this.getResourceUrl()}/${id}`, parameters);
+    return this.networkClient.get(`${this.getResourceUrl()}/${id}`, parameters);
   }
 
   /**
@@ -87,7 +91,7 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   public list(parameters: ListParameters, callback: Callback<List<Customer>>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(), 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 
   /**
@@ -104,7 +108,7 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
     if (!checkId(id, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    return this.network.patch(`${this.getResourceUrl()}/${id}`, parameters);
+    return this.networkClient.patch(`${this.getResourceUrl()}/${id}`, parameters);
   }
 
   /**
@@ -121,6 +125,6 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
     if (!checkId(id, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    return this.network.delete<true>(`${this.getResourceUrl()}/${id}`, parameters);
+    return this.networkClient.delete<true>(`${this.getResourceUrl()}/${id}`, parameters);
   }
 }

--- a/src/resources/customers/mandates/CustomersMandatesResource.ts
+++ b/src/resources/customers/mandates/CustomersMandatesResource.ts
@@ -4,16 +4,20 @@ import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
 import List from '../../../data/list/List';
 import Mandate, { injectPrototypes } from '../../../data/customers/mandates/Mandate';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class CustomersMandatesResource extends ParentedResource<MandateData, Mandate> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(customerId: string): string {
     return `customers/${customerId}/mandates`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Get all of a customer's mandates
@@ -64,7 +68,7 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
       throw new ApiError('The customer id is invalid');
     }
     const { customerId: _, ...data } = parameters;
-    return this.network.post(this.getResourceUrl(customerId), data);
+    return this.networkClient.post<Mandate>(this.getResourceUrl(customerId), data);
   }
 
   /**
@@ -81,13 +85,13 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
     if (!checkId(id, 'mandate')) {
       throw new ApiError('The customers_mandate id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const customerId = this.getParentId((parameters || {}).customerId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    const { customerId: _, ...query } = parameters || {};
-    return this.network.get(`${this.getResourceUrl(customerId)}/${id}`, query);
+    const { customerId: _, ...query } = parameters ?? {};
+    return this.networkClient.get(`${this.getResourceUrl(customerId)}/${id}`, query);
   }
 
   /**
@@ -101,13 +105,13 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
   public list(parameters: ListParameters, callback: Callback<List<Mandate>>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const customerId = this.getParentId((parameters || {}).customerId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    const { customerId: _, ...query } = parameters || {};
-    return this.network.list(this.getResourceUrl(customerId), 'mandates', query).then(result => this.injectPaginationHelpers(result, this.list, parameters || {}));
+    const { customerId: _, ...query } = parameters ?? {};
+    return this.networkClient.list(this.getResourceUrl(customerId), 'mandates', query).then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
   }
 
   /**
@@ -124,12 +128,12 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
     if (!checkId(id, 'mandate')) {
       throw new ApiError('The customers_mandate id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const customerId = this.getParentId((parameters || {}).customerId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer is invalid');
     }
-    const { customerId: _, ...context } = parameters || {};
-    return this.network.delete<true>(`${this.getResourceUrl(customerId)}/${id}`, context);
+    const { customerId: _, ...context } = parameters ?? {};
+    return this.networkClient.delete<true>(`${this.getResourceUrl(customerId)}/${id}`, context);
   }
 }

--- a/src/resources/customers/subscriptions/CustomersSubscriptionsResource.ts
+++ b/src/resources/customers/subscriptions/CustomersSubscriptionsResource.ts
@@ -3,17 +3,21 @@ import { SubscriptionData } from '../../../data/subscription/data';
 import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
 import List from '../../../data/list/List';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
 import Subscription, { injectPrototypes } from '../../../data/subscription/Subscription';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class CustomersSubscriptionsResource extends ParentedResource<SubscriptionData, Subscription> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(customerId: string): string {
     return `customers/${customerId}/subscriptions`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Delete a customer subscription.
@@ -56,7 +60,7 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
       throw new ApiError('The customer id is invalid');
     }
     const { customerId: _, ...data } = parameters;
-    return this.network.post(this.getResourceUrl(customerId), data);
+    return this.networkClient.post<Subscription>(this.getResourceUrl(customerId), data);
   }
 
   /**
@@ -73,13 +77,13 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
     if (!checkId(id, 'subscription')) {
       throw new ApiError('The subscription id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const customerId = this.getParentId((parameters || {}).customerId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    const { customerId: _, ...query } = parameters || {};
-    return this.network.get(`${this.getResourceUrl(customerId)}/${id}`, query);
+    const { customerId: _, ...query } = parameters ?? {};
+    return this.networkClient.get(`${this.getResourceUrl(customerId)}/${id}`, query);
   }
 
   /**
@@ -93,13 +97,13 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
   public list(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const customerId = this.getParentId((parameters || {}).customerId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
-    const { customerId: _, ...query } = parameters || {};
-    return this.network.list(this.getResourceUrl(customerId), 'subscriptions', query).then(result => this.injectPaginationHelpers(result, this.list, parameters || {}));
+    const { customerId: _, ...query } = parameters ?? {};
+    return this.networkClient.list(this.getResourceUrl(customerId), 'subscriptions', query).then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
   }
 
   /**
@@ -121,7 +125,7 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
       throw new ApiError('The customer is invalid');
     }
     const { customerId: _, ...data } = parameters;
-    return this.network.patch(`${this.getResourceUrl(customerId)}/${id}`, data);
+    return this.networkClient.patch(`${this.getResourceUrl(customerId)}/${id}`, data);
   }
 
   /**
@@ -138,12 +142,12 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
     if (!checkId(id, 'subscription')) {
       throw new ApiError('The subscription id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const customerId = this.getParentId((parameters || {}).customerId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer is invalid');
     }
-    const { customerId: _, ...context } = parameters || {};
-    return this.network.delete<Subscription>(`${this.getResourceUrl(customerId)}/${id}`, context);
+    const { customerId: _, ...context } = parameters ?? {};
+    return this.networkClient.delete<Subscription>(`${this.getResourceUrl(customerId)}/${id}`, context);
   }
 }

--- a/src/resources/methods/MethodsResource.ts
+++ b/src/resources/methods/MethodsResource.ts
@@ -3,15 +3,19 @@ import { MethodData } from '../../data/methods/data';
 import Callback from '../../types/Callback';
 import List from '../../data/list/List';
 import Method, { injectPrototypes } from '../../data/methods/Method';
+import NetworkClient from '../../NetworkClient';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class MethodsResource extends Resource<MethodData, Method> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'methods';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Retrieve a list of Payment Methods
@@ -41,7 +45,7 @@ export default class MethodsResource extends Resource<MethodData, Method> {
   public get(id: string, parameters: GetParameters, callback: Callback<Method>): void;
   public get(id: string, parameters?: GetParameters) {
     if (renege(this, this.get, ...arguments)) return;
-    return this.network.get(`${this.getResourceUrl()}/${id}`, parameters);
+    return this.networkClient.get(`${this.getResourceUrl()}/${id}`, parameters);
   }
 
   /**
@@ -55,6 +59,6 @@ export default class MethodsResource extends Resource<MethodData, Method> {
   public list(parameters: ListParameters, callback: Callback<List<Method>>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(), 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/resources/onboarding/OnboardingResource.ts
+++ b/src/resources/onboarding/OnboardingResource.ts
@@ -1,16 +1,20 @@
 import { OnboardingData } from '../../data/onboarding/data';
 import { SubmitParameters } from './parameters';
 import Callback from '../../types/Callback';
+import NetworkClient from '../../NetworkClient';
 import Onboarding, { injectPrototypes } from '../../data/onboarding/Onboarding';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class OnboardingResource extends Resource<OnboardingData, Onboarding> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'onboarding/me';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Get the status of onboarding of the authenticated organization.
@@ -23,7 +27,7 @@ export default class OnboardingResource extends Resource<OnboardingData, Onboard
   public get(callback: Callback<Onboarding>): void;
   public get() {
     if (renege(this, this.get, ...arguments)) return;
-    return this.network.get(this.getResourceUrl());
+    return this.networkClient.get(this.getResourceUrl());
   }
 
   /**
@@ -38,6 +42,6 @@ export default class OnboardingResource extends Resource<OnboardingData, Onboard
   public submit(parameters: SubmitParameters, callback: Callback<true>): void;
   public submit(parameters: SubmitParameters) {
     if (renege(this, this.submit, ...arguments)) return;
-    return this.network.post<true>(this.getResourceUrl(), parameters);
+    return this.networkClient.post<true>(this.getResourceUrl(), parameters);
   }
 }

--- a/src/resources/orders/orderlines/OrderLinesResource.ts
+++ b/src/resources/orders/orderlines/OrderLinesResource.ts
@@ -2,17 +2,21 @@ import { CancelParameters, UpdateParameters } from './parameters';
 import { OrderData } from '../../../data/orders/data';
 import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
+import NetworkClient from '../../../NetworkClient';
 import Order, { injectPrototypes } from '../../../data/orders/Order';
 import ParentedResource from '../../ParentedResource';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class OrdersLinesResource extends ParentedResource<OrderData, Order> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(orderId: string): string {
     return `orders/${orderId}/lines`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Cancel an order line by ID or multiple order lines
@@ -42,7 +46,7 @@ export default class OrdersLinesResource extends ParentedResource<OrderData, Ord
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...data } = parameters;
-    return this.network.patch(`${this.getResourceUrl(orderId)}/${id}`, data);
+    return this.networkClient.patch(`${this.getResourceUrl(orderId)}/${id}`, data);
   }
 
   /**
@@ -61,6 +65,6 @@ export default class OrdersLinesResource extends ParentedResource<OrderData, Ord
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...data } = parameters;
-    return this.network.delete<true>(this.getResourceUrl(orderId), data);
+    return this.networkClient.delete<true>(this.getResourceUrl(orderId), data);
   }
 }

--- a/src/resources/organizations/OrganizationsResource.ts
+++ b/src/resources/organizations/OrganizationsResource.ts
@@ -1,16 +1,20 @@
 import ApiError from '../../errors/ApiError';
 import Callback from '../../types/Callback';
 import checkId from '../../plumbing/checkId';
+import NetworkClient from '../../NetworkClient';
 import Organization, { injectPrototypes, OrganizationData } from '../../data/organizations/Organizations';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class OrganizationsResource extends Resource<OrganizationData, Organization> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'organizations';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Retrieve an organization by its ID.
@@ -26,7 +30,7 @@ export default class OrganizationsResource extends Resource<OrganizationData, Or
     if (!checkId(id, 'organization')) {
       throw new ApiError('The organization id is invalid');
     }
-    return this.network.get(`${this.getResourceUrl()}/${id}`);
+    return this.networkClient.get(`${this.getResourceUrl()}/${id}`);
   }
 
   /**
@@ -40,6 +44,6 @@ export default class OrganizationsResource extends Resource<OrganizationData, Or
   public getCurrent(callback: Callback<Organization>): void;
   public getCurrent() {
     if (renege(this, this.getCurrent, ...arguments)) return;
-    return this.network.get(`${this.getResourceUrl()}/me`);
+    return this.networkClient.get(`${this.getResourceUrl()}/me`);
   }
 }

--- a/src/resources/payments/chargebacks/PaymentsChargebacksResource.ts
+++ b/src/resources/payments/chargebacks/PaymentsChargebacksResource.ts
@@ -3,16 +3,20 @@ import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
 import Chargeback, { ChargebackData, injectPrototypes } from '../../../data/chargebacks/Chargeback';
 import List from '../../../data/list/List';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class PaymentsChargebacksResource extends ParentedResource<ChargebackData, Chargeback> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(paymentId: string): string {
     return `payments/${paymentId}/chargebacks`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Retrieve a list of Payment Chargebacks
@@ -45,13 +49,13 @@ export default class PaymentsChargebacksResource extends ParentedResource<Charge
     if (!checkId(id, 'refund')) {
       throw new ApiError('The payments_refund id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const paymentId = this.getParentId((parameters || {}).paymentId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.network.get(`${this.getResourceUrl(paymentId)}/${id}`, query);
+    return this.networkClient.get(`${this.getResourceUrl(paymentId)}/${id}`, query);
   }
 
   /**
@@ -65,12 +69,12 @@ export default class PaymentsChargebacksResource extends ParentedResource<Charge
   public list(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const paymentId = this.getParentId((parameters || {}).paymentId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.network.list(this.getResourceUrl(paymentId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(paymentId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/resources/payments/orders/OrdersPaymentsResource.ts
+++ b/src/resources/payments/orders/OrdersPaymentsResource.ts
@@ -2,17 +2,21 @@ import { CreateParameters } from './parameters';
 import { PaymentData } from '../../../data/payments/data';
 import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
 import Payment, { injectPrototypes } from '../../../data/payments/Payment';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class OrdersPaymentsResource extends ParentedResource<PaymentData, Payment> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(orderId: string): string {
     return `orders/${orderId}/payments`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Create order payment
@@ -30,6 +34,6 @@ export default class OrdersPaymentsResource extends ParentedResource<PaymentData
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...data } = parameters;
-    return this.network.post(this.getResourceUrl(orderId), data);
+    return this.networkClient.post<Payment>(this.getResourceUrl(orderId), data);
   }
 }

--- a/src/resources/payments/refunds/PaymentRefundsResource.ts
+++ b/src/resources/payments/refunds/PaymentRefundsResource.ts
@@ -3,17 +3,21 @@ import { RefundData } from '../../../data/refunds/data';
 import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
 import List from '../../../data/list/List';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
 import Refund, { injectPrototypes } from '../../../data/refunds/Refund';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class PaymentsRefundsResource extends ParentedResource<RefundData, Refund> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(paymentId: string): string {
     return `payments/${paymentId}/refunds`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Get all payment refunds. Alias of list.
@@ -54,7 +58,7 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...data } = parameters;
-    return this.network.post(this.getResourceUrl(paymentId), data);
+    return this.networkClient.post(this.getResourceUrl(paymentId), data);
   }
 
   /**
@@ -71,13 +75,13 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
     if (!checkId(id, 'refund')) {
       throw new ApiError('The payments_refund id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const paymentId = this.getParentId((parameters || {}).paymentId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.network.get(`${this.getResourceUrl(paymentId)}/${id}`, query);
+    return this.networkClient.get(`${this.getResourceUrl(paymentId)}/${id}`, query);
   }
 
   /**
@@ -91,13 +95,13 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
   public list(parameters: ListParameters, callback: Callback<List<Refund>>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const paymentId = this.getParentId((parameters || {}).paymentId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.network.list(this.getResourceUrl(paymentId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(paymentId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 
   /**
@@ -114,12 +118,12 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
     if (!checkId(id, 'refund')) {
       throw new ApiError('The payments_refund id is invalid');
     }
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const paymentId = this.getParentId((parameters || {}).paymentId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...context } = parameters;
-    return this.network.delete<true>(`${this.getResourceUrl(paymentId)}/${id}`, context);
+    return this.networkClient.delete<true>(`${this.getResourceUrl(paymentId)}/${id}`, context);
   }
 }

--- a/src/resources/permissions/PermissionResource.ts
+++ b/src/resources/permissions/PermissionResource.ts
@@ -2,16 +2,20 @@ import ApiError from '../../errors/ApiError';
 import Callback from '../../types/Callback';
 import checkId from '../../plumbing/checkId';
 import List from '../../data/list/List';
+import NetworkClient from '../../NetworkClient';
 import Permission, { injectPrototypes, PermissionData } from '../../data/permissions/Permission';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class PermissionsResource extends Resource<PermissionData, Permission> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'permissions';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * All API actions through OAuth are by default protected for privacy and/or money related reasons and therefore
@@ -29,7 +33,7 @@ export default class PermissionsResource extends Resource<PermissionData, Permis
     if (!checkId(id, 'permission')) {
       throw new ApiError('The permission id is invalid');
     }
-    return this.network.get(`${this.getResourceUrl()}/${id}`);
+    return this.networkClient.get(`${this.getResourceUrl()}/${id}`);
   }
 
   /**
@@ -43,6 +47,6 @@ export default class PermissionsResource extends Resource<PermissionData, Permis
   public list(callback: Callback<List<Permission>>): void;
   public list() {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.list, undefined));
+    return this.networkClient.list(this.getResourceUrl(), 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.list, undefined));
   }
 }

--- a/src/resources/profiles/ProfilesResource.ts
+++ b/src/resources/profiles/ProfilesResource.ts
@@ -3,17 +3,21 @@ import { ProfileData } from '../../data/profiles/data';
 import ApiError from '../../errors/ApiError';
 import Callback from '../../types/Callback';
 import List from '../../data/list/List';
+import NetworkClient from '../../NetworkClient';
 import Profile, { injectPrototypes } from '../../data/profiles/Profile';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 
 export default class ProfilesResource extends Resource<ProfileData, Profile> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'profiles';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * In order to process payments, you need to create a website profile. A website profile can easily be created via
@@ -27,7 +31,7 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   public create(parameters: CreateParameters, callback: Callback<Profile>): void;
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
-    return this.network.post(this.getResourceUrl(), parameters);
+    return this.networkClient.post<Profile>(this.getResourceUrl(), parameters);
   }
 
   /**
@@ -44,7 +48,7 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
     if (!checkId(id, 'profile')) {
       throw new ApiError('The profile id is invalid');
     }
-    return this.network.get(`${this.getResourceUrl()}/${id}`);
+    return this.networkClient.get(`${this.getResourceUrl()}/${id}`);
   }
 
   /**
@@ -59,7 +63,7 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   public getCurrent(callback: Callback<Profile>): void;
   public getCurrent() {
     if (renege(this, this.getCurrent, ...arguments)) return;
-    return this.network.get(`${this.getResourceUrl()}/me`);
+    return this.networkClient.get(`${this.getResourceUrl()}/me`);
   }
 
   /**
@@ -73,7 +77,7 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   public list(parameters: ListParameters, callback: Callback<List<Profile>>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(), 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 
   /**
@@ -91,7 +95,7 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
     if (!checkId(id, 'profile')) {
       throw new ApiError('The profile id is invalid');
     }
-    return this.network.patch(`${this.getResourceUrl()}/${id}`, parameters);
+    return this.networkClient.patch(`${this.getResourceUrl()}/${id}`, parameters);
   }
 
   /**
@@ -108,6 +112,6 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
     if (!checkId(id, 'profile')) {
       throw new ApiError('The profile id is invalid');
     }
-    return this.network.delete<true>(`${this.getResourceUrl()}/${id}`);
+    return this.networkClient.delete<true>(`${this.getResourceUrl()}/${id}`);
   }
 }

--- a/src/resources/profiles/methods/ProfileMethodsResource.ts
+++ b/src/resources/profiles/methods/ProfileMethodsResource.ts
@@ -1,0 +1,3 @@
+import Resource from '../../Resource';
+
+export default class ProfileMethodsResource extends Resource<ProfileData, Profile> {}

--- a/src/resources/refunds/RefundsResource.ts
+++ b/src/resources/refunds/RefundsResource.ts
@@ -2,16 +2,20 @@ import { ListParameters } from './parameters';
 import { RefundData } from '../../data/refunds/data';
 import Callback from '../../types/Callback';
 import List from '../../data/list/List';
+import NetworkClient from '../../NetworkClient';
 import Refund, { injectPrototypes } from '../../data/refunds/Refund';
 import Resource from '../Resource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class RefundsResource extends Resource<RefundData, Refund> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'refunds';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * List Refunds
@@ -41,6 +45,6 @@ export default class RefundsResource extends Resource<RefundData, Refund> {
   public list(parameters: ListParameters, callback: Callback<List<Refund>>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(), 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/resources/refunds/orders/OrdersRefundsResource.ts
+++ b/src/resources/refunds/orders/OrdersRefundsResource.ts
@@ -3,17 +3,21 @@ import { RefundData } from '../../../data/refunds/data';
 import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
 import List from '../../../data/list/List';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
 import Refund, { injectPrototypes } from '../../../data/refunds/Refund';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class RefundsResource extends ParentedResource<RefundData, Refund> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(orderId: string): string {
     return `orders/${orderId}/refunds`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Get all order refunds
@@ -48,7 +52,7 @@ export default class RefundsResource extends ParentedResource<RefundData, Refund
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...data } = parameters;
-    return this.network.post(this.getResourceUrl(orderId), data);
+    return this.networkClient.post<Refund>(this.getResourceUrl(orderId), data);
   }
 
   /**
@@ -62,12 +66,12 @@ export default class RefundsResource extends ParentedResource<RefundData, Refund
   public list(parameters: ListParameters, callback: Callback<List<Refund>>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
-    // parameters || {} is used here, because in case withParent is used, parameters could be omitted.
-    const orderId = this.getParentId((parameters || {}).orderId);
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const orderId = this.getParentId((parameters ?? {}).orderId);
     if (!checkId(orderId, 'order')) {
       throw new ApiError('The order id is invalid');
     }
-    const { orderId: _, ...query } = parameters || {};
-    return this.network.list(this.getResourceUrl(orderId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.list, parameters || {}));
+    const { orderId: _, ...query } = parameters ?? {};
+    return this.networkClient.list(this.getResourceUrl(orderId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
   }
 }

--- a/src/resources/subscriptions/SubscriptionsResource.ts
+++ b/src/resources/subscriptions/SubscriptionsResource.ts
@@ -3,15 +3,19 @@ import { SubscriptionData } from '../../data/subscription/data';
 import Callback from '../../types/Callback';
 import Subscription, { injectPrototypes } from '../../data/subscription/Subscription';
 import List from '../../data/list/List';
+import NetworkClient from '../../NetworkClient';
 import ParentedResource from '../ParentedResource';
+import TransformingNetworkClient from '../../TransformingNetworkClient';
 import renege from '../../plumbing/renege';
 
 export default class SubscriptionsResource extends ParentedResource<SubscriptionData, Subscription> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(): string {
     return 'subscriptions';
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Retrieves all subscriptions, ordered from newest to oldest.
@@ -22,6 +26,6 @@ export default class SubscriptionsResource extends ParentedResource<Subscription
   public list(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.network.list(this.getResourceUrl(), 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(), 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
+++ b/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
@@ -3,17 +3,21 @@ import { PaymentData } from '../../../data/payments/data';
 import ApiError from '../../../errors/ApiError';
 import Callback from '../../../types/Callback';
 import List from '../../../data/list/List';
+import NetworkClient from '../../../NetworkClient';
 import ParentedResource from '../../ParentedResource';
 import Payment, { injectPrototypes } from '../../../data/payments/Payment';
+import TransformingNetworkClient from '../../../TransformingNetworkClient';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 
 export default class SubscriptionsPaymentsResource extends ParentedResource<PaymentData, Payment> {
+  constructor(networkClient: NetworkClient) {
+    super(new TransformingNetworkClient(networkClient, injectPrototypes));
+  }
+
   protected getResourceUrl(customerId: string, subscriptionId: string): string {
     return `customers/${customerId}/subscriptions/${subscriptionId}/payments`;
   }
-
-  protected injectPrototypes = injectPrototypes;
 
   /**
    * Retrieve all payments of a specific subscriptions of a customer.
@@ -35,6 +39,6 @@ export default class SubscriptionsPaymentsResource extends ParentedResource<Paym
       throw new ApiError('The subscription id is invalid');
     }
     const { customerId: _, subscriptionId: __, ...query } = parameters;
-    return this.network.list(this.getResourceUrl(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list(this.getResourceUrl(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export default createMollieClient;
 
 export * from './createMollieClient';
 export type MollieClient = ReturnType<typeof createMollieClient>;
+export { default as MollieOptions } from './Options';
 
 export { default as List } from './data/list/List';
 

--- a/tests/unit/createMollieClient.test.ts
+++ b/tests/unit/createMollieClient.test.ts
@@ -2,6 +2,7 @@ import createMollieClient from '../..';
 
 describe('mollie', () => {
   it('should fail when no api key is provided', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
     // @ts-ignore
     expect(() => createMollieClient(undefined)).toThrowError(TypeError);
   });

--- a/tests/unit/resources/lists.test.ts
+++ b/tests/unit/resources/lists.test.ts
@@ -2,18 +2,19 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import CustomersResource from '../../../src/resources/customers/CustomersResource';
+import NetworkClient from '../../../src/NetworkClient';
 
 import page1 from '../__stubs__/list/customers_page_1.json';
 import page2 from '../__stubs__/list/customers_page_2.json';
 import page3 from '../__stubs__/list/customers_page_3.json';
-import List from '../../../src/data/List';
+import List from '../../../src/data/list/List';
 
 const mock = new MockAdapter(axios);
 
 describe('lists', () => {
   let customers: CustomersResource;
   beforeEach(() => {
-    customers = new CustomersResource(axios.create());
+    customers = new CustomersResource(new NetworkClient({ apiKey: 'mock-api-key', nodeVersion: process.version, libraryVersion: 'mock' }));
   });
 
   describe('.list()', () => {

--- a/tests/unit/resources/methods.test.ts
+++ b/tests/unit/resources/methods.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
 import MethodsResource from '../../../src/resources/methods/MethodsResource';
+import NetworkClient from '../../../src/NetworkClient';
 
 import response from '../__stubs__/methods.json';
 import ApiError from '../../../src/errors/ApiError';
@@ -11,7 +12,7 @@ const mock = new MockAdapter(axios);
 describe('methods', () => {
   let methods: MethodsResource;
   beforeEach(() => {
-    methods = new MethodsResource(axios.create());
+    methods = new MethodsResource(new NetworkClient({ apiKey: 'mock-api-key', nodeVersion: process.version, libraryVersion: 'mock' }));
   });
 
   describe('.get()', () => {


### PR DESCRIPTION
Before this refactor, the `Resource` class was responsible for some of the networking logic. After it, this responsibility is split into a `NetworkClient` class (shared by all resources) and a `TransformingNetworkClient` (one for each resource).

This simplifies both the `Resource` class and the `createMollieClient.ts` module.

The `Resource` (base)class is now a candidate for removal. It only contains the `injectPaginationHelpers` helper function. The `ParentedResource` (base)class is candidate for removal as well, as it only exists to facilitate `withParent` (which has been deprecated since 2.0.0).