### PR TITLE
Add documentation from docs.mollie.com

### DIFF
--- a/src/data/chargebacks/Chargeback.ts
+++ b/src/data/chargebacks/Chargeback.ts
@@ -63,7 +63,17 @@ type Chargeback = Seal<
 export default Chargeback;
 
 export interface ChargebackLinks extends Links {
+  /**
+   * The API resource URL of the payment this chargeback belongs to.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=_links/payment#response
+   */
   payment: Url;
+  /**
+   * The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=_links/settlement#response
+   */
   settlement?: Url;
 }
 

--- a/src/data/chargebacks/Chargeback.ts
+++ b/src/data/chargebacks/Chargeback.ts
@@ -5,35 +5,49 @@ import Payment, { injectPrototypes as injectPaymentPrototypes } from '../payment
 import Seal from '../../types/Seal';
 import commonHelpers from '../commonHelpers';
 
-/**
- * Chargeback Response object.
- *
- * @param resource - Indicates the response contains a Chargeback object.
- *                   Will always contain `chargeback` for this endpoint.
- * @param id - The chargeback’s unique identifier, for example `chb_n9z0tp`.
- * @param amount - The amount charged back by the consumer.
- * @param settlementAmount - This optional field will contain the amount that will be deducted from your account,
- *                           converted to the currency your account is settled in. It follows the same syntax as
- *                           the `amount` property. Note that for chargebacks, the `value` key of `settlementAmount`
- *                           will be negative. Any amounts not settled by Mollie will not be reflected in this amount,
- *                           e.g. PayPal chargebacks.
- * @param createdAt - The date and time the chargeback was issued, in ISO 8601 format.
- * @param reversedAt - The date and time the chargeback was reversed if applicable, in ISO 8601 format.
- * @param paymentId - The unique identifier of the payment this chargeback was issued for. For example: `tr_7UhSN1zuXS`.
- *                    The full payment object can be retrieved via the `payment` URL in the `_links` object.
- * @param _links - An object with several URL objects relevant to the chargeback.
- *
- * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback
- */
 export interface ChargebackData extends Model<'chargeback'> {
+  /**
+   * The amount charged back by the consumer.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=amount#response
+   */
   amount: Amount;
+  /**
+   * This optional field will contain the amount that will be deducted from your account, converted to the currency your account is settled in. It follows the same syntax as the `amount` property.
+   *
+   * Note that for chargebacks, the `value` key of `settlementAmount` will be negative.
+   *
+   * Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal chargebacks.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=settlementAmount#response
+   */
   settlementAmount: Amount;
+  /**
+   * The date and time the chargeback was issued, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * The date and time the chargeback was reversed if applicable, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=reversedAt#response
+   */
   reversedAt: string;
+  /**
+   * The unique identifier of the payment this chargeback was issued for. For example: `tr_7UhSN1zuXS`. The full payment object can be retrieved via the `payment` URL in the `_links` object.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=paymentId#response
+   */
   paymentId: string;
   _embedded?: {
     payments?: Omit<PaymentData, '_embedded'>[];
   };
+  /**
+   * An object with several URL objects relevant to the chargeback. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback?path=_links#response
+   */
   _links: ChargebackLinks;
 }
 
@@ -48,13 +62,6 @@ type Chargeback = Seal<
 
 export default Chargeback;
 
-/**
- * Chargebacks _links object
- *
- * @param payment - The API resource URL of the payment this chargeback belongs to.
- * @param settlement - The API resource URL of the settlement this payment has been settled with. Not present if not
- *                     yet settled.
- */
 export interface ChargebackLinks extends Links {
   payment: Url;
   settlement?: Url;

--- a/src/data/customers/Customer.ts
+++ b/src/data/customers/Customer.ts
@@ -3,19 +3,54 @@ import Model from '../Model';
 import Seal from '../../types/Seal';
 import commonHelpers from '../commonHelpers';
 
-/**
- * Customer Response object.
- *
- * @see https://docs.mollie.com/reference/v2/customers-api/get-customer
- */
 export interface CustomerData extends Model<'customer'> {
+  /**
+   * The mode used to create this customer.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=mode#response
+   */
   mode: ApiMode;
+  /**
+   * The full name of the customer as provided when the customer was created.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=name#response
+   */
   name: string;
+  /**
+   * The email address of the customer as provided when the customer was created.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=email#response
+   */
   email: string;
+  /**
+   * Allows you to preset the language to be used in the hosted payment pages shown to the consumer. If this parameter was not provided when the customer was created, the browser language will be used
+   * instead in the payment flow (which is usually more accurate).
+   *
+   * Possible values: `en_US` `nl_NL` `nl_BE` `fr_FR` `fr_BE` `de_DE` `de_AT` `de_CH` `es_ES` `ca_ES` `pt_PT` `it_IT` `nb_NO` `sv_SE` `fi_FI` `da_DK` `is_IS` `hu_HU` `pl_PL` `lv_LV` `lt_LT`
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=locale#response
+   */
   locale: Locale;
   recentlyUsedMethods: PaymentMethod[];
+  /**
+   * Data provided during the customer creation.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=metadata#response
+   */
   metadata: Record<string, string>;
+  /**
+   * The customer's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * An object with several URL objects relevant to the customer. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links#response
+   */
   _links: CustomerLinks;
 }
 
@@ -23,13 +58,6 @@ type Customer = Seal<CustomerData, typeof commonHelpers>;
 
 export default Customer;
 
-/**
- * Customer _links object
- *
- * @param mandates - Mandates list
- * @param subscriptions - Subscriptions list
- * @param payments - Payments list
- */
 export interface CustomerLinks extends Links {
   mandates: Url;
   subscriptions: Url;

--- a/src/data/customers/Customer.ts
+++ b/src/data/customers/Customer.ts
@@ -59,8 +59,23 @@ type Customer = Seal<CustomerData, typeof commonHelpers>;
 export default Customer;
 
 export interface CustomerLinks extends Links {
+  /**
+   * The API resource URL of the mandates belonging to the Customer, if there are no mandates this parameter is omitted.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links/mandates#response
+   */
   mandates: Url;
+  /**
+   * The API resource URL of the subscriptions belonging to the Customer, if there are no subscriptions this parameter is omitted.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links/subscriptions#response
+   */
   subscriptions: Url;
+  /**
+   * The API resource URL of the payments belonging to the Customer, if there are no payments this parameter is omitted.
+   *
+   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links/payments#response
+   */
   payments: Url;
 }
 

--- a/src/data/customers/mandates/data.ts
+++ b/src/data/customers/mandates/data.ts
@@ -2,19 +2,58 @@ import { ApiMode, CardLabel, Links, Url } from '../../global';
 import Model from '../../Model';
 import Nullable from '../../../types/Nullable';
 
-/**
- * Mandate Response object
- *
- * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate
- */
 export interface MandateData extends Model<'mandate'> {
+  /**
+   * The mode used to create this mandate.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=mode#response
+   */
   mode: ApiMode;
+  /**
+   * The status of the mandate. Please note that a status can be `pending` for mandates when the first payment is not yet finalized or when we did not received the IBAN yet.
+   *
+   * Possible values: `valid` `pending` `invalid`
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=status#response
+   */
   status: MandateStatus;
+  /**
+   * Payment method of the mandate.
+   *
+   * Possible values: `directdebit` `creditcard` `paypal`
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=method#response
+   */
   method: MandateMethod;
+  /**
+   * The mandate detail object contains different fields per payment method. See the list below.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=details#response
+   */
   details: MandateDetails;
+  /**
+   * The mandate's custom reference, if this was provided when creating the mandate.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=mandateReference#response
+   */
   mandateReference: string;
+  /**
+   * The signature date of the mandate in `YYYY-MM-DD` format.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=signatureDate#response
+   */
   signatureDate: string;
+  /**
+   * The mandate's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * An object with several URL objects relevant to the mandate. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=_links#response
+   */
   _links: MandateLinks;
 }
 

--- a/src/data/customers/mandates/data.ts
+++ b/src/data/customers/mandates/data.ts
@@ -58,6 +58,11 @@ export interface MandateData extends Model<'mandate'> {
 }
 
 export interface MandateLinks extends Links {
+  /**
+   * The API resource URL of the customer the mandate is for.
+   *
+   * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate?path=_links/customer#response
+   */
   customer: Url;
 }
 

--- a/src/data/customers/mandates/helpers.ts
+++ b/src/data/customers/mandates/helpers.ts
@@ -4,7 +4,7 @@ import commonHelpers from '../../commonHelpers';
 export default {
   ...commonHelpers,
   /**
-   * If the mandate is valid
+   * Returns whether the mandate is valid.
    */
   isValid: function isValid(this: MandateData): boolean {
     return this.status === MandateStatus.valid;

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -54,12 +54,6 @@ export enum ApiMode {
   live = 'live',
 }
 
-export interface Image {
-  size1x: string;
-  size2x: string;
-  svg: string;
-}
-
 export interface Url {
   href: string;
   type: string;

--- a/src/data/methods/data.ts
+++ b/src/data/methods/data.ts
@@ -2,33 +2,42 @@ import { Amount, FeeRegion, Image, Links, PaymentMethod as PaymentMethodEnum } f
 import Model from '../Model';
 import Nullable from '../../types/Nullable';
 
-/**
- * Method Response object.
- *
- * @param resource - Indicates the response contains a method object. Will always contain `method` for this endpoint.
- * @param id - The unique identifier of the payment method. When used during payment creation, the payment method
- *             selection screen will be skipped.
- * @param description - The full name of the payment method, translated in the optional locale passed.
- * @param image - The URLs of images representing the payment method.
- * @param pricing - See {@link IMethodPricing}
- * @param _links - An object with several URL objects relevant to the payment method.
- *
- * @see https://docs.mollie.com/reference/v2/methods-api/get-method
- */
 export interface MethodData extends Model<'method', PaymentMethodEnum> {
+  /**
+   * The full name of the payment method, translated in the optional locale passed.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=description#response
+   */
   description: string;
   /**
-   * An object containing `value` and `currency`. It represents the minimum payment amount required to use this payment
-   * method.
+   * An object containing `value` and `currency`. It represents the minimum payment amount required to use this payment method.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=minimumAmount#response
    */
   minimumAmount: Amount;
   /**
-   * An object containing `value` and `currency`. It represents the maximum payment amount allowed when using this
-   * payment method.
+   * An object containing `value` and `currency`. It represents the maximum payment amount allowed when using this payment method.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=maximumAmount#response
    */
   maximumAmount: Nullable<Amount>;
+  /**
+   * The URLs of images representing the payment method.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=image#response
+   */
   image: Image;
+  /**
+   * Pricing set of the payment method what will be include if you add the parameter.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=pricing#response
+   */
   pricing: MethodPricing;
+  /**
+   * An object with several URL objects relevant to the payment method. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=_links#response
+   */
   _links: Links;
 }
 
@@ -43,19 +52,9 @@ export enum MethodInclude {
   pricing = 'pricing',
 }
 
-/**
- * Pricing set of the payment method what will be include if you add the parameter.
- *
- * @param description - The area or product-type where the pricing is applied for, translated in the optional locale passed.
- * @param fixed - The fixed price per transaction
- * @param variable - A string containing the percentage what will be charged over the payment amount besides the fixed price.
- */
 export interface MethodPricing {
   description: string;
   fixed: Amount;
   variable: string;
-  /**
-   * This value is only available for credit card rates.
-   */
   feeRegion: FeeRegion;
 }

--- a/src/data/methods/data.ts
+++ b/src/data/methods/data.ts
@@ -1,4 +1,4 @@
-import { Amount, FeeRegion, Image, Links, PaymentMethod as PaymentMethodEnum } from '../global';
+import { Amount, FeeRegion, Links, PaymentMethod as PaymentMethodEnum } from '../global';
 import Model from '../Model';
 import Nullable from '../../types/Nullable';
 
@@ -39,6 +39,27 @@ export interface MethodData extends Model<'method', PaymentMethodEnum> {
    * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=_links#response
    */
   _links: Links;
+}
+
+export interface Image {
+  /**
+   * The URL for a payment method icon of 32x24 pixels.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=image/size1x#response
+   */
+  size1x: string;
+  /**
+   * The URL for a payment method icon of 64x48 pixels.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=image/size2x#response
+   */
+  size2x: string;
+  /**
+   * The URL for a payment method icon in vector format. Usage of this format is preferred since it can scale to any desired size.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=image/svg#response
+   */
+  svg: string;
 }
 
 export enum MethodImageSize {

--- a/src/data/methods/helpers.ts
+++ b/src/data/methods/helpers.ts
@@ -5,10 +5,11 @@ import commonHelpers from '../commonHelpers';
 export default {
   ...commonHelpers,
   /**
-   * Method image URL
+   * The URLs of images representing the payment method.
    *
    * @since 2.0.0
    * @since 3.0.0 SVG support
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=image#response
    */
   getImage: function getImage(this: MethodData, size: MethodImageSize | '1x' | '2x' = MethodImageSize.size2x): string {
     switch (size) {

--- a/src/data/onboarding/data.ts
+++ b/src/data/onboarding/data.ts
@@ -50,6 +50,16 @@ export interface OnboardingData extends Model<'onboarding', undefined> {
 }
 
 export interface OnboardingLinks extends Links {
+  /**
+   * The URL of the onboarding process in Mollie Dashboard. You can redirect your customer to here for e.g. completing the onboarding process.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=_links/dashboard#response
+   */
   dashboard: Url;
+  /**
+   * The API resource URL of the organization.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=_links/organization#response
+   */
   organization: Url;
 }

--- a/src/data/onboarding/data.ts
+++ b/src/data/onboarding/data.ts
@@ -2,47 +2,54 @@ import { Links, Url } from '../global';
 import Model from '../Model';
 
 /**
+ * Get the status of onboarding of the authenticated organization.
+ *
  * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status
  */
 export interface OnboardingData extends Model<'onboarding', undefined> {
   /**
    * The name of the organization.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=name#response
    */
   name: string;
   /**
    * The sign up date and time of the organization.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=signedUpAt#response
    */
   signedUpAt: string;
   /**
-   * The current status of the organization’s onboarding process. Possible values:
+   * The current status of the organization's onboarding process. Possible values:
    *
-   *  * `'needs-data'`: The onboarding is not completed and the merchant needs to provide (more) information
-   *  * `'in-review'`: The merchant provided all information and Mollie needs to check this
-   *  * `'completed'`: The onboarding is completed
+   * -   `needs-data` The onboarding is not completed and the merchant needs to provide (more) information
+   * -   `in-review` The merchant provided all information and Mollie needs to check this
+   * -   `completed` The onboarding is completed
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=status#response
    */
   status: 'needs-data' | 'in-review' | 'completed';
   /**
    * Whether or not the organization can receive payments.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=canReceivePayments#response
    */
   canReceivePayments: boolean;
   /**
    * Whether or not the organization can receive settlements.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=canReceiveSettlements#response
    */
   canReceiveSettlements: boolean;
   /**
-   * An object with several URL objects relevant to the onboarding status.
+   * An object with several URL objects relevant to the onboarding status. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=_links#response
    */
   _links: OnboardingLinks;
 }
 
 export interface OnboardingLinks extends Links {
-  /**
-   * The URL of the onboarding process in Mollie Dashboard. You can redirect your customer to here for e.g. completing
-   * the onboarding process.
-   */
   dashboard: Url;
-  /**
-   * The API resource URL of the organization.
-   */
   organization: Url;
 }

--- a/src/data/orders/data.ts
+++ b/src/data/orders/data.ts
@@ -175,6 +175,17 @@ export interface OrderData extends Model<'order'> {
 }
 
 export interface OrderLinks extends Links {
+  /**
+   * The URL your customer should visit to make the payment for the order. This is where you should redirect the customer to after creating the order.
+   *
+   * As long as order is still in the `created` state, this link can be used by your customer to pay for this order. You can safely share this URL with your customer.
+   *
+   * The URL can also be retrieved and copied from the Mollie Dashboard.
+   *
+   * Recurring, authorized, paid and finalized orders do not have a checkout URL.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=_links/checkout#response
+   */
   checkout?: Url;
 }
 
@@ -190,11 +201,41 @@ export enum OrderStatus {
 }
 
 export interface OrderAddress extends Address {
+  /**
+   * The person's organization, if applicable.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=organizationName#addresses
+   */
   organizationName?: string;
+  /**
+   * The title of the person.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=title#addresses
+   */
   title?: string;
+  /**
+   * The given name (first name) of the person.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=givenName#addresses
+   */
   givenName: string;
+  /**
+   * The family name (surname) of the person.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=familyName#addresses
+   */
   familyName: string;
+  /**
+   * The email address of the person.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=email#addresses
+   */
   email: string;
+  /**
+   * The phone number of the person. Will be in the [E.164](https://en.wikipedia.org/wiki/E.164) format. For example `+31208202070`.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=phone#addresses
+   */
   phone?: string;
 }
 

--- a/src/data/orders/data.ts
+++ b/src/data/orders/data.ts
@@ -6,40 +6,171 @@ import { ShipmentData } from './shipments/Shipment';
 import Model from '../Model';
 import Nullable from '../../types/Nullable';
 
-/**
- * Order Response object.
- *
- * @see https://docs.mollie.com/reference/v2/orders-api/get-order
- */
 export interface OrderData extends Model<'order'> {
+  /**
+   * The mode used to create this order.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=mode#response
+   */
   mode: ApiMode;
+  /**
+   * The profile the order was created on, for example `pfl_v9hTwCvYqw`.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=profileId#response
+   */
   profileId: string;
+  /**
+   * The payment method last used when paying for the order.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=method#response
+   */
   method: Nullable<string>;
+  /**
+   * The total amount of the order, including VAT and discounts.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=amount#response
+   */
   amount: Amount;
+  /**
+   * The amount captured, thus far. The captured amount will be settled to your account.
+   *
+   * For orders that have the status `authorized`, you must ship the order to ensure the order amount gets captured.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=amountCaptured#response
+   */
   amountCaptured?: Nullable<Amount>;
+  /**
+   * The total amount refunded, thus far.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=amountRefunded#response
+   */
   amountRefunded?: Nullable<Amount>;
+  /**
+   * The status of the order. One of the following values:
+   *
+   * -   `created`
+   * -   `paid`
+   * -   `authorized`
+   * -   `canceled`
+   * -   `shipping`
+   * -   `completed`
+   * -   `expired`
+   *
+   * See Order status changes for details on the orders' statuses.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=status#response
+   */
   status: OrderStatus;
+  /**
+   * Whether or not the order can be (partially) canceled.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=isCancelable#response
+   */
   isCancelable: boolean;
+  /**
+   * The person and the address the order is billed to. See below.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=billingAddress#response
+   */
   billingAddress: OrderAddress;
+  /**
+   * The date of birth of your customer, if available.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=consumerDateOfBirth#response
+   */
   consumerDateOfBirth?: string;
+  /**
+   * Your order number that was used when creating the order.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=orderNumber#response
+   */
   orderNumber: string;
+  /**
+   * The person and the address the order is billed to. See below.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=shippingAddress#response
+   */
   shippingAddress: OrderAddress;
+  /**
+   * The locale used during checkout. Note that the locale may have been changed by your customer during checkout.
+   *
+   * Can be any ISO 15897 locale. Example values: `en_US` `nl_NL` `nl_BE` `fr_FR` `fr_BE` `de_DE` `de_AT` `de_CH` `es_ES` `ca_ES` `pt_PT` `it_IT` `nb_NO` `sv_SE` `fi_FI` `da_DK` `is_IS` `hu_HU`
+   * `pl_PL` `lv_LV` `lt_LT`.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=locale#response
+   */
   locale: string;
+  /**
+   * Data provided during the order creation.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=metadata#response
+   */
   metadata?: any;
+  /**
+   * The URL your customer will be redirected to after completing or canceling the payment process.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=redirectUrl#response
+   */
   redirectUrl: Nullable<string>;
   lines: OrderLineData[];
+  /**
+   * The URL Mollie will call as soon an important status change on the order takes place.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=webhookUrl#response
+   */
   webhookUrl?: string;
+  /**
+   * The order's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * The date and time the order will expire, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. Note that you have until this date to fully ship the order.
+   *
+   * For some payment methods, such as *Klarna Pay later* this means that you will lose the authorization and not be settled for the amounts of the unshipped order lines.
+   *
+   * The expiry period for orders is 28 days.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=expiresAt#response
+   */
   expiresAt?: string;
+  /**
+   * If the order has been paid, the time of payment will be present in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=paidAt#response
+   */
   paidAt?: string;
+  /**
+   * If the order has been authorized, the time of authorization will be present in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=authorizedAt#response
+   */
   authorizedAt?: string;
+  /**
+   * If the order has been canceled, the time of cancellation will be present in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=canceledAt#response
+   */
   canceledAt?: string;
+  /**
+   * If the order is completed, the time of completion will be present in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=completedAt#response
+   */
   completedAt?: string;
   _embedded?: {
     payments?: Omit<PaymentData, '_embedded'>[];
     refunds?: Omit<RefundData, '_embedded'>[];
     shipments?: Omit<ShipmentData, '_embedded'>[];
   };
+  /**
+   * An object with several URL objects relevant to the order. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=_links#response
+   */
   _links: OrderLinks;
 }
 

--- a/src/data/orders/orderlines/OrderLine.ts
+++ b/src/data/orders/orderlines/OrderLine.ts
@@ -158,7 +158,17 @@ type OrderLine = Seal<OrderLineData, typeof commonHelpers>;
 export default OrderLine;
 
 export interface OrderLineLinks {
+  /**
+   * A link pointing to the product page in your web shop of the product sold.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=_links/productUrl#order-line-details
+   */
   productUrl: Url;
+  /**
+   * A link pointing to an image of the product sold.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=_links/imageUrl#order-line-details
+   */
   imageUrl: Url;
 }
 

--- a/src/data/orders/orderlines/OrderLine.ts
+++ b/src/data/orders/orderlines/OrderLine.ts
@@ -4,32 +4,151 @@ import Model from '../../Model';
 import Seal from '../../../types/Seal';
 import commonHelpers from '../../commonHelpers';
 
-/**
- * OrderLine Response object.
- */
 export interface OrderLineData extends Model<'orderline'> {
+  /**
+   * The ID of the order the line belongs too, for example `ord_kEn1PlbGa`.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=orderId#order-line-details
+   */
   orderId?: string;
+  /**
+   * Always `orderline`.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=type#order-line-details
+   */
   type: OrderLineType;
+  /**
+   * A description of the order line, for example *LEGO 4440 Forest Police Station*.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=name#order-line-details
+   */
   name: string;
+  /**
+   * Status of the order line. One of the following values:
+   *
+   * -   `created`
+   * -   `authorized`
+   * -   `paid`
+   * -   `shipping`
+   * -   `canceled`
+   * -   `completed`
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=status#order-line-details
+   */
   status: OrderStatus;
+  /**
+   * Whether or not the order line can be (partially) canceled.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=isCancelable#order-line-details
+   */
   isCancelable: boolean;
+  /**
+   * The number of items in the order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=quantity#order-line-details
+   */
   quantity: number;
+  /**
+   * The number of items that are shipped for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=quantityShipped#order-line-details
+   */
   quantityShipped: number;
+  /**
+   * The total amount that is shipped for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=amountShipped#order-line-details
+   */
   amountShipped: Amount;
+  /**
+   * The number of items that are refunded for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=quantityRefunded#order-line-details
+   */
   quantityRefunded: number;
+  /**
+   * The total amount that is refunded for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=amountRefunded#order-line-details
+   */
   amountRefunded: Amount;
+  /**
+   * The number of items that are canceled in this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=quantityCanceled#order-line-details
+   */
   quantityCanceled: number;
+  /**
+   * The total amount that is canceled in this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=amountCanceled#order-line-details
+   */
   amountCanceled: Amount;
+  /**
+   * The number of items that can still be shipped for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=shippableQuantity#order-line-details
+   */
   shippableQuantity: number;
+  /**
+   * The number of items that can still be refunded for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=refundableQuantity#order-line-details
+   */
   refundableQuantity: number;
+  /**
+   * The number of items that can still be canceled for this order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=cancelableQuantity#order-line-details
+   */
   cancelableQuantity: number;
+  /**
+   * The price of a single item including VAT in the order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=unitPrice#order-line-details
+   */
   unitPrice: Amount;
+  /**
+   * Any discounts applied to the order line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=discountAmount#order-line-details
+   */
   discountAmount?: Amount;
+  /**
+   * The total amount of the line, including VAT and discounts.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=totalAmount#order-line-details
+   */
   totalAmount: Amount;
+  /**
+   * The VAT rate applied to the order line, for example `"21.00"` for 21%. The `vatRate` is passed as a string and not as a float to ensure the correct number of decimals are passed.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=vatRate#order-line-details
+   */
   vatRate: string;
+  /**
+   * The amount of value-added tax on the line.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=vatAmount#order-line-details
+   */
   vatAmount: Amount;
+  /**
+   * The SKU, EAN, ISBN or UPC of the product sold.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=sku#order-line-details
+   */
   sku?: string;
+  /**
+   * The order line's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=createdAt#order-line-details
+   */
   createdAt: string;
+  /**
+   * An object with several URL objects relevant to the order line. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=_links#order-line-details
+   */
   _links: OrderLineLinks;
   metadata: any;
 }

--- a/src/data/orders/shipments/Shipment.ts
+++ b/src/data/orders/shipments/Shipment.ts
@@ -45,12 +45,32 @@ type Shipment = Seal<ShipmentData & { lines: OrderLine[] }, typeof commonHelpers
 export default Shipment;
 
 export interface ShipmentLinks extends Links {
+  /**
+   * The resource URL of the order this shipment was created for.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=_links/order#response
+   */
   order: Url;
 }
 
 export interface ShipmentTracking {
+  /**
+   * The name of the postal carrier.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=tracking/carrier#response
+   */
   carrier: string;
+  /**
+   * The track and trace code for the shipment.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=tracking/code#response
+   */
   code: string;
+  /**
+   * The URL where your customer can track the shipment.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=tracking/url#response
+   */
   url?: string;
 }
 

--- a/src/data/orders/shipments/Shipment.ts
+++ b/src/data/orders/shipments/Shipment.ts
@@ -5,13 +5,38 @@ import Seal from '../../../types/Seal';
 import commonHelpers from '../../commonHelpers';
 
 export interface ShipmentData extends Model<'shipment'> {
+  /**
+   * The order this shipment was created on, for example `ord_8wmqcHMN4U`.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=orderId#response
+   */
   orderId: string;
+  /**
+   * The shipment's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=createdAt#response
+   */
   createdAt: string;
   /**
-   * An object containing shipment tracking details.
+   * An object containing shipment tracking details. Will be omitted when no tracking details are available.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=tracking#response
    */
   tracking?: ShipmentTracking;
+  /**
+   * An array of order line objects as described in Get order.
+   *
+   * The lines will show the `quantity`, `discountAmount`, `vatAmount` and `totalAmount` shipped in this shipment. If the line was partially shipped, these values will be different from the values in
+   * response from the Get order API.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=lines#response
+   */
   lines: OrderLineData[];
+  /**
+   * An object with several URL objects relevant to the shipment. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment?path=_links#response
+   */
   _links: ShipmentLinks;
 }
 
@@ -19,28 +44,13 @@ type Shipment = Seal<ShipmentData & { lines: OrderLine[] }, typeof commonHelpers
 
 export default Shipment;
 
-/**
- * Shipments _links object
- *
- * @param order - The resource URL of the order this shipment was created for.
- */
 export interface ShipmentLinks extends Links {
   order: Url;
 }
 
 export interface ShipmentTracking {
-  /**
-   * Name of the postal carrier (as specific as possible). For example `'PostNL'`.
-   */
   carrier: string;
-  /**
-   * The track and trace code of the shipment. For example `'3SKABA000000000'`.
-   */
   code: string;
-  /**
-   * The URL where your customer can track the shipment, for example:
-   * `'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'`.
-   */
   url?: string;
 }
 

--- a/src/data/organizations/Organizations.ts
+++ b/src/data/organizations/Organizations.ts
@@ -3,38 +3,47 @@ import Model from '../Model';
 import Seal from '../../types/Seal';
 import commonHelpers from '../commonHelpers';
 
-/**
- * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization
- */
 export interface OrganizationData extends Model<'organization', string> {
   /**
    * The name of the organization.
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=name#response
    */
   name: string;
   /**
    * The preferred locale of the merchant which has been set in Mollie Dashboard.
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=locale#response
    */
   locale: Locale;
   /**
    * The address of the organization.
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=address#response
    */
   address: Address;
   /**
    * The registration number of the organization at the (local) chamber of commerce.
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=registrationNumber#response
    */
   registrationNumber: string;
   /**
-   * The VAT number of the organization, if based in the European Union. The VAT number has been checked with the VIES
-   * service by Mollie.
+   * The VAT number of the organization, if based in the European Union. The VAT number has been checked with the [VIES](http://ec.europa.eu/taxation_customs/vies/) service by Mollie.
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=vatNumber#response
    */
   vatNumber: string;
   /**
-   * The organization's VAT regulation, if based in the European Union. Either shifted (VAT is shifted) or dutch (Dutch
-   * VAT rate).
+   * The organization's VAT regulation, if based in the European Union. Either `shifted` (VAT is shifted) or `dutch` (Dutch VAT rate).
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=vatRegulation#response
    */
   vatRegulation: string;
   /**
-   * An object with several URL objects relevant to the organization.
+   * An object with several URL objects relevant to the organization. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=_links#response
    */
   _links: OrganizationLinks;
 }

--- a/src/data/payments/captures/Capture.ts
+++ b/src/data/payments/captures/Capture.ts
@@ -3,37 +3,57 @@ import Model from '../../Model';
 import Seal from '../../../types/Seal';
 import commonHelpers from '../../commonHelpers';
 
-/**
- * Capture Response object.
- *
- * @param resource - Indicates the response contains a capture object. Will always contain `capture` for this endpoint.
- * @param id - The capture’s unique identifier, for example `cpt_4qqhO89gsT`.
- * @param mode - The mode used to create this capture.
- * @param amount - The amount captured.
- * @param settlementAmount - This optional field will contain the amount that will be settled to your account, converted
- *                           to the currency your account is settled in. It follows the same syntax as the `amount` property.
- * @param paymentId - The unique identifier of the payment this capture was created for, for example: `tr_7UhSN1zuXS`.
- *                    The full payment object can be retrieved via the `payment` URL in the `_links` object.
- * @param shipmentId - The unique identifier of the shipment that triggered the creation of this capture, for example:
- *                     `shp_3wmsgCJN4U`. The full shipment object can be retrieved via the `shipment` URL in the
- *                     `_links` object.
- * @param settlementId - The unique identifier of the settlement this capture was settled with, for example:
- *                       `stl_jDk30akdN`. The full settlement object can be retrieved via the `capture` URL in the
- *                       `_links` object.
- * @param createdAt - The capture’s date and time of creation, in ISO 8601 format.
- * @param _links - An object with several URL objects relevant to the capture. Every URL object will contain an `href`
- *                 and a `type` field.
- *
- * @see https://docs.mollie.com/reference/v2/captures-api/get-capture
- */
 export interface CaptureData extends Model<'capture'> {
+  /**
+   * The mode used to create this capture.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=mode#response
+   */
   mode: ApiMode;
+  /**
+   * The amount captured.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=amount#response
+   */
   amount: Amount;
+  /**
+   * This optional field will contain the amount that will be settled to your account, converted to the currency your account is settled in. It follows the same syntax as the `amount` property.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=settlementAmount#response
+   */
   settlementAmount: Amount;
+  /**
+   * The unique identifier of the payment this capture was created for, for example: `tr_7UhSN1zuXS`. The full payment object can be retrieved via the `payment` URL in the `_links` object.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=paymentId#response
+   */
   paymentId: string;
+  /**
+   * The unique identifier of the shipment that triggered the creation of this capture, for example: `shp_3wmsgCJN4U`. The full shipment object can be retrieved via the `shipment` URL in the `_links`
+   * object.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=shipmentId#response
+   */
   shipmentId?: string;
+  /**
+   * The unique identifier of the settlement this capture was settled with, for example: `stl_jDk30akdN`. The full settlement object can be retrieved via the `capture` URL in the `_links` object.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=settlementId#response
+   */
   settlementId?: string;
+  /**
+   * The capture's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * An object with several URL objects relevant to the capture. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links#response
+   */
   _links: CaptureLinks;
 }
 

--- a/src/data/payments/captures/Capture.ts
+++ b/src/data/payments/captures/Capture.ts
@@ -62,8 +62,23 @@ type Capture = Seal<CaptureData, typeof commonHelpers>;
 export default Capture;
 
 export interface CaptureLinks extends Links {
+  /**
+   * The API resource URL of the payment the capture belongs to.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links/payment#response
+   */
   payment: Url;
+  /**
+   * The API resource URL of the shipment that triggered the capture to be created.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links/shipment#response
+   */
   shipment?: Url;
+  /**
+   * The API resource URL of the settlement this capture has been settled with. Not present if not yet settled.
+   *
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links/settlement#response
+   */
   settlement?: Url;
 }
 

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -4,134 +4,217 @@ import { ChargebackData } from '../chargebacks/Chargeback';
 import Model from '../Model';
 import Nullable from '../../types/Nullable';
 
-/**
- * Payment Response Object.
- *
- * @param resource - Indicates the response contains a payment object.
- *                   Will always contain `payment` for this endpoint.
- * @param id - The identifier uniquely referring to this payment.
- *             Mollie assigns this identifier at payment creation time.
- *             For example `tr_7UhSN1zuXS`. Its ID will always be used
- *             by Mollie to refer to a certain payment.
- * @param mode - The mode used to create this payment. Mode determines
- *               whether a payment is real (live mode) or a test payment.
- * @param createdAt - The payment’s date and time of creation, in ISO
- *                    8601 format.
- * @param status - The payment’s status. Please refer to the documentation
- *                 regarding statuses for more info about which statuses
- *                 occur at what point.
- * @param isCancelable - Whether or not the payment can be canceled.
- * @param authorizedAt - The date and time the payment became authorized,
- *                       in ISO 8601 format. This parameter is omitted if
- *                       the payment is not authorized (yet).
- * @param paidAt - The date and time the payment became paid, in ISO 8601
- *                 format. This parameter is omitted if the payment is not
- *                 completed (yet).
- * @param canceledAt - The date and time the payment was canceled, in
- *                     ISO 8601 format. This parameter is omitted if the
- *                     payment is not canceled (yet).
- * @param expiresAt - The date and time the payment will expire, in
- *                    ISO 8601 format.
- * @param expiredAt - The date and time the payment was expired, in
- *                    ISO 8601 format. This parameter is omitted if the
- *                    payment did not expire (yet).
- * @param failedAt - The date and time the payment failed, in ISO 8601 format.
- *                   This parameter is omitted if the payment did not fail (yet).
- * @param amount - The amount of the payment, e.g. `{"currency":"EUR", "value":"100.00"}`
- *                 for a €100.00 payment.
- * @param amountRefunded - The total amount that is already refunded. Only
- *                         available when refunds are available for this payment.
- *                         For some payment methods, this amount may be higher than
- *                         the payment amount, for example to allow reimbursement of
- *                         the costs for a return shipment to the customer.
- * @param amountRemaining - The remaining amount that can be refunded. Only available
- *                          when refunds are available for this payment.
- * @param amountCaptured - The total amount that is already captured for this payment.
- *                         Only available when this payment supports captures.
- * @param description - A short description of the payment. The description is visible
- *                      in the Dashboard and will be shown on the customer’s bank or card
- *                      statement when possible.
- * @param redirectUrl - The URL your customer will be redirected to after completing or
- *                      canceling the payment process. (The URL will be `null` for
- *                      recurring payments.)`
- * @param webhookUrl - The URL Mollie will call as soon an important status change
- *                     takes place.
- * @param method - The payment method used for this payment, either forced on creation
- *                 by specifying the method parameter, or chosen by the customer on our
- *                 payment method selection screen. If the payment is only partially paid
- *                 with a gift card, the method remains `giftcard`.
- * @param metadata - The optional metadata you provided upon payment creation. Metadata
- *                   can for example be used to link an order to a payment.
- * @param locale - The customer’s locale, either forced on creation by specifying the locale
- *                 parameter, or detected by us during checkout. Will be a full locale, for
- *                 example `nl_NL`.
- * @param countryCode - This optional field contains your customer’s ISO 3166-1 alpha-2
- *                      country code, detected by us during checkout. For example: `BE`.
- *                      This field is omitted if the country code was not detected.
- * @param profileId - The identifier referring to the profile this payment was created on.
- *                    For example, `pfl_QkEhN94Ba`.
- * @param settlementAmount - This optional field will contain the amount that will be settled
- *                           to your account, converted to the currency your account is settled
- *                           in. It follows the same syntax as the amount property. Any amounts
- *                           not settled by Mollie will not be reflected in this amount,
- *                           e.g. PayPal or gift cards.
- * @param settlementId - The identifier referring to the settlement this payment was settled with.
- *                       For example, `stl_BkEjN2eBb`.
- * @param customerId - If a customer was specified upon payment creation, the customer’s token
- *                     will be available here as well. For example, `cst_XPn78q9CfT`.
- * @param sequenceType - Indicates which type of payment this is in a recurring sequence. Set to
- *                       first for first payments that allow the customer to agree to automatic
- *                       recurring charges taking place on their account in the future.
- *                       Set to recurring for payments where the customer’s card is charged
- *                       automatically. Set to `oneoff` by default, which indicates the payment
- *                       is a regular non-recurring payment.
- * @param mandateId - If the payment is a first or recurring payment, this field will hold the
- *                    ID of the mandate.
- * @param subscriptionId - When implementing the Subscriptions API, any recurring charges
- *                         resulting from the subscription will hold the ID of the subscription
- *                         that triggered the payment.
- * @param orderId - If the payment was created for an order, the ID of that order will
- *                  be part of the response.
- * @param applicationFee - The application fee, if the payment was created with one.
- * @param _links - An object with several URL objects relevant to the payment. Every URL
- *                 object will contain an `href` and a `type` field.
- *
- */
 export interface PaymentData extends Model<'payment'> {
+  /**
+   * The mode used to create this payment. Mode determines whether a payment is *real* (live mode) or a *test* payment.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=mode#response
+   */
   mode: ApiMode;
+  /**
+   * The payment's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * The payment's status. Please refer to the documentation regarding statuses for more info about which statuses occur at what point.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=status#response
+   */
   status: PaymentStatus;
+  /**
+   * Whether or not the payment can be canceled. This parameter is omitted if the payment reaches a final state.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=isCancelable#response
+   */
   isCancelable: boolean;
+  /**
+   * The date and time the payment became authorized, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment is not authorized (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=authorizedAt#response
+   */
   authorizedAt?: string;
+  /**
+   * The date and time the payment became paid, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment is not completed (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=paidAt#response
+   */
   paidAt?: string;
+  /**
+   * The date and time the payment was canceled, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment is not canceled (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=canceledAt#response
+   */
   canceledAt?: string;
+  /**
+   * The date and time the payment will expire, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment can no longer expire.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=expiresAt#response
+   */
   expiresAt?: string; // TODO: check if this should become a required field, even as an embedded object
+  /**
+   * The date and time the payment was expired, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment did not expire (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=expiredAt#response
+   */
   expiredAt?: string;
+  /**
+   * The date and time the payment failed, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment did not fail (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=failedAt#response
+   */
   failedAt?: string;
+  /**
+   * The amount of the payment, e.g. `{"currency":"EUR", "value":"100.00"}` for a €100.00 payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=amount#response
+   */
   amount: Amount;
+  /**
+   * The total amount that is already refunded. Only available when refunds are available for this payment. For some payment methods, this amount may be higher than the payment amount, for example to
+   * allow reimbursement of the costs for a return shipment to the customer.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=amountRefunded#response
+   */
   amountRefunded?: Amount;
+  /**
+   * The remaining amount that can be refunded. Only available when refunds are available for this payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=amountRemaining#response
+   */
   amountRemaining?: Amount;
+  /**
+   * The total amount that is already captured for this payment. Only available when this payment supports captures.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=amountCaptured#response
+   */
   amountCaptured?: Amount;
+  /**
+   * A short description of the payment. The description is visible in the Dashboard and will be shown on the customer's bank or card statement when possible.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=description#response
+   */
   description: string;
+  /**
+   * The URL your customer will be redirected to after completing or canceling the payment process.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=redirectUrl#response
+   */
   redirectUrl?: string;
+  /**
+   * The URL Mollie will call as soon an important status change takes place.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=webhookUrl#response
+   */
   webhookUrl?: string;
+  /**
+   * The payment method used for this payment, either forced on creation by specifying the `method` parameter, or chosen by the customer on our payment method selection screen.
+   *
+   * If the payment is only partially paid with a gift card, the method remains `giftcard`.
+   *
+   * Possible values: `null` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `klarnapaylater` `klarnasliceit` `mybank` `paypal`
+   * `paysafecard` `przelewy24` `sofort`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=method#response
+   */
   method?: PaymentMethod | HistoricPaymentMethod;
+  /**
+   * The optional metadata you provided upon payment creation. Metadata can for example be used to link an order to a payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=metadata#response
+   */
   metadata: any;
+  /**
+   * The customer's locale, either forced on creation by specifying the `locale` parameter, or detected by us during checkout. Will be a full locale, for example `nl_NL`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=locale#response
+   */
   locale: Locale;
+  /**
+   * This optional field contains your customer's [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code, detected by us during checkout. For example: `BE`. This field is
+   * omitted if the country code was not detected.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=countryCode#response
+   */
   countryCode?: string;
+  /**
+   * The identifier referring to the profile this payment was created on. For example, `pfl_QkEhN94Ba`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=profileId#response
+   */
   profileId: string;
+  /**
+   * This optional field will contain the amount that will be settled to your account, converted to the currency your account is settled in. It follows the same syntax as the `amount` property.
+   *
+   * Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal or gift cards. If no amount is settled by Mollie the `settlementAmount` is omitted from the response.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=settlementAmount#response
+   */
   settlementAmount?: Amount;
+  /**
+   * The identifier referring to the settlement this payment was settled with. For example, `stl_BkEjN2eBb`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=settlementId#response
+   */
   settlementId?: string;
+  /**
+   * If a customer was specified upon payment creation, the customer's token will be available here as well. For example, `cst_XPn78q9CfT`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=customerId#response
+   */
   customerId?: string;
+  /**
+   * Indicates which type of payment this is in a recurring sequence. Set to `first` for first payments that allow the customer to agree to automatic recurring charges taking place on their account in
+   * the future. Set to `recurring` for payments where the customer's card is charged automatically.
+   *
+   * Set to `oneoff` by default, which indicates the payment is a regular non-recurring payment.
+   *
+   * Possible values: `oneoff` `first` `recurring`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=sequenceType#response
+   */
   sequenceType: SequenceType;
+  /**
+   * If the payment is a first or recurring payment, this field will hold the ID of the mandate.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=mandateId#response
+   */
   mandateId?: string;
+  /**
+   * When implementing the Subscriptions API, any recurring charges resulting from the subscription will hold the ID of the subscription that triggered the payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=subscriptionId#response
+   */
   subscriptionId?: string;
+  /**
+   * If the payment was created for an order, the ID of that order will be part of the response.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=orderId#response
+   */
   orderId?: string;
+  /**
+   * The application fee, if the payment was created with one.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=applicationFee#response
+   */
   applicationFee?: {
     amount: Amount;
     description: string;
   };
+  /**
+   * An object with several URL objects relevant to the payment. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links#response
+   */
   _links: PaymentLinks;
+  /**
+   * An object with payment details.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details#ideal
+   */
   details?: Details; // TODO: check if this should become a required field, even as an embedded object
   _embedded?: {
     refunds?: Omit<RefundData, '_embedded'>[];
@@ -139,35 +222,6 @@ export interface PaymentData extends Model<'payment'> {
   };
 }
 
-/**
- * Payment _links object
- *
- * @param checkout - The URL your customer should visit to make the payment.
- *                   This is where you should redirect the consumer to.
- *                   Recurring payments don’t have a checkout URL.
- * @param changePaymentState - Recurring payments do not have a checkout URL,
- *                             because these payments are executed without any
- *                             user interaction. This link is only included for
- *                             test mode recurring payments, and allows you to
- *                             set the final payment state for such payments.
- * @param refunds - The API resource URL of the refunds that belong to this payment.
- * @param chargebacks - The API resource URL of the chargebacks that belong to
- *                      this payment.
- * @param captures - The API resource URL of the captures that belong to this payment.
- * @param settlement - The API resource URL of the settlement this payment has been
- *                     settled with. Not present if not yet settled.
- * @param documentation - The URL to the payment retrieval endpoint documentation.
- * @param mandate - The API resource URL of the mandate linked to this payment.
- *                  Not present if a one-off payment.
- * @param subscription - The API resource URL of the subscription this payment is
- *                       part of. Not present if not a subscription payment.
- * @param customer - The API resource URL of the customer this payment belongs to.
- *                   Not present if not linked to a customer.
- * @param order - The API resource URL of the order this payment was created for.
- *                Not present if not created for an order.
- *
- * @see https://docs.mollie.com/reference/v2/payments-api/get-payment
- */
 interface PaymentLinks {
   self: Url;
   documentation?: Url; // TODO: check if this should become a required field, even as an embedded object
@@ -199,19 +253,6 @@ export type Details =
   | SepaDirectDebitDetails
   | SofortBankingDetails;
 
-/**
- * Bancontact details
- *
- * @param cardNumber - Only available if the payment is completed - The last four digits of the card number.
- * @param cardFingerprint - Only available if the payment is completed - Unique alphanumeric representation of card,
- *                          usable for identifying returning customers.
- * @param qrCode - Only available if requested during payment creation - The QR code that can be scanned by the mobile
- *                 Bancontact application. This enables the desktop to mobile feature.
- * @param consumerName - Only available if the payment is completed – The consumer’s name.
- * @param consumerAccount - Only available if the payment is completed – The consumer’s bank account. This may be an
- *                          IBAN, or it may be a domestic account number.
- * @param consumerBic - Only available if the payment is completed – The consumer’s bank’s BIC / SWIFT code.
- */
 export interface BancontactDetails {
   cardNumber: string;
   cardFingerprint: string;
@@ -221,37 +262,11 @@ export interface BancontactDetails {
   consumerBic: string;
 }
 
-/**
- * For bank transfer payments, the `_links` object
- * will contain some additional URL objects relevant to the payment.
- *
- * @param status - A link to a hosted payment page where your customer
- *                 can check the status of their payment.
- * @param payOnline - A link to a hosted payment page where your customer
- *                    can finish the payment using an alternative payment
- *                    method also activated on your website profile.
- */
 export interface BankTransferLinks extends Links {
   status: Url;
   payOnline: Url;
 }
 
-/**
- * Bank transfer details
- *
- * @param bankName - The name of the bank the consumer should wire the amount to.
- * @param bankAccount - The IBAN the consumer should wire the amount to.
- * @param bankBic - The BIC of the bank the consumer should wire the amount to.
- * @param transferReference - The reference the consumer should use when wiring the amount. Note you should not apply
- *                            any formatting here; show it to the consumer as-is.
- * @param consumerName - Only available if the payment has been completed – The consumer’s name.
- * @param consumerAccount - Only available if the payment has been completed – The consumer’s bank account. This may be
- *                          an IBAN, or it may be a domestic account number.
- * @param consumerBic - Only available if the payment has been completed – The consumer’s bank’s BIC / SWIFT code.
- * @param billingEmail - Only available if filled out in the API or by the consumer – The email address which the
- *                       consumer asked the payment instructions to be sent to.
- * @param _links - See {@link IBankTransferLinks}
- */
 export interface BankTransferDetails {
   bankName: string;
   bankAccount: string;
@@ -264,35 +279,12 @@ export interface BankTransferDetails {
   _links: BankTransferLinks;
 }
 
-/**
- * Belfius Payment Button details
- *
- * @param consumerName - Only available one banking day after the payment has been completed – The consumer’s name.
- * @param consumerAccount - Only available one banking day after the payment has been completed – The consumer’s IBAN.
- * @param consumerBic - Only available one banking day after the payment has been completed – `GKCCBEBB`.
- */
 export interface BelfiusPayButtonDetails {
   consumerName: string;
   consumerAccount: string;
   consumerBic: string;
 }
 
-/**
- * Bitcoin details
- *
- * @param bitcoinAddress - Only available if the payment has been completed
- *                         – The bitcoin address the bitcoins were
- *                         transferred to.
- * @param bitcoinAmount - The amount transferred in XBT.
- * @param bitcoinUri - A URI that is understood by Bitcoin wallet clients
- *                     and will cause such clients to prepare the transaction.
- *                     Follows the
- *                     {@link https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki BIP 21 URI scheme}.
- * @param qrCode - Only available if requested during payment creation
- *                 - The QR code that can be scanned by Bitcoin wallet
- *                 clients and will cause such clients to prepare the
- *                 transaction.
- */
 export interface BitcoinDetails {
   bitcoinAddress: string;
   bitcoinAmount: string;
@@ -300,33 +292,6 @@ export interface BitcoinDetails {
   qrCode: QrCode;
 }
 
-/**
- * Credit Card Details
- *
- * @param cardHolder - Only available if the payment has been completed
- *                     - The card holder’s name.
- * @param cardNumber - Only available if the payment has been completed
- *                     - The last four digits of the card number.
- * @param cardFingerprint - Only available if the payment has been completed
- *                          - Unique alphanumeric representation of card,
- *                          usable for identifying returning customers.
- * @param cardAudience - Only available if the payment has been completed
- * and if the data is available
- *                       - The card’s target audience.
- * @param cardLabel - Only available if the payment has been completed
- *                    - The card’s label. Note that not all labels can be
- *                    processed through Mollie.
- * @param cardCountryCode - Only available if the payment has been completed
- *                          - The ISO 3166-1 alpha-2 country code of the country
- *                          the card was issued in. For example: `BE`.
- * @param cardSecurity - Only available if the payment has been completed
- *                       – The type of security used during payment processing.
- * @param feeRegion - Only available if the payment has been completed
- *                    – The fee region for the payment: `intra-eu` for consumer
- *                    cards from the EU, and other for all other cards.
- * @param failureReason - Only available for failed payments. Contains a
- *                        failure reason code.
- */
 export interface CreditCardDetails {
   cardHolder: string;
   cardNumber: string;
@@ -339,18 +304,6 @@ export interface CreditCardDetails {
   failureReason: CardFailureReason;
 }
 
-/**
- * Gift Card Details
- *
- * @param voucherNumber - The voucher number, with the last four digits masked. When multiple gift cards are used, this
- *                        is the first voucher number. Example: `606436353088147****`.
- * @param giftcards - A list of details of all giftcards that are used for this payment. Each object will contain the
- *                    following properties.
- * @param remainderAmount - Only available if another payment method was used to pay the remainder amount – The amount
- *                          that was paid with another payment method for the remainder amount.
- * @param remainderMethod - Only available if another payment method was used to pay the remainder amount – The payment
- *                          method that was used to pay the remainder amount.
- */
 export interface GiftCardDetails {
   voucherNumber: string;
   giftcards: GiftCard[];
@@ -358,74 +311,28 @@ export interface GiftCardDetails {
   remainderMethod: Amount;
 }
 
-/**
- * iDEAL details
- *
- * @param consumerName - Only available if the payment has been completed
- *                       – The consumer’s name.
- * @param consumerAccount - Only available if the payment has been completed
- *                          – The consumer’s IBAN.
- * @param consumerBic - Only available if the payment has been completed
- *                      – The consumer’s bank’s BIC.
- */
 export interface IdealDetails {
   consumerName: string;
   consumerAccount: string;
   consumerBic: string;
 }
 
-/**
- * ING Home'Pay details
- *
- * @param consumerName - Only available one banking day after the payment has been completed
- *                       – The consumer’s name.
- * @param consumerAccount - Only available one banking day after the payment has been completed
- *                          – The consumer’s IBAN.
- * @param consumerBic - Only available one banking day after the payment has been completed
- *                      – `BBRUBEBB`.
- */
 export interface IngHomePayDetails {
   consumerName: string;
   consumerAccount: string;
   consumerBic: string;
 }
 
-/**
- * KBC/CBC Payment Button details
- *
- * @param consumerName - Only available one banking day after the payment has been completed – The consumer’s name.
- * @param consumerAccount - Only available one banking day after the payment has been completed – The consumer’s IBAN.
- * @param consumerBic - Only available one banking day after the payment has been completed – The consumer’s bank’s BIC.
- */
 export interface KbcCbcPaymentButtonDetails {
   consumerName: string;
   consumerAccount: string;
   consumerBic: string;
 }
 
-/**
- * For some industries, additional purchase information can be sent to Klarna to increase the authorization rate. You
- * can submit your extra data in this field if you have agreed upon this with Klarna. This field should be an object
- * containing any of the allowed keys and sub objects described at the
- * [Klarna Developer Documentation](https://developers.klarna.com/api/#payments-api__create-a-new-credit-sessionattachment__body)
- * under `attachment.body`.
- *
- * Note that Klarna needs to do some work to make sure this information is incorporated in their risk decisions, so
- * there is no point in sending it without making agreements with Klarna first.
- *
- * Please reach out to your account manager at Mollie to enable this feature with Klarna.
- */
 export interface KlarnaDetails {
   extraMerchantData?: any;
 }
 
-/**
- * PayPal details
- *
- * @param consumerName - Only available if the payment has been completed – The consumer’s first and last name.
- * @param consumerAccount - Only available if the payment has been completed – The consumer’s email address.
- * @param paypalReference - PayPal’s reference for the transaction, for instance `9AL35361CF606152E`.
- */
 export interface PayPalDetails {
   /**
    * Only available if the payment has been completed – The consumer's first and last name.
@@ -460,39 +367,10 @@ export interface PayPalDetails {
   paypalFee?: Amount;
 }
 
-/**
- * paysafecard details
- *
- * @param customerReference - The consumer identification supplied when the payment was created.
- */
 export interface PaysafecardDetails {
   customerReference: string;
 }
 
-/**
- * SEPA Direct Debit details
- *
- * @param transferReference - Transfer reference used by Mollie to identify this payment.
- * @param creditorIdentifier - The creditor identifier indicates who is authorized to execute the payment. In this case,
- *                             it is a reference to Mollie.
- * @param consumerName - The consumer’s name.
- * @param consumerAccount - The consumer’s IBAN.
- * @param consumerBic - The consumer’s bank’s BIC.
- * @param dueDate - Estimated date the payment is debited from the consumer’s bank account, in `YYYY-MM-DD` format.
- * @param signatureDate - Only available if the payment has been verified – Date the payment has been signed by the
- *                        consumer, in `YYYY-MM-DD` format.
- * @param bankReasonCode - Only available if the payment has failed – The official reason why this payment has failed.
- *                         A detailed description of each reason is available on the website of the European Payments Council.
- * @param bankReason - Only available if the payment has failed – A textual desciption of the failure reason.
- * @param endToEndIdentifier - Only available for batch transactions – The original end-to-end identifier that you’ve
- *                             specified in your batch.
- * @param mandateReference - Only available for batch transactions – The original mandate reference that you’ve
- *                           specified in your batch.
- * @param batchReference - Only available for batch transactions – The original batch reference that you’ve
- *                         specified in your batch.
- * @param fileReference - Only available for batch transactions – The original file reference that you’ve specified
- *                        in your batch.
- */
 export interface SepaDirectDebitDetails {
   transferReference: string;
   creditorIdentifier: string;
@@ -509,28 +387,12 @@ export interface SepaDirectDebitDetails {
   fileReference: string;
 }
 
-/**
- * Sofort Banking details
- *
- * @param consumerName - Only available if the payment has been completed – The consumer’s name.
- * @param consumerAccount - Only available if the payment has been completed – The consumer’s IBAN.
- * @param consumerBic - Only available if the payment has been completed – The consumer’s bank’s BIC.
- */
 export interface SofortBankingDetails {
   consumerName: string;
   consumerAccount: string;
   consumerBic: string;
 }
 
-/**
- *  QR Code
- *
- * @param height - Height of the image in pixels.
- * @param width - Width of the image in pixels.
- * @param src - The URI you can use to display the QR code.
- *              Note that we can send both data URIs as well
- *              as links to HTTPS images. You should support both.
- */
 export interface QrCode {
   height: number;
   width: number;
@@ -554,13 +416,6 @@ export enum PaymentEmbed {
   chargebacks = 'chargebacks',
 }
 
-/**
- * Gift Card
- *
- * @param issuer - The ID of the gift card brand that was used during the payment.
- * @param amount - The amount in EUR that was paid with this gift card.
- * @param voucherNumber - The voucher number, with the last four digits masked. Example: `606436353088147****`
- */
 export interface GiftCard {
   issuer: string;
   amount: Amount;

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -222,18 +222,72 @@ export interface PaymentData extends Model<'payment'> {
   };
 }
 
-interface PaymentLinks {
-  self: Url;
-  documentation?: Url; // TODO: check if this should become a required field, even as an embedded object
+interface PaymentLinks extends Links {
+  /**
+   * The URL your customer should visit to make the payment. This is where you should redirect the consumer to.
+   *
+   * Recurring payments do not have a checkout URL.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/checkout#response
+   */
   checkout?: Url;
+  /**
+   * Recurring payments do not have a checkout URL, because these payments are executed without any user interaction. This link is included for test mode recurring payments, and allows you to set the
+   * final payment state for such payments.
+   *
+   * This link is also included for paid test mode payments. This allows you to create a refund or chargeback for the payment. This works for all payment types that can be charged back and/or
+   * refunded.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/changePaymentState#response
+   */
   changePaymentState?: Url;
+  /**
+   * The API resource URL of the refunds that belong to this payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/refunds#response
+   */
   refunds?: Url;
+  /**
+   * The API resource URL of the chargebacks that belong to this payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/chargebacks#response
+   */
   chargebacks?: Url;
+  /**
+   * The API resource URL of the captures that belong to this payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/captures#response
+   */
   captures?: Url;
+  /**
+   * The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/settlement#response
+   */
   settlement?: Url;
+  /**
+   * The API resource URL of the mandate linked to this payment. Not present if a one-off payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/mandate#response
+   */
   mandate?: Url;
+  /**
+   * The API resource URL of the subscription this payment is part of. Not present if not a subscription payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/subscription#response
+   */
   subscription?: Url;
+  /**
+   * The API resource URL of the customer this payment belongs to. Not present if not linked to a customer.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/customer#response
+   */
   customer?: Url;
+  /**
+   * The API resource URL of the order this payment was created for. Not present if not created for an order.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/order#response
+   */
   order?: Url;
 }
 
@@ -254,34 +308,128 @@ export type Details =
   | SofortBankingDetails;
 
 export interface BancontactDetails {
+  /**
+   * Only available if the payment is completed - The last four digits of the card number.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardNumber#bancontact
+   */
   cardNumber: string;
+  /**
+   * Only available if the payment is completed - Unique alphanumeric representation of card, usable for identifying returning customers.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardFingerprint#bancontact
+   */
   cardFingerprint: string;
+  /**
+   * Only available if requested during payment creation - The QR code that can be scanned by the mobile Bancontact application. This enables the desktop to mobile feature.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/qrCode#bancontact
+   */
   qrCode: QrCode;
+  /**
+   * Only available if the payment is completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#bancontact
+   */
   consumerName: string;
+  /**
+   * Only available if the payment is completed – The consumer's bank account. This may be an IBAN, or it may be a domestic account number.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#bancontact
+   */
   consumerAccount: string;
+  /**
+   * Only available if the payment is completed – The consumer's bank's BIC / SWIFT code.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#bancontact
+   */
   consumerBic: string;
 }
 
 export interface BankTransferLinks extends Links {
+  /**
+   * A link to a hosted payment page where your customer can check the status of their payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/status#bank-transfer
+   */
   status: Url;
+  /**
+   * A link to a hosted payment page where your customer can finish the payment using an alternative payment method also activated on your website profile.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/payOnline#bank-transfer
+   */
   payOnline: Url;
 }
 
 export interface BankTransferDetails {
+  /**
+   * The name of the bank the consumer should wire the amount to.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/bankName#bank-transfer
+   */
   bankName: string;
+  /**
+   * The IBAN the consumer should wire the amount to.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/bankAccount#bank-transfer
+   */
   bankAccount: string;
+  /**
+   * The BIC of the bank the consumer should wire the amount to.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/bankBic#bank-transfer
+   */
   bankBic: string;
+  /**
+   * The reference the consumer should use when wiring the amount. Note you should not apply any formatting here; show it to the consumer as-is.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/transferReference#bank-transfer
+   */
   transferReference: string;
+  /**
+   * Only available if the payment has been completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#bank-transfer
+   */
   consumerName: string;
+  /**
+   * Only available if the payment has been completed – The consumer's bank account. This may be an IBAN, or it may be a domestic account number.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#bank-transfer
+   */
   consumerAccount: string;
+  /**
+   * Only available if the payment has been completed – The consumer's bank's BIC / SWIFT code.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#bank-transfer
+   */
   consumerBic: string;
+  /**
+   * Only available if filled out in the API or by the consumer – The email address which the consumer asked the payment instructions to be sent to.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/billingEmail#bank-transfer
+   */
   billingEmail: string;
-  _links: BankTransferLinks;
 }
 
 export interface BelfiusPayButtonDetails {
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#belfius-pay-button
+   */
   consumerName: string;
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's IBAN.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#belfius-pay-button
+   */
   consumerAccount: string;
+  /**
+   * Only available one banking day after the payment has been completed – `GKCCBEBB`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#belfius-pay-button
+   */
   consumerBic: string;
 }
 
@@ -293,39 +441,161 @@ export interface BitcoinDetails {
 }
 
 export interface CreditCardDetails {
+  /**
+   * Only available if the payment has been completed - The card holder's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardHolder#Credit%20card%20v2
+   */
   cardHolder: string;
+  /**
+   * Only available if the payment has been completed - The last four digits of the card number.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardNumber#Credit%20card%20v2
+   */
   cardNumber: string;
+  /**
+   * Only available if the payment has been completed - Unique alphanumeric representation of card, usable for identifying returning customers.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardFingerprint#Credit%20card%20v2
+   */
   cardFingerprint: string;
+  /**
+   * Only available if the payment has been completed and if the data is available - The card's target audience.
+   *
+   * Possible values: `consumer` `business` `null`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardAudience#Credit%20card%20v2
+   */
   cardAudience: Nullable<CardAudience>;
+  /**
+   * Only available if the payment has been completed - The card's label. Note that not all labels can be processed through Mollie.
+   *
+   * Possible values: `American Express` `Carta Si` `Carte Bleue` `Dankort` `Diners Club` `Discover` `JCB` `Laser` `Maestro` `Mastercard` `Unionpay` `Visa` `null`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardLabel#Credit%20card%20v2
+   */
   cardLabel: Nullable<CardLabel>;
+  /**
+   * Only available if the payment has been completed - The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code of the country the card was issued in. For example:
+   * `BE`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardCountryCode#Credit%20card%20v2
+   */
   cardCountryCode: string;
+  /**
+   * Only available if the payment has been completed – The type of security used during payment processing.
+   *
+   * Possible values: `normal` `3dsecure`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardSecurity#Credit%20card%20v2
+   */
   cardSecurity: string;
+  /**
+   * Only available if the payment has been completed – The fee region for the payment. The `intra-eu` value is for consumer cards from the EEA.
+   *
+   * Possible values: `american-express` `amex-intra-eea` `carte-bancaire` `intra-eu` `intra-eu-corporate` `domestic` `maestro` `other`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/feeRegion#Credit%20card%20v2
+   */
   feeRegion: FeeRegion;
+  /**
+   * Only available for failed payments. Contains a failure reason code.
+   *
+   * Possible values: `authentication_failed` `card_declined` `card_expired` `inactive_card` `insufficient_funds` `invalid_card_holder_name` `invalid_card_number` `invalid_card_type` `invalid_cvv`
+   * `possible_fraud` `refused_by_issuer` `unknown_reason`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/failureReason#Credit%20card%20v2
+   */
   failureReason: CardFailureReason;
 }
 
 export interface GiftCardDetails {
+  /**
+   * The voucher number, with the last four digits masked. When multiple gift cards are used, this is the first voucher number. Example: `606436353088147****`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/voucherNumber#gift-cards
+   */
   voucherNumber: string;
+  /**
+   * A list of details of all giftcards that are used for this payment. Each object will contain the following properties.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/giftcards#gift-cards
+   */
   giftcards: GiftCard[];
+  /**
+   * Only available if another payment method was used to pay the remainder amount – The amount that was paid with another payment method for the remainder amount.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/remainderAmount#gift-cards
+   */
   remainderAmount: Amount;
+  /**
+   * Only available if another payment method was used to pay the remainder amount – The payment method that was used to pay the remainder amount.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/remainderMethod#gift-cards
+   */
   remainderMethod: Amount;
 }
 
 export interface IdealDetails {
+  /**
+   * Only available if the payment has been completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#ideal
+   */
   consumerName: string;
+  /**
+   * Only available if the payment has been completed – The consumer's IBAN.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#ideal
+   */
   consumerAccount: string;
+  /**
+   * Only available if the payment has been completed – The consumer's bank's BIC.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#ideal
+   */
   consumerBic: string;
 }
 
 export interface IngHomePayDetails {
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#ing-homepay
+   */
   consumerName: string;
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's IBAN.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#ing-homepay
+   */
   consumerAccount: string;
+  /**
+   * Only available one banking day after the payment has been completed – `BBRUBEBB`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#ing-homepay
+   */
   consumerBic: string;
 }
 
 export interface KbcCbcPaymentButtonDetails {
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#kbccbc-payment-button
+   */
   consumerName: string;
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's IBAN.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#kbccbc-payment-button
+   */
   consumerAccount: string;
+  /**
+   * Only available one banking day after the payment has been completed – The consumer's bank's BIC.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#kbccbc-payment-button
+   */
   consumerBic: string;
 }
 
@@ -336,60 +606,160 @@ export interface KlarnaDetails {
 export interface PayPalDetails {
   /**
    * Only available if the payment has been completed – The consumer's first and last name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#paypal
    */
   consumerName: string;
   /**
    * Only available if the payment has been completed – The consumer's email address.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#paypal
    */
   consumerAccount: string;
   /**
-   * PayPal's reference for the transaction, for instance `'9AL35361CF606152E'`.
+   * PayPal's reference for the transaction, for instance `9AL35361CF606152E`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/paypalReference#paypal
    */
   paypalReference: string;
   /**
-   * ID for the consumer's PayPal account, for instance `'WDJJHEBZ4X2LY'`.
+   * ID for the consumer's PayPal account, for instance `WDJJHEBZ4X2LY`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/paypalPayerId#paypal
    */
   paypalPayerId: string;
   /**
    * Indicates if the payment is eligible for PayPal's Seller Protection.
    *
+   * Possible values: `Eligible` `Ineligible` `Partially Eligible - INR Only` `Partially Eligible - Unauth Only` `PartiallyEligible` `None` `Active Fraud Control - Unauth Premium Eligible`
+   *
    * This parameter is omitted if we did not received the information from PayPal.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/sellerProtection#paypal
    */
   sellerProtection?: 'Eligible' | 'Ineligible' | 'Partially Eligible - INR Only' | 'Partially Eligible - Unauth Only' | 'PartiallyEligible' | 'None' | 'Active Fraud Control - Unauth Premium Eligible';
   /**
    * The shipping address details.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/shippingAddress#paypal
    */
   shippingAddress: Address;
   /**
-   * The amount of fee PayPal will charge for this transaction. This field is omitted if PayPal will not charge a fee
-   * for this transaction.
+   * The amount of fee PayPal will charge for this transaction. This field is omitted if PayPal will not charge a fee for this transaction.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/paypalFee#paypal
    */
   paypalFee?: Amount;
 }
 
 export interface PaysafecardDetails {
+  /**
+   * The consumer identification supplied when the payment was created.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/customerReference#paysafecard
+   */
   customerReference: string;
 }
 
 export interface SepaDirectDebitDetails {
+  /**
+   * Transfer reference used by Mollie to identify this payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/transferReference#sepa-direct-debit
+   */
   transferReference: string;
+  /**
+   * The creditor identifier indicates who is authorized to execute the payment. In this case, it is a reference to Mollie.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/creditorIdentifier#sepa-direct-debit
+   */
   creditorIdentifier: string;
+  /**
+   * The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#sepa-direct-debit
+   */
   consumerName: string;
+  /**
+   * The consumer's IBAN.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#sepa-direct-debit
+   */
   consumerAccount: string;
+  /**
+   * The consumer's bank's BIC.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#sepa-direct-debit
+   */
   consumerBic: string;
+  /**
+   * Estimated date the payment is debited from the consumer's bank account, in `YYYY-MM-DD` format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/dueDate#sepa-direct-debit
+   */
   dueDate: string;
+  /**
+   * Only available if the payment has been verified – Date the payment has been signed by the consumer, in `YYYY-MM-DD` format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/signatureDate#sepa-direct-debit
+   */
   signatureDate: string;
+  /**
+   * Only available if the payment has failed – The official reason why this payment has failed. A detailed description of each reason is available on the website of the European Payments Council.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/bankReasonCode#sepa-direct-debit
+   */
   bankReasonCode: string;
+  /**
+   * Only available if the payment has failed – A textual description of the failure reason.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/bankReason#sepa-direct-debit
+   */
   bankReason: string;
+  /**
+   * Only available for batch transactions – The original end-to-end identifier that you've specified in your batch.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/endToEndIdentifier#sepa-direct-debit
+   */
   endToEndIdentifier: string;
+  /**
+   * Only available for batch transactions – The original mandate reference that you've specified in your batch.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/mandateReference#sepa-direct-debit
+   */
   mandateReference: string;
+  /**
+   * Only available for batch transactions – The original batch reference that you've specified in your batch.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/batchReference#sepa-direct-debit
+   */
   batchReference: string;
+  /**
+   * Only available for batch transactions – The original file reference that you've specified in your batch.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/fileReference#sepa-direct-debit
+   */
   fileReference: string;
 }
 
 export interface SofortBankingDetails {
+  /**
+   * Only available if the payment has been completed – The consumer's name.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#sofort-banking
+   */
   consumerName: string;
+  /**
+   * Only available if the payment has been completed – The consumer's IBAN.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#sofort-banking
+   */
   consumerAccount: string;
+  /**
+   * Only available if the payment has been completed – The consumer's bank's BIC.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#sofort-banking
+   */
   consumerBic: string;
 }
 
@@ -417,7 +787,22 @@ export enum PaymentEmbed {
 }
 
 export interface GiftCard {
+  /**
+   * The ID of the gift card brand that was used during the payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/giftcards/issuer#gift-cards
+   */
   issuer: string;
+  /**
+   * The amount in EUR that was paid with this gift card.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/giftcards/amount#gift-cards
+   */
   amount: Amount;
+  /**
+   * The voucher number, with the last four digits masked. Example: `606436353088147****`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/giftcards/voucherNumber#gift-cards
+   */
   voucherNumber: string;
 }

--- a/src/data/payments/helpers.ts
+++ b/src/data/payments/helpers.ts
@@ -7,42 +7,42 @@ import Nullable from '../../types/Nullable';
 export default {
   ...commonHelpers,
   /**
-   * If the payment is open
+   * Returns whether the payment has been created, but nothing else has happened with it yet.
    */
   isOpen: function isOpen(this: PaymentData): boolean {
     return this.status === PaymentStatus.open;
   },
 
   /**
-   * If the payment is authorized
+   * Returns whether new captures can be created for this payment.
    */
   isAuthorized: function isAuthorized(this: PaymentData): boolean {
     return this.status === PaymentStatus.authorized;
   },
 
   /**
-   * If the payment is paid
+   * Returns whether the payment is successfully paid.
    */
   isPaid: function isPaid(this: PaymentData): boolean {
     return this.paidAt != undefined;
   },
 
   /**
-   * If the payment is canceled
+   * Returns whether the payment has been canceled by the customer.
    */
   isCanceled: function isCanceled(this: PaymentData): boolean {
     return this.status == PaymentStatus.canceled;
   },
 
   /**
-   * If the payment is expired
+   * Returns whether the payment has expired, e.g. the customer has abandoned the payment.
    */
   isExpired: function isExpired(this: PaymentData): boolean {
     return this.status == PaymentStatus.expired;
   },
 
   /**
-   * If the payment is refundable
+   * Returns whether the payment is refundable.
    *
    * @since 2.0.0-rc.2
    */
@@ -51,7 +51,7 @@ export default {
   },
 
   /**
-   * Get the payment URL
+   * Returns the URL the customer should visit to make the payment. This is to where you should redirect the consumer.
    */
   getPaymentUrl: function getPaymentUrl(this: PaymentData): string {
     return get(this._links, 'checkout.href', null);

--- a/src/data/permissions/Permission.ts
+++ b/src/data/permissions/Permission.ts
@@ -3,20 +3,23 @@ import Model from '../Model';
 import Seal from '../../types/Seal';
 import commonHelpers from '../commonHelpers';
 
-/**
- * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission
- */
 export interface PermissionData extends Model<'permission', string> {
   /**
    * A short description of what the permission allows.
+   *
+   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission?path=description#response
    */
   description: string;
   /**
    * Whether this permission is granted to the app by the organization or not.
+   *
+   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission?path=granted#response
    */
   granted: boolean;
   /**
-   * An object with several URL objects relevant to the permission.
+   * An object with several URL objects relevant to the permission. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission?path=_links#response
    */
   _links: PermissionLinks;
 }

--- a/src/data/profiles/data.ts
+++ b/src/data/profiles/data.ts
@@ -3,99 +3,122 @@ import Model from '../Model';
 import Nullable from '../../types/Nullable';
 
 /**
+ * Retrieve details of a profile, using the profile's identifier.
+ *
  * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile
  */
 export interface ProfileData extends Model<'profile', string> {
+  /**
+   * Indicates whether the profile is in test or production mode.
+   *
+   * Possible values:
+   *
+   * -   `live` The profile is verified.
+   * -   `test` The profile has not been verified yet and can only be used to create test payments.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=mode#response
+   */
   mode: ApiMode;
   /**
-   * The profile's name, this will usually reflect the tradename or brand name of the profile's website or application.
+   * The profile's name, this will usually reflect the trade name or brand name of the profile's website or application.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=name#response
    */
   name: string;
   /**
-   * The URL to the profile’s website or application.
+   * The URL to the profile's website or application.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=website#response
    */
   website: string;
   /**
    * The email address associated with the profile's trade name or brand.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=email#response
    */
   email: string;
   /**
    * The phone number associated with the profile's trade name or brand.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=phone#response
    */
   phone: string;
   /**
-   * The industry associated with the profile’s trade name or brand. Possible values:
+   * The industry associated with the profile's trade name or brand.
    *
-   *  * `5192`: Books, magazines and newspapers
-   *  * `5399`: General merchandise
-   *  * `5499`: Food and drinks
-   *  * `5533`: Automotive Products
-   *  * `5641`: Children Products
-   *  * `5651`: Clothing & Shoes
-   *  * `5732`: Electronics, computers and software
-   *  * `5734`: Hosting/VPN services
-   *  * `5735`: Entertainment
-   *  * `5815`: Credits/vouchers/giftcards
-   *  * `5921`: Alcohol
-   *  * `5944`: Jewelry & Accessories
-   *  * `5977`: Health & Beauty products
-   *  * `6012`: Financial services
-   *  * `7299`: Consultancy
-   *  * `7999`: Travel, rental and transportation
-   *  * `8299`: Advising/coaching/training
-   *  * `8398`: Charity and donations
-   *  * `8699`: Political parties
-   *  * `0`: Other
+   * Possible values:
+   *
+   * -   `5192` Books, magazines and newspapers
+   * -   `5262` Marketplaces, crowdfunding, donation platforms
+   * -   `5399` General merchandise
+   * -   `5499` Food and drinks
+   * -   `5533` Automotive Products
+   * -   `5641` Children Products
+   * -   `5651` Clothing & Shoes
+   * -   `5712` Home furnishing
+   * -   `5732` Electronics, computers and software
+   * -   `5734` Hosting/VPN services
+   * -   `5735` Entertainment
+   * -   `5815` Credits/vouchers/giftcards
+   * -   `5921` Alcohol
+   * -   `5944` Jewelry & Accessories
+   * -   `5945` Hobby, Toy, and Game Shops
+   * -   `5977` Health & Beauty products
+   * -   `6012` Financial services
+   * -   `6051` Crypto currency
+   * -   `7299` Consultancy
+   * -   `7922` Events, conferences, concerts, tickets
+   * -   `7997` Gyms, membership fee based sports
+   * -   `7999` Travel, rental and transportation
+   * -   `8111` Lawyers and legal advice
+   * -   `8299` Advising/coaching/training
+   * -   `8398` Charity and donations
+   * -   `8699` Political parties
+   * -   `9399` Government services
+   * -   `0` Other
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=categoryCode#response
    */
   categoryCode: number;
   /**
-   * The profile status determines whether the profile is able to receive live payments. Possible values:
+   * The profile status determines whether the profile is able to receive live payments.
    *
-   *  * `'unverified'`: The profile has not been verified yet and can only be used to create test payments.
-   *  * `'verified'`: The profile has been verified and can be used to create live payments and test payments.
-   *  * `'blocked'`: The profile is blocked and can thus no longer be used or changed.
+   * Possible values:
+   *
+   * -   `unverified` The profile has not been verified yet and can only be used to create test payments.
+   * -   `verified` The profile has been verified and can be used to create live payments and test payments.
+   * -   `blocked` The profile is blocked and can thus no longer be used or changed.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=status#response
    */
   status: 'unverified' | 'verified' | 'blocked';
   /**
-   * The presence of a review object indicates changes have been made that have not yet been approved by Mollie.
-   * Changes to test profiles are approved automatically, unless a switch to a live profile has been requested. The
-   * review object will therefore usually be `null` in test mode.
+   * The presence of a review object indicates changes have been made that have not yet been approved by Mollie. Changes to test profiles are approved automatically, unless a switch to a live profile
+   * has been requested. The review object will therefore usually be `null` in test mode.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=review#response
    */
   review: Nullable<{
-    /**
-     * The status of the requested profile changes. Possible values:
-     *
-     *  * `'pending'`: The changes are pending review. We will review your changes soon.
-     *  * `'rejected'`: We’ve reviewed and rejected your changes.
-     */
     status: string;
   }>;
   /**
-   * The profile's date and time of creation, in ISO 8601 format.
+   * The profile's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=createdAt#response
    */
   createdAt: string;
+  /**
+   * An object with several URL objects relevant to the profile. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links#response
+   */
   _links: PermissionLinks;
 }
 
 export interface PermissionLinks extends Links {
-  /**
-   * The API resource URL of the chargebacks that belong to this profile.
-   */
   chargebacks: Url;
-  /**
-   * The API resource URL of the methods that are enabled for this profile.
-   */
   methods: Url;
-  /**
-   * The API resource URL of the payments that belong to this profile.
-   */
   payments: Url;
-  /**
-   * The API resource URL of the refunds that belong to this profile.
-   */
   refunds: Url;
-  /**
-   * The Checkout preview URL. You need to be logged in to access this page.
-   */
   checkoutPreviewUrl: Url;
 }

--- a/src/data/profiles/data.ts
+++ b/src/data/profiles/data.ts
@@ -2,11 +2,6 @@ import { ApiMode, Links, Url } from '../global';
 import Model from '../Model';
 import Nullable from '../../types/Nullable';
 
-/**
- * Retrieve details of a profile, using the profile's identifier.
- *
- * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile
- */
 export interface ProfileData extends Model<'profile', string> {
   /**
    * Indicates whether the profile is in test or production mode.
@@ -99,6 +94,16 @@ export interface ProfileData extends Model<'profile', string> {
    * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=review#response
    */
   review: Nullable<{
+    /**
+     * The status of the requested profile changes.
+     *
+     * Possible values:
+     *
+     * -   `pending` The changes are pending review. We will review your changes soon.
+     * -   `rejected` We have reviewed and rejected your changes.
+     *
+     * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=review/status#response
+     */
     status: string;
   }>;
   /**
@@ -116,9 +121,34 @@ export interface ProfileData extends Model<'profile', string> {
 }
 
 export interface PermissionLinks extends Links {
+  /**
+   * The API resource URL of the chargebacks that belong to this profile.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/chargebacks#response
+   */
   chargebacks: Url;
+  /**
+   * The API resource URL of the methods that are enabled for this profile.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/methods#response
+   */
   methods: Url;
+  /**
+   * The API resource URL of the payments that belong to this profile.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/payments#response
+   */
   payments: Url;
+  /**
+   * The API resource URL of the refunds that belong to this profile.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/refunds#response
+   */
   refunds: Url;
+  /**
+   * The Checkout preview URL. You need to be logged in to access this page.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/checkoutPreviewUrl#response
+   */
   checkoutPreviewUrl: Url;
 }

--- a/src/data/refunds/data.ts
+++ b/src/data/refunds/data.ts
@@ -3,45 +3,94 @@ import { OrderLineData } from '../orders/orderlines/OrderLine';
 import { PaymentData } from '../payments/data';
 import Model from '../Model';
 
-/**
- * The `Refund` model
- *
- * {@link IRefund}
- */
 export interface RefundData extends Model<'refund'> {
+  /**
+   * The amount refunded to your customer with this refund.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=amount#response
+   */
   amount: Amount;
   /**
-   * The identifier referring to the settlement this payment was settled with. For example, `'stl_BkEjN2eBb'`. This
-   * field is omitted if the refund is not settled (yet).
+   * The identifier referring to the settlement this payment was settled with. For example, `stl_BkEjN2eBb`. This field is omitted if the refund is not settled (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=settlementId#response
    */
   settlementId?: string;
+  /**
+   * This optional field will contain the amount that will be deducted from your account balance, converted to the currency your account is settled in. It follows the same syntax as the `amount`
+   * property.
+   *
+   * Note that for refunds, the `value` key of `settlementAmount` will be negative.
+   *
+   * Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal refunds.
+   *
+   * Queued refunds in non EUR currencies will not have a settlement amount until they become `pending`.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=settlementAmount#response
+   */
   settlementAmount?: Amount;
+  /**
+   * The description of the refund that may be shown to your customer, depending on the payment method used.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=description#response
+   */
   description: string;
   /**
-   * The optional metadata you provided upon refund creation. Metadata can for example be used to link an bookkeeping
-   * ID to a refund.
+   * The optional metadata you provided upon refund creation. Metadata can for example be used to link an bookkeeping ID to a refund.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=metadata#response
    */
   metadata?: any;
+  /**
+   * Since refunds may not be instant for certain payment methods, the refund carries a status field.
+   *
+   * For a full overview, see refund-statuses.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=status#response
+   */
   status: RefundStatus;
+  /**
+   * An array of order line objects as described in Get order.
+   *
+   * The lines will show the `quantity`, `discountAmount`, `vatAmount` and `totalAmount` refunded. If the line was partially refunded, these values will be different from the values in response from
+   * the Get order API.
+   *
+   * Only available if the refund was created via the Create Order Refund API.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=lines#response
+   */
   lines?: OrderLineData[];
+  /**
+   * The unique identifier of the payment this refund was created for. For example: `tr_7UhSN1zuXS`. The full payment object can be retrieved via the `payment` URL in the `_links` object.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=paymentId#response
+   */
   paymentId: string;
+  /**
+   * The unique identifier of the order this refund was created for. For example: `ord_8wmqcHMN4U`. Not present if the refund was not created for an order.
+   *
+   * The full order object can be retrieved via the `order` URL in the `_links` object.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=orderId#response
+   */
   orderId?: string;
+  /**
+   * The date and time the refund was issued, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=createdAt#response
+   */
   createdAt: string;
+  /**
+   * An object with several URL objects relevant to the refund. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=_links#response
+   */
   _links: PaymentRefundLinks;
   _embedded?: {
     payments?: Omit<PaymentData, '_embedded'>[];
   };
 }
 
-/**
- * Refund statuses
- *
- * @enum queued - The refund will be processed once you have enough balance. You can still cancel this refund.
- * @enum pending - The refund will be processed soon (usually the next business day). You can still cancel this refund.
- * @enum processing - The refund is being processed. Cancellation is no longer possible.
- * @enum refunded - The refund has been paid out to your customer.
- * @enum failed - The refund has failed during processing.
- */
 export enum RefundStatus {
   queued = 'queued',
   pending = 'pending',
@@ -54,13 +103,6 @@ export enum RefundEmbed {
   payment = 'payment',
 }
 
-/**
- * Payment Refund _links object
- *
- * @param payment - The API resource URL of the payment the refund belongs to.
- * @param settlement - The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
- * @param order - The API resource URL of the order the refund belongs to. Not present if the refund does not belong to an order.
- */
 export interface PaymentRefundLinks extends Links {
   payment: Url;
   settlement?: Url;

--- a/src/data/refunds/data.ts
+++ b/src/data/refunds/data.ts
@@ -104,7 +104,22 @@ export enum RefundEmbed {
 }
 
 export interface PaymentRefundLinks extends Links {
+  /**
+   * The API resource URL of the payment the refund belongs to.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=_links/payment#response
+   */
   payment: Url;
+  /**
+   * The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=_links/settlement#response
+   */
   settlement?: Url;
+  /**
+   * The API resource URL of the order the refund belongs to. Not present if the refund does not belong to an order.
+   *
+   * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund?path=_links/order#response
+   */
   order?: Url;
 }

--- a/src/data/refunds/helpers.ts
+++ b/src/data/refunds/helpers.ts
@@ -4,37 +4,35 @@ import commonHelpers from '../commonHelpers';
 export default {
   ...commonHelpers,
   /**
-   * The refund is queued until there is enough balance to process te refund.
-   * You can still cancel the refund.
+   * Returns whether the refund is queued due to a lack of balance. A queued refund can be canceled.
    */
   isQueued: function isQueued(this: RefundData): boolean {
     return this.status === RefundStatus.queued;
   },
 
   /**
-   * The refund will be sent to the bank on the next business day. You can still cancel the refund.
+   * Returns whether the refund is ready to be sent to the bank. You can still cancel the refund if you like.
    */
   isPending: function isPending(this: RefundData): boolean {
     return this.status === RefundStatus.pending;
   },
 
   /**
-   * The refund has been sent to the bank. The refund amount will be transferred to the consumer
-   * account as soon as possible.
+   * Returns whether the refund is being processed. Cancellation is no longer possible if so.
    */
   isProcessing: function isProcessing(this: RefundData): boolean {
     return this.status === RefundStatus.processing;
   },
 
   /**
-   * The refund amount has been transferred to the consumer.
+   * Returns whether the refund has been settled to your customer.
    */
   isRefunded: function isRefunded(this: RefundData): boolean {
     return this.status === RefundStatus.refunded;
   },
 
   /**
-   * The refund has failed during processing.
+   * Returns whether the refund has failed after processing.
    */
   isFailed: function isFailed(this: RefundData): boolean {
     return this.status === RefundStatus.failed;

--- a/src/data/subscription/data.ts
+++ b/src/data/subscription/data.ts
@@ -1,45 +1,116 @@
 import { Amount, ApiMode, Links, Url } from '../global';
 import Model from '../Model';
 
-/**
- * Subscription Response object.
- *
- * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
- */
 export interface SubscriptionData extends Model<'subscription'> {
+  /**
+   * The mode used to create this subscription. Mode determines whether the subscription's payments are real or test payments.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=mode#response
+   */
   mode: ApiMode;
+  /**
+   * The subscription's current status, depends on whether the customer has a pending, valid or invalid mandate.
+   *
+   * Possible values: `pending` `active` `canceled` `suspended` `completed`
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=status#response
+   */
   status: SubscriptionStatus;
+  /**
+   * The constant amount that is charged with each subscription payment, e.g. `{"currency":"EUR", "value":"10.00"}` for a €10.00 subscription.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=amount#response
+   */
   amount: Amount;
+  /**
+   * Total number of charges for the subscription to complete.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=times#response
+   */
   times: number;
+  /**
+   * Number of charges left for the subscription to complete.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=timesRemaining#response
+   */
   timesRemaining: number;
+  /**
+   * Interval to wait between charges, for example `1 month` or `14 days`.
+   *
+   * Possible values: `... months` `... weeks` `... days`
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=interval#response
+   */
   interval: string;
+  /**
+   * The start date of the subscription in `YYYY-MM-DD` format.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=startDate#response
+   */
   startDate: string;
+  /**
+   * The date of the next scheduled payment in `YYYY-MM-DD` format. When there will be no next payment, for example when the subscription has ended, this parameter will not be returned.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=nextPaymentDate#response
+   */
   nextPaymentDate?: string;
+  /**
+   * The description specified during subscription creation. This will be included in the payment description.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=description#response
+   */
   description: string;
+  /**
+   * The payment method used for this subscription, either forced on creation or `null` if any of the customer's valid mandates may be used.
+   *
+   * Possible values: `creditcard` `directdebit` `paypal` `null`
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=method#response
+   */
   method: string;
+  /**
+   * The mandate used for this subscription. When there is no mandate specified, this parameter will not be returned.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=mandateId#response
+   */
   mandateId?: string;
+  /**
+   * The subscription's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=createdAt#response
+   */
   createdAt?: string;
+  /**
+   * The subscription's date and time of cancellation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment is not canceled (yet).
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=canceledAt#response
+   */
   canceledAt: string;
+  /**
+   * The URL Mollie will call as soon a payment status change takes place.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=webhookUrl#response
+   */
   webhookUrl: string;
+  /**
+   * The optional metadata you provided upon subscription creation. Metadata can for example be used to link a plan to a subscription.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=metadata#response
+   */
   metadata: any;
+  /**
+   * An object with several URL objects relevant to the subscription. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links#response
+   */
   _links: SubscriptionLinks;
 }
 
-/**
- * Subscription _links object
- *
- * @param customer - The API resource URL of the customer the subscription is for.
- */
 export interface SubscriptionLinks extends Links {
   customer: Url;
-  /**
-   * The API resource URL of the website profile on which this subscription was created.
-   */
   profile?: Url;
-  /**
-   * The API resource URL of the payments that are created by this subscription. Not present if no payments yet
-   * created.
-   */
   payments?: Url;
 }
 

--- a/src/data/subscription/data.ts
+++ b/src/data/subscription/data.ts
@@ -109,8 +109,23 @@ export interface SubscriptionData extends Model<'subscription'> {
 }
 
 export interface SubscriptionLinks extends Links {
+  /**
+   * The API resource URL of the customer the subscription is for.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links/customer#response
+   */
   customer: Url;
+  /**
+   * The API resource URL of the website profile on which this subscription was created.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links/profile#response
+   */
   profile?: Url;
+  /**
+   * The API resource URL of the payments that are created by this subscription. Not present if no payments yet created.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links/payments#response
+   */
   payments?: Url;
 }
 

--- a/src/data/subscription/helpers.ts
+++ b/src/data/subscription/helpers.ts
@@ -4,43 +4,28 @@ import commonHelpers from '../commonHelpers';
 export default {
   ...commonHelpers,
   /**
-   * Get the webhook url
+   * Returns the URL Mollie will call as soon a payment status change takes place.
    */
   getWebhookUrl: function getWebhookUrl(this: SubscriptionData): string {
     return this.webhookUrl;
   },
 
-  /**
-   * If the subscription is active
-   */
   isActive: function isActive(this: SubscriptionData): boolean {
     return this.status === SubscriptionStatus.active;
   },
 
-  /**
-   * If the subscription is pending
-   */
   isPending: function isPending(this: SubscriptionData): boolean {
     return this.status === SubscriptionStatus.pending;
   },
 
-  /**
-   * If the subscription is completed
-   */
   isCompleted: function isCompleted(this: SubscriptionData): boolean {
     return this.status === SubscriptionStatus.completed;
   },
 
-  /**
-   * If the subscription is suspended
-   */
   isSuspended: function isSuspended(this: SubscriptionData): boolean {
     return this.status === SubscriptionStatus.suspended;
   },
 
-  /**
-   * If the subscription is canceled
-   */
   isCanceled: function isCanceled(this: SubscriptionData): boolean {
     return SubscriptionStatus.canceled == this.status;
   },

--- a/src/plumbing/checkId.ts
+++ b/src/plumbing/checkId.ts
@@ -22,7 +22,7 @@ export default function checkId(value: string | undefined, resource: ResourceKin
     return false;
   }
   // Examples of permission identifiers are 'payments.read' and 'refunds.write'. This function currently relies on the
-  // API to return an error if the identifier is unexpected, instead of returning a client-side check.
+  // API to return an error if the identifier is unexpected, instead of performing a client-side check.
   if (resource == 'permission') {
     return true;
   }

--- a/src/resources/applePay/ApplePayResource.ts
+++ b/src/resources/applePay/ApplePayResource.ts
@@ -7,6 +7,29 @@ import renege from '../../plumbing/renege';
 export default class ApplePayResource {
   constructor(protected readonly networkClient: NetworkClient) {}
 
+  /**
+   * For integrating Apple Pay in your own checkout on the web, you need to [provide merchant
+   * validation](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/providing_merchant_validation). This is normally done using Apple's [Requesting Apple Pay
+   * Session](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/requesting_an_apple_pay_payment_session). The merchant validation proves (to Apple) that a validated
+   * merchant is calling the Apple Pay Javascript APIs.
+   *
+   * When integrating Apple Pay via Mollie, you cannot call Apple's API but you should call this API instead. The response of this API call should be passed as-is to the the completion method,
+   * [completeMerchantValidation](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778015-completemerchantvalidation).
+   *
+   * Before requesting an Apple Pay Payment Session, you must place the [domain validation file](http://www.mollie.com/.well-known/apple-developer-merchantid-domain-association) on your server at:
+   * `https://[domain]/.well-known/apple-developer-merchantid-domain-association`. Without this file, it will not be possible to use Apple Pay on your domain.
+   *
+   * The guidelines for working with a payment session are:
+   *
+   * -   Request a new payment session object for each transaction. You can only use a merchant session object a single time.
+   * -   The payment session object expires five minutes after it is created.
+   * -   Never request the payment session from the browser. The request must be sent from your server.
+   *
+   * For the full documentation, see the official [Apple Pay JS API](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api) documentation.
+   *
+   * @since 3.5.0
+   * @see https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session
+   */
   public requestPaymentSession(parameters: RequestPaymentSessionParameters): Promise<ApplePaySession>;
   public requestPaymentSession(parameters: RequestPaymentSessionParameters, callback: Callback<ApplePaySession>): void;
   public requestPaymentSession(parameters: RequestPaymentSessionParameters) {

--- a/src/resources/applePay/parameters.ts
+++ b/src/resources/applePay/parameters.ts
@@ -1,11 +1,17 @@
 export interface RequestPaymentSessionParameters {
   /**
-   * The validationUrl you got from the ApplePayValidateMerchant event
-   * https://developer.apple.com/documentation/apple_pay_on_the_web/applepayvalidatemerchantevent
+   * The `validationUrl` you got from the [ApplePayValidateMerchant event](https://developer.apple.com/documentation/apple_pay_on_the_web/applepayvalidatemerchantevent).
+   *
+   * A [list of all valid host names](https://developer.apple.com/documentation/apple_pay_on_the_web/setting_up_your_server#3172427) for merchant validation is available. You should white list these
+   * in your application and reject any `validationUrl` that have a host name not in the list.
+   *
+   * @see https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session?path=validationUrl#parameters
    */
   validationUrl: string;
   /**
-   * The domain of your web shop, that is visible in the browser’s location bar. For example pay.myshop.com.
+   * The domain of your web shop, that is visible in the browser's location bar. For example `pay.myshop.com`.
+   *
+   * @see https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session?path=domain#parameters
    */
   domain: string;
 }

--- a/src/resources/chargebacks/ChargebacksResource.ts
+++ b/src/resources/chargebacks/ChargebacksResource.ts
@@ -17,27 +17,30 @@ export default class ChargebacksResource extends ParentedResource<ChargebackData
   }
 
   /**
-   * List chargebacks
+   * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
   public all: ChargebacksResource['list'] = this.list;
   /**
-   * List chargebacks
+   * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
   public page: ChargebacksResource['list'] = this.list;
 
   /**
-   * List chargebacks
+   * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
   public list(parameters?: ListParameters): Promise<List<Chargeback>>;

--- a/src/resources/customers/CustomersResource.ts
+++ b/src/resources/customers/CustomersResource.ts
@@ -19,41 +19,36 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   }
 
   /**
-   * List Customers.
+   * Retrieve all customers created.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
   public all: CustomersResource['list'] = this.list;
   /**
-   * List Customers.
+   * Retrieve all customers created.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
   public page: CustomersResource['list'] = this.list;
   /**
-   * Delete a Customer.
+   * Delete a customer. All mandates and subscriptions created for this customer will be canceled as well.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/delete-customer
    */
   public cancel: CustomersResource['delete'] = this.delete;
 
   /**
-   * Creates a simple minimal representation of a customer in the Mollie API
-   * to use for the {@link https://www.mollie.com/en/checkout Mollie Checkout}
-   * and Recurring features.
-   * These customers will appear in your
-   * {@link https://www.mollie.com/dashboard/ Mollie Dashboard}
-   * where you can manage their details,
-   * and also see their payments and subscriptions.
+   * Creates a simple minimal representation of a customer in the Mollie API to use for the [Mollie Checkout](https://www.mollie.com/en/checkout) and Recurring features. These customers will appear in
+   * your [Mollie Dashboard](https://www.mollie.com/dashboard/) where you can manage their details, and also see their payments and subscriptions.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/create-customer
    */
   public create(parameters: CreateParameters): Promise<Customer>;
@@ -64,10 +59,9 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   }
 
   /**
-   * Retrieve a single customer by its ID
+   * Retrieve a single customer by its ID.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/get-customer
    */
   public get(id: string, parameters?: GetParameters): Promise<Customer>;
@@ -81,10 +75,11 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   }
 
   /**
-   * List customers
+   * Retrieve all customers created.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
   public list(parameters?: ListParameters): Promise<List<Customer>>;
@@ -95,10 +90,9 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   }
 
   /**
-   * Update a customer
+   * Update an existing customer.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/update-customer
    */
   public update(id: string, parameters: UpdateParameters): Promise<Customer>;
@@ -112,10 +106,9 @@ export default class CustomersResource extends Resource<CustomerData, Customer> 
   }
 
   /**
-   * Delete a customer
+   * Delete a customer. All mandates and subscriptions created for this customer will be canceled as well.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/delete-customer
    */
   public delete(id: string, parameters?: DeleteParameters): Promise<true>;

--- a/src/resources/customers/mandates/CustomersMandatesResource.ts
+++ b/src/resources/customers/mandates/CustomersMandatesResource.ts
@@ -20,43 +20,45 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
   }
 
   /**
-   * Get all of a customer's mandates
+   * Retrieve all mandates for the given `customerId`, ordered from newest to oldest.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 1.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
   public all: CustomersMandatesResource['list'] = this.list;
   /**
-   * Get all of a customer's mandates
+   * Retrieve all mandates for the given `customerId`, ordered from newest to oldest.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
   public page: CustomersMandatesResource['list'] = this.list;
   /**
-   * Alias for revoke
+   * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
    *
    * @since 1.3.2
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
    */
   public cancel: CustomersMandatesResource['revoke'] = this.revoke;
   /**
-   * Alias for revoke
+   * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
    */
   public delete: CustomersMandatesResource['revoke'] = this.revoke;
 
   /**
-   * Create a customer mandate
+   * Create a mandate for a specific customer. Mandates allow you to charge a customer's credit card, PayPal account or bank account recurrently.
+   *
+   * It is only possible to create mandates for IBANs and PayPal billing agreements with this endpoint. To create mandates for credit cards, have your customers perform a 'first payment' with their
+   * credit card.
    *
    * @since 1.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate
    */
   public create(parameters: CreateParameters): Promise<Mandate>;
@@ -72,10 +74,9 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
   }
 
   /**
-   * Get a customer mandate by ID
+   * Retrieve a mandate by its ID and its customer's ID. The mandate will either contain IBAN or credit card details, depending on the type of mandate.
    *
    * @since 1.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/get-mandate
    */
   public get(id: string, parameters: GetParameters): Promise<Mandate>;
@@ -95,10 +96,11 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
   }
 
   /**
-   * Get all of a customer's mandates
+   * Retrieve all mandates for the given `customerId`, ordered from newest to oldest.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
   public list(parameters: ListParameters): Promise<List<Mandate>>;
@@ -115,10 +117,9 @@ export default class CustomersMandatesResource extends ParentedResource<MandateD
   }
 
   /**
-   * Delete a customer subscription
+   * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
    */
   public revoke(id: string, parameters: RevokeParameters): Promise<true>;

--- a/src/resources/customers/mandates/parameters.ts
+++ b/src/resources/customers/mandates/parameters.ts
@@ -8,10 +8,35 @@ interface ContextParameters {
 
 export type CreateParameters = ContextParameters &
   Pick<MandateData, 'method'> & {
+    /**
+     * The consumer's name.
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=consumerName#parameters
+     */
     consumerName?: string;
+    /**
+     * The consumer's IBAN.
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=consumerAccount#parameters
+     */
     consumerAccount?: string;
+    /**
+     * The consumer's bank's BIC.
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=consumerBic#parameters
+     */
     consumerBic?: string;
+    /**
+     * The date when the mandate was signed in `YYYY-MM-DD` format.
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
+     */
     signatureDate?: string;
+    /**
+     * A custom mandate reference. Use an unique `mandateReference` as some banks decline a Direct Debit payment if the `mandateReference` is not unique.
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=mandateReference#parameters
+     */
     mandateReference?: string;
   };
 

--- a/src/resources/customers/payments/CustomersPaymentsResource.ts
+++ b/src/resources/customers/payments/CustomersPaymentsResource.ts
@@ -20,27 +20,31 @@ export default class CustomersPaymentsResource extends ParentedResource<PaymentD
   }
 
   /**
-   * Get all of a customer's payments.
+   * Retrieve all Payments linked to the Customer.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
   public all: CustomersPaymentsResource['list'] = this.list;
   /**
-   * Get all of a customer's payments.
+   * Retrieve all Payments linked to the Customer.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
   public page: CustomersPaymentsResource['list'] = this.list;
 
   /**
-   * Create a customer payment.
+   * Creates a payment for the customer.
+   *
+   * Linking customers to payments enables a number of [Mollie Checkout](https://www.mollie.com/en/checkout) features, including:
+   *
+   * -   Keeping track of payment preferences for your customers.
+   * -   Enabling your customers to charge a previously used credit card with a single click.
+   * -   Improved payment insights in your dashboard.
+   * -   Recurring payments.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/create-customer-payment
    */
   public create(parameters: CreateParameters): Promise<Payment>;
@@ -56,10 +60,9 @@ export default class CustomersPaymentsResource extends ParentedResource<PaymentD
   }
 
   /**
-   * Get all of a customer's payments.
+   * Retrieve all Payments linked to the Customer.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
   public list(parameters: ListParameters): Promise<List<Payment>>;

--- a/src/resources/customers/payments/parameters.ts
+++ b/src/resources/customers/payments/parameters.ts
@@ -10,13 +10,16 @@ export type CreateParameters = ContextParameters &
   Pick<PaymentData, 'amount' | 'description'> &
   PickOptional<PaymentData, 'locale' | 'mandateId' | 'metadata' | 'sequenceType' | 'webhookUrl' | 'redirectUrl'> & {
     /**
-     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment
-     * method and your customer will skip the selection screen and is sent directly to the chosen payment method. The
-     * parameter enables you to fully integrate the payment method selection into your website.
+     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
+     * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
      *
-     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen
-     * but will only show the methods specified in the array. For example, you can use this functionality to only show
-     * payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
+     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+     *
+     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `mybank` `paypal` `paysafecard` `przelewy24`
+     * `sofort`
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=method#parameters
      */
     method: PaymentMethod | PaymentMethod[];
   };

--- a/src/resources/customers/subscriptions/CustomersSubscriptionsResource.ts
+++ b/src/resources/customers/subscriptions/CustomersSubscriptionsResource.ts
@@ -20,35 +20,41 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
   }
 
   /**
-   * Delete a customer subscription.
+   * A subscription can be canceled any time by calling `DELETE` on the resource endpoint.
    *
    * @since 1.3.2
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
    */
   public delete: CustomersSubscriptionsResource['cancel'] = this.cancel;
   /**
-   * List the Customer's Subscriptions.
+   * Retrieve all subscriptions of a customer.
    *
    * @since 1.3.2
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
   public all: CustomersSubscriptionsResource['list'] = this.list;
   /**
-   * List the Customer's Subscriptions.
+   * Retrieve all subscriptions of a customer.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
   public page: CustomersSubscriptionsResource['list'] = this.list;
 
   /**
-   * Create a customer subscription.
+   * With subscriptions, you can schedule recurring payments to take place at regular intervals.
+   *
+   * For example, by simply specifying an `amount` and an `interval`, you can create an endless subscription to charge a monthly fee, until you cancel the subscription.
+   *
+   * Or, you could use the `times` parameter to only charge a limited number of times, for example to split a big transaction in multiple parts.
+   *
+   * A few example usages:
+   *
+   * -   `amount[currency]="EUR" amount[value]="5.00" interval="2 weeks"` Your consumer will be charged €5 once every two weeks.
+   * -   `amount[currency]="EUR" amount[value]="20.00" interval="1 day" times=5` Your consumer will be charged €20 every day, for five consecutive days.
+   * -   `amount[currency]="EUR" amount[value]="10.00" interval="1 month" startDate="2018-04-30"` Your consumer will be charged €10 on the last day of each month, starting in April 2018.
    *
    * @since 1.3.2
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription
    */
   public create(parameters: CreateParameters): Promise<Subscription>;
@@ -64,10 +70,9 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
   }
 
   /**
-   * Get a customer subscription.
+   * Retrieve a subscription by its ID and its customer's ID.
    *
    * @since 1.3.2
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
    */
   public get(id: string, parameters: GetParameters): Promise<Subscription>;
@@ -87,10 +92,9 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
   }
 
   /**
-   * Get all customer's subscriptions.
+   * Retrieve all subscriptions of a customer.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
   public list(parameters: ListParameters): Promise<List<Subscription>>;
@@ -107,10 +111,11 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
   }
 
   /**
-   * Update a customer's subscription.
+   * Some fields of a subscription can be updated by calling `PATCH` on the resource endpoint. Each field is optional.
+   *
+   * You cannot update a canceled subscription.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription
    */
   public update(id: string, parameters: UpdateParameters): Promise<Subscription>;
@@ -129,10 +134,9 @@ export default class CustomersSubscriptionsResource extends ParentedResource<Sub
   }
 
   /**
-   * Cancel a Subscription
+   * A subscription can be canceled any time by calling `DELETE` on the resource endpoint.
    *
    * @since 1.3.2
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
    */
   public cancel(id: string, parameters: CancelParameters): Promise<Subscription>;

--- a/src/resources/methods/MethodsResource.ts
+++ b/src/resources/methods/MethodsResource.ts
@@ -18,27 +18,49 @@ export default class MethodsResource extends Resource<MethodData, Method> {
   }
 
   /**
-   * Retrieve a list of Payment Methods
+   * Retrieve all enabled payment methods. The results are not paginated.
+   *
+   * -   For test mode, payment methods are returned that are enabled in the Dashboard (or the activation is pending).
+   * -   For live mode, payment methods are returned that have been activated on your account and have been enabled in the Dashboard.
+   *
+   * New payment methods can be activated via the Enable payment method endpoint in the Profiles API.
+   *
+   * When using the `first` sequence type, methods will be returned if they can be used as a first payment in a recurring sequence and if they are enabled in the Dashboard.
+   *
+   * When using the `recurring` sequence type, payment methods that can be used for recurring payments or subscriptions will be returned. Enabling / disabling methods in the dashboard does not affect
+   * how they can be used for recurring payments.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
   public all: MethodsResource['list'] = this.list;
   /**
-   * Retrieve a list of Payment Methods
+   * Retrieve all enabled payment methods. The results are not paginated.
+   *
+   * -   For test mode, payment methods are returned that are enabled in the Dashboard (or the activation is pending).
+   * -   For live mode, payment methods are returned that have been activated on your account and have been enabled in the Dashboard.
+   *
+   * New payment methods can be activated via the Enable payment method endpoint in the Profiles API.
+   *
+   * When using the `first` sequence type, methods will be returned if they can be used as a first payment in a recurring sequence and if they are enabled in the Dashboard.
+   *
+   * When using the `recurring` sequence type, payment methods that can be used for recurring payments or subscriptions will be returned. Enabling / disabling methods in the dashboard does not affect
+   * how they can be used for recurring payments.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
   public page: MethodsResource['list'] = this.list;
 
   /**
-   * Retrieve a single Payment Method
+   * Retrieve a single method by its ID. Note that if a method is not available on the website profile a status `404 Not found` is returned. When the method is not enabled, a status `403 Forbidden` is
+   * returned. You can enable payments methods via the Enable payment method endpoint in the Profiles API, or via your [Mollie Dashboard](https://www.mollie.com/dashboard).
+   *
+   * If you do not know the method's ID, you can use the methods list endpoint to retrieve all payment methods that are available.
+   *
+   * Additionally, it is possible to check if Wallets such as Apple Pay are enabled by passing the wallet ID (`applepay`) as the method ID.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/methods-api/get-method
    */
   public get(id: string, parameters?: GetParameters): Promise<Method>;
@@ -49,10 +71,19 @@ export default class MethodsResource extends Resource<MethodData, Method> {
   }
 
   /**
-   * Retrieve a list of Payment Methods
+   * Retrieve all enabled payment methods. The results are not paginated.
+   *
+   * -   For test mode, payment methods are returned that are enabled in the Dashboard (or the activation is pending).
+   * -   For live mode, payment methods are returned that have been activated on your account and have been enabled in the Dashboard.
+   *
+   * New payment methods can be activated via the Enable payment method endpoint in the Profiles API.
+   *
+   * When using the `first` sequence type, methods will be returned if they can be used as a first payment in a recurring sequence and if they are enabled in the Dashboard.
+   *
+   * When using the `recurring` sequence type, payment methods that can be used for recurring payments or subscriptions will be returned. Enabling / disabling methods in the dashboard does not affect
+   * how they can be used for recurring payments.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
   public list(parameters?: ListParameters): Promise<List<Method>>;

--- a/src/resources/methods/parameters.ts
+++ b/src/resources/methods/parameters.ts
@@ -1,69 +1,87 @@
 import { Amount, Locale, SequenceType } from '../../data/global';
 import { MethodInclude } from '../../data/methods/data';
 
-/**
- * Get Method parameters
- *
- * @param locale - Passing a locale will translate the payment method name in
- *                the corresponding language.
- * @param include - This endpoint allows you to include additional information.
- *
- * @param profileId - The website profile’s unique identifier, for example
- *                    `pfl_3RkSN1zuPE`. This field is mandatory.
- * @param testmode -Set this to true to list all methods available in testmode.
- *
- * @see https://docs.mollie.com/reference/v2/methods-api/get-method
- */
 export interface GetParameters {
+  /**
+   * Passing a locale will translate the payment method name in the corresponding language.
+   *
+   * Possible values: `en_US` `nl_NL` `nl_BE` `fr_FR` `fr_BE` `de_DE` `de_AT` `de_CH` `es_ES` `ca_ES` `pt_PT` `it_IT` `nb_NO` `sv_SE` `fi_FI` `da_DK` `is_IS` `hu_HU` `pl_PL` `lv_LV` `lt_LT`
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=locale#parameters
+   */
   locale?: Locale;
   include?: MethodInclude[] | MethodInclude;
   profileId?: string;
   testmode?: boolean;
   /**
-   * The currency to receiving the `minimumAmount` and `maximumAmount` in. We will return an error when the currency is
-   * not supported by the payment method.
+   * The currency to receiving the `minimumAmount` and `maximumAmount` in. We will return an error when the currency is not supported by the payment method.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=currency#parameters
    */
   currency?: string;
 }
 
 /**
- * List Methods parameters
+ * Retrieve all enabled payment methods. The results are not paginated.
  *
- * @param sequenceType - Passing first will only show payment methods eligible
- *                       for making a first payment. Passing recurring shows
- *                       payment methods which can be used to automatically
- *                       charge your customer’s account when authorization has
- *                       been given. Set to `oneoff` by default, which indicates
- *                       the payment method is available for a regular
- *                       non-recurring payment.
- * @param locale - Passing a locale will sort the payment methods in the preferred
- *                 order for the country, and translate the payment method names
- *                 in the corresponding language.
- * @param amount - An object containing value and currency. Only payment methods
- *                 that support the amount and currency are returned.
- * @param resource - Use the resource parameter to indicate if you will use the
- *                   result with the Create Order or Create Payment API. For example:
- *                   when passing orders the result will include payment methods that
- *                   can only be used in conjunction with orders, such as
- *                   Klarna Pay later. Default behaviour is returning all
- *                   available payment methods for payments.
- * @param billingCountry - The billing country of your customer in ISO 3166-1 alpha-2
- *                         format. This parameter can be used to check whether your
- *                         customer is eligible for certain payment methods,
- *                         for example Klarna Slice it.
- * @param include - This endpoint allows you to include additional information.
+ * -   For test mode, payment methods are returned that are enabled in the Dashboard (or the activation is pending).
+ * -   For live mode, payment methods are returned that have been activated on your account and have been enabled in the Dashboard.
  *
- * @param profileId - The website profile’s unique identifier, for example `pfl_3RkSN1zuPE`.
- *                    This field is mandatory.
- * @param testmode - Set this to `true` to list all payment methods available in testmode.
+ * New payment methods can be activated via the Enable payment method endpoint in the Profiles API.
+ *
+ * When using the `first` sequence type, methods will be returned if they can be used as a first payment in a recurring sequence and if they are enabled in the Dashboard.
+ *
+ * When using the `recurring` sequence type, payment methods that can be used for recurring payments or subscriptions will be returned. Enabling / disabling methods in the dashboard does not affect
+ * how they can be used for recurring payments.
  *
  * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
  */
 export interface ListParameters {
+  /**
+   * Passing `first` will only show payment methods eligible for making a first payment. Passing `recurring` shows payment methods which can be used to automatically charge your customer's account
+   * when authorization has been given. Set to `oneoff` by default, which indicates the payment method is available for a regular non-recurring payment.
+   *
+   * Possible values: `oneoff` `first` `recurring`
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods?path=sequenceType#parameters
+   */
   sequenceType?: SequenceType;
+  /**
+   * Passing a locale will sort the payment methods in the preferred order for the country, and translate the payment method names in the corresponding language.
+   *
+   * Possible values: `en_US` `nl_NL` `nl_BE` `fr_FR` `fr_BE` `de_DE` `de_AT` `de_CH` `es_ES` `ca_ES` `pt_PT` `it_IT` `nb_NO` `sv_SE` `fi_FI` `da_DK` `is_IS` `hu_HU` `pl_PL` `lv_LV` `lt_LT`
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods?path=locale#parameters
+   */
   locale?: Locale;
+  /**
+   * An object containing `value` and `currency`. Only payment methods that support the amount and currency are returned.
+   *
+   * Example: `https://api.mollie.com/v2/methods?amount[value]=100.00&amount[currency]=USD`
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods?path=amount#parameters
+   */
   amount?: Amount;
+  /**
+   * Use the `resource` parameter to indicate if you will use the result with the Create Order or Create
+   * Payment API.
+   *
+   * For example: when passing `orders` the result will include payment methods that can only be used in conjunction with orders, such as *Klarna Pay later* and meal vouchers. Default behaviour is
+   * returning all available payment methods for `payments`.
+   *
+   * Possible values: `orders` `payments`.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods?path=resource#parameters
+   */
   resource?: string;
+  /**
+   * The billing country of your customer in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. This parameter can be used to check whether your customer is eligible for
+   * certain payment methods, for example *Klarna Slice it*.
+   *
+   * Example: `https://api.mollie.com/v2/methods?resource=orders&billingCountry=DE`
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods?path=billingCountry#parameters
+   */
   billingCountry?: string;
   include?: MethodInclude[] | MethodInclude;
   profileId?: string;

--- a/src/resources/onboarding/OnboardingResource.ts
+++ b/src/resources/onboarding/OnboardingResource.ts
@@ -20,7 +20,6 @@ export default class OnboardingResource extends Resource<OnboardingData, Onboard
    * Get the status of onboarding of the authenticated organization.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status
    */
   public get(): Promise<Onboarding>;
@@ -31,11 +30,9 @@ export default class OnboardingResource extends Resource<OnboardingData, Onboard
   }
 
   /**
-   * Submit data that will be prefilled in the merchant's onboarding. Please note that the data you submit will only be
-   * processed when the onboarding status is `'needs-data'`.
+   * Submit data that will be prefilled in the merchant's onboarding. Please note that the data you submit will only be processed when the onboarding status is `needs-data`.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data
    */
   public submit(parameters?: SubmitParameters): Promise<true>;

--- a/src/resources/onboarding/parameters.ts
+++ b/src/resources/onboarding/parameters.ts
@@ -3,6 +3,8 @@ import { Address } from '../../data/global';
 export interface SubmitParameters {
   /**
    * Data of the organization you want to provide.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data?path=organization#parameters
    */
   organization?: {
     /**
@@ -30,6 +32,8 @@ export interface SubmitParameters {
   };
   /**
    * Data of the payment profile you want to provide.
+   *
+   * @see https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data?path=profile#parameters
    */
   profile?: {
     /**

--- a/src/resources/orders/OrdersResource.ts
+++ b/src/resources/orders/OrdersResource.ts
@@ -11,6 +11,21 @@ import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 
 /**
+ * The **Orders API** allows you to use Mollie for your order management.
+ *
+ * For each order in your shop, you can create an Order via the Mollie API. The order will remain valid for a certain amount of time (default 28 days).
+ *
+ * Just as a Payment, the Order will have a `_links.checkout` property where you can redirect your customer to pay for the Order. For each attempt to Pay, a Payment is created. If the customer pays
+ * for the Order, the Order will transition to the `paid` state (or `authorized` in case of pay after delivery).
+ *
+ * Should the initial Payment fail, the Order remains in the `created` state so that your customer can try to pay again. This can be done using a dedicated link available through the Dashboard which
+ * you can share with your customer, or you can create an additional Payment on the Order via the API.
+ *
+ * *Pay after delivery* payment methods, such as *Klarna Pay later*, *Klarna Slice it*, and *Vouchers* require the Orders API and cannot be used with the Payments API.
+ *
+ * Once you ship the goods to your customer, you should inform Mollie of the shipments via the API or via the Dashboard. This is mandatory for pay after delivery methods. Only shipped amounts will be
+ * settled to your account.
+ *
  * @see https://docs.mollie.com/orders/overview#orders-api
  */
 export default class OrdersResource extends Resource<OrderData, Order> {
@@ -23,48 +38,55 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   }
 
   /**
-   * Cancel an Order.
+   * The order can only be canceled while:
+   *
+   * -   the order doesn't have any open payments except for the methods `banktransfer`, `directdebit`, `klarnapaylater`, and `klarnasliceit`.
+   * -   the order's `status` field is either `created`, `authorized` or `shipping`[1].
+   *
+   * 1.  In case of `created`, all order lines will be canceled and the new order status will be `canceled`.
+   * 2.  In case of `authorized`, the authorization will be released, all order lines will be canceled and the new order status will be `canceled`.
+   * 3.  In case of `shipping`, any order lines that are still `authorized` will be canceled and order lines that are `shipping` will be completed. The new order status will be `completed`.
+   *
+   * For more information about the status transitions please check our order status changes guide.
+   *
+   * [1] If the order status is `shipping`, some order lines can have the status `paid` if the order was paid using a payment method that does not support authorizations (such as iDEAL) and the order
+   * lines are not shipped yet. In this case, the order cannot be canceled. You should create refunds for these order lines instead.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
    */
   public delete: OrdersResource['cancel'] = this.cancel;
   /**
-   * List Orders.
+   * Retrieve all orders.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
   public all: OrdersResource['list'] = this.list;
   /**
-   * List Orders.
+   * Retrieve all orders.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
   public page: OrdersResource['list'] = this.list;
 
   /**
-   * Using the Orders API is the preferred approach when integrating
-   * the Mollie API into e-commerce applications such as webshops.
-   * If you want to use pay after delivery methods such as Klarna Pay later,
-   * using the Orders API is mandatory.
+   * Using the Orders API is the preferred approach when integrating the Mollie API into e-commerce applications such as webshops. If you want to use *pay after delivery* methods such as *Klarna Pay
+   * later*, using the Orders API is mandatory.
    *
-   * Creating an order will automatically create the required payment to allow
-   * your customer to pay for the order.
+   * Creating an Order will automatically create the required Payment to allow your customer to pay for the order.
    *
-   * Once you have created an order, you should redirect your customer to the
-   * URL in the _links.checkout property from the response.
+   * Once you have created an Order, you should redirect your customer to the URL in the `_links.checkout` property from the response.
    *
-   * Note that when the payment fails, expires or is canceled, you can create
-   * a new payment using the Create order payment API. This is only possible
-   * for orders that have a created status.
+   * Note that when the payment fails, expires or is canceled, you can create a new Payment for the Order using the /reference/v2/orders-api/create-order-payment. This is only possible for orders that
+   * have a `created` status.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order
    */
   public create(parameters: CreateParameters): Promise<Order>;
@@ -77,10 +99,9 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   }
 
   /**
-   * Retrieve an Order.
+   * Retrieve a single order by its ID.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/get-order
    */
   public get(id: string, parameters?: GetParameters): Promise<Order>;
@@ -94,10 +115,11 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   }
 
   /**
-   * List Orders.
+   * Retrieve all orders.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
   public list(parameters?: ListParameters): Promise<List<Order>>;
@@ -108,10 +130,12 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   }
 
   /**
-   * Update an Order.
+   * This endpoint can be used to update the billing and/or shipping address of an order.
+   *
+   * When updating an order that uses a *pay after delivery* method such as *Klarna Pay later*, Klarna may decline the requested changes, resulting in an error response from the Mollie API. The order
+   * remains intact, though the requested changes are not persisted.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/update-order
    */
   public update(id: string, parameters: UpdateParameters): Promise<Order>;
@@ -125,10 +149,21 @@ export default class OrdersResource extends Resource<OrderData, Order> {
   }
 
   /**
-   * Cancel an Order.
+   * The order can only be canceled while:
+   *
+   * -   the order doesn't have any open payments except for the methods `banktransfer`, `directdebit`, `klarnapaylater`, and `klarnasliceit`.
+   * -   the order's `status` field is either `created`, `authorized` or `shipping`[1].
+   *
+   * 1.  In case of `created`, all order lines will be canceled and the new order status will be `canceled`.
+   * 2.  In case of `authorized`, the authorization will be released, all order lines will be canceled and the new order status will be `canceled`.
+   * 3.  In case of `shipping`, any order lines that are still `authorized` will be canceled and order lines that are `shipping` will be completed. The new order status will be `completed`.
+   *
+   * For more information about the status transitions please check our order status changes guide.
+   *
+   * [1] If the order status is `shipping`, some order lines can have the status `paid` if the order was paid using a payment method that does not support authorizations (such as iDEAL) and the order
+   * lines are not shipped yet. In this case, the order cannot be canceled. You should create refunds for these order lines instead.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
    */
   public cancel(id: string, parameters?: CancelParameters): Promise<Order>;

--- a/src/resources/orders/orderlines/OrderLinesResource.ts
+++ b/src/resources/orders/orderlines/OrderLinesResource.ts
@@ -19,19 +19,40 @@ export default class OrdersLinesResource extends ParentedResource<OrderData, Ord
   }
 
   /**
-   * Cancel an order line by ID or multiple order lines
+   * This endpoint can be used to cancel one or more order lines that were previously authorized using a *pay after delivery* payment method. Use the Cancel Order API if you want to cancel the entire
+   * order or the remainder of the order.
+   *
+   * Canceling or partially canceling an order line will immediately release the authorization held for that amount. Your customer will be able to see the updated order in his portal / app. Any
+   * canceled lines will be removed from the customer's point of view, but will remain visible in the Mollie Dashboard.
+   *
+   * You should cancel an order line if you do not intend to (fully) ship it.
+   *
+   * An order line can only be canceled while its `status` field is either `authorized` or `shipping`. If you cancel an `authorized` order line, the new order line status will be `canceled`. Canceling
+   * a `shipping` order line will result in a `completed` order line status.
+   *
+   * If the order line is `paid` or already `completed`, you should create a refund using the Create Order Refund API instead.
+   *
+   * For more information about the status transitions please check our order status changes guide.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
    */
   public delete: OrdersLinesResource['cancel'] = this.cancel;
 
   /**
-   * Update order lines
+   * This endpoint can be used to update an order line. Only the lines that belong to an order with status `created`, `pending` or `authorized` can be updated.
+   *
+   * Use cases for this endpoint could be updating the `name`, `productUrl`, `imageUrl`, and `metadata` for a certain order line because your customer wants to swap the item for a different variant,
+   * for example exchanging a blue skirt for the same skirt in red.
+   *
+   * Or update the `quantity`, `unitPrice`, `discountAmount`, `totalAmount`, `vatAmount` and `vatRate` if you want to substitute a product for an entirely different one.
+   *
+   * Alternatively, you can also (partially) cancel order lines instead of updating the quantity.
+   *
+   * When updating an order line that uses a *pay after delivery* method such as *Klarna Pay later*, Klarna may decline the requested changes, resulting in an error response from the Mollie API. The
+   * order remains intact, though the requested changes are not persisted.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/update-orderline
    */
   public update(id: string, parameters: UpdateParameters): Promise<Order>;
@@ -50,10 +71,22 @@ export default class OrdersLinesResource extends ParentedResource<OrderData, Ord
   }
 
   /**
-   * Cancel an order line by ID or multiple order lines
+   * This endpoint can be used to cancel one or more order lines that were previously authorized using a *pay after delivery* payment method. Use the Cancel Order API if you want to cancel the entire
+   * order or the remainder of the order.
+   *
+   * Canceling or partially canceling an order line will immediately release the authorization held for that amount. Your customer will be able to see the updated order in his portal / app. Any
+   * canceled lines will be removed from the customer's point of view, but will remain visible in the Mollie Dashboard.
+   *
+   * You should cancel an order line if you do not intend to (fully) ship it.
+   *
+   * An order line can only be canceled while its `status` field is either `authorized` or `shipping`. If you cancel an `authorized` order line, the new order line status will be `canceled`. Canceling
+   * a `shipping` order line will result in a `completed` order line status.
+   *
+   * If the order line is `paid` or already `completed`, you should create a refund using the Create Order Refund API instead.
+   *
+   * For more information about the status transitions please check our order status changes guide.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
    */
   public cancel(parameters: CancelParameters): Promise<true>;

--- a/src/resources/orders/orderlines/parameters.ts
+++ b/src/resources/orders/orderlines/parameters.ts
@@ -11,10 +11,14 @@ export type UpdateParameters = ContextParameters &
   PickOptional<OrderLineData, 'name' | 'quantity' | 'unitPrice' | 'discountAmount' | 'totalAmount' | 'vatAmount' | 'vatRate'> & {
     /**
      * A link pointing to an image of the product sold.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/update-orderline?path=imageUrl#parameters
      */
     imageUrl?: string;
     /**
      * A link pointing to the product page in your web shop of the product sold.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/update-orderline?path=productUrl#parameters
      */
     productUrl?: string;
   };
@@ -22,6 +26,8 @@ export type UpdateParameters = ContextParameters &
 export type CancelParameters = ContextParameters & {
   /**
    * An array of objects containing the order line details you want to cancel.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines?path=lines#parameters
    */
   lines: {
     /**

--- a/src/resources/orders/orderlines/parameters.ts
+++ b/src/resources/orders/orderlines/parameters.ts
@@ -31,31 +31,33 @@ export type CancelParameters = ContextParameters & {
    */
   lines: {
     /**
-     * The API resource token of the order line, for example: `'odl_jp31jz'`.
+     * The API resource token of the order line, for example: `odl_jp31jz`.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines?path=lines/id#parameters
      */
     id: string;
     /**
-     * The number of items that should be canceled for this order line. When this parameter is omitted, the whole order
-     * line will be canceled. When part of the line has been shipped, it will cancel the remainder and the order line
-     * will be completed.
+     * The number of items that should be canceled for this order line. When this parameter is omitted, the whole order line will be canceled. When part of the line has been shipped, it will cancel
+     * the remainder and the order line will be completed.
      *
      * Must be less than the number of items already shipped or canceled for this order line.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines?path=lines/quantity#parameters
      */
     quantity?: number;
     /**
      * The amount that you want to cancel. In almost all cases, Mollie can determine the amount automatically.
      *
-     * The amount is required only if you are partially canceling an order line which has a non-zero `discountAmount`.
+     * The amount is required only if you are *partially* canceling an order line which has a non-zero `discountAmount`.
      *
-     * The amount you can cancel depends on various properties of the order line and the cancel order lines request.
-     * The maximum that can be canceled is `unit price x quantity to cancel`.
+     * The amount you can cancel depends on various properties of the order line and the cancel order lines request. The maximum that can be canceled is `unit price x quantity to cancel`.
      *
-     * The minimum amount depends on the discount applied to the line, the quantity already shipped or canceled, the
-     * amounts already shipped or canceled and the quantity you want to cancel.
+     * The minimum amount depends on the discount applied to the line, the quantity already shipped or canceled, the amounts already shipped or canceled and the quantity you want to cancel.
      *
-     * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the
-     * amount cannot be determined automatically. The error will contain the `extra.minimumAmount` and
-     * `extra.maximumAmount` properties that allow you pick the right amount.
+     * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the amount cannot be determined automatically. The error will contain the
+     * `extra.minimumAmount` and `extra.maximumAmount` properties that allow you pick the right amount.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines?path=lines/amount#parameters
      */
     amount?: Amount;
   }[];

--- a/src/resources/orders/parameters.ts
+++ b/src/resources/orders/parameters.ts
@@ -6,38 +6,74 @@ import { PaymentMethod } from '../../data/global';
 import PickOptional from '../../types/PickOptional';
 
 export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billingAddress' | 'webhookUrl' | 'locale' | 'metadata' | 'expiresAt'> & {
+  /**
+   * The lines in the order. Each line contains details such as a description of the item ordered, its price et cetera. See order-lines-details for the exact details on the lines.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=lines#parameters
+   */
   lines: (Pick<OrderLineData, 'name' | 'quantity' | 'unitPrice' | 'totalAmount' | 'vatRate' | 'vatAmount'> &
     PickOptional<OrderLineData, 'type' | 'discountAmount' | 'sku' | 'metadata'> & {
+      /**
+       * The category of product bought. Must be one of the following values:
+       *
+       * -   `meal`
+       * -   `eco`
+       * -   `gift`
+       *
+       * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=category#order-lines-details
+       */
       category?: string;
+      /**
+       * A link pointing to an image of the product sold.
+       *
+       * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=imageUrl#order-lines-details
+       */
       imageUrl?: string;
+      /**
+       * A link pointing to the product page in your web shop of the product sold.
+       *
+       * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=productUrl#order-lines-details
+       */
       productUrl?: string;
     })[];
   /**
-   * The shipping address for the order. If omitted, it is assumed to be identical to the `billingAddress`.
+   * The shipping address for the order. See order-address-details for the exact fields needed. If omitted, it is assumed to be identical to the `billingAddress`.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=shippingAddress#parameters
    */
   shippingAddress?: OrderAddress;
   /**
    * The URL your customer will be redirected to after the payment process.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=redirectUrl#parameters
    */
   redirectUrl?: string;
   /**
-   * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment
-   * method and your customer will skip the selection screen and is sent directly to the chosen payment method. The
-   * parameter enables you to fully integrate the payment method selection into your website.
+   * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
+   * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
    *
-   * You can also specify the methods in an array. By doing so we will still show the payment method selection screen
-   * but will only show the methods specified in the array. For example, you can use this functionality to only show
-   * payment methods from a specific country to your customer `["bancontact", "belfius", "inghomepay"]`.
+   * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
+   * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+   *
+   * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `klarnapaylater` `klarnasliceit` `mybank`
+   * `paypal` `paysafecard` `przelewy24` `sofort` `voucher`
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=method#parameters
    */
   method?: PaymentMethod | PaymentMethod[];
   /**
-   * Any payment specific properties can be passed here.
+   * Any payment specific properties (for example, the `dueDate` for bank transfer payments) can be passed here. See payment-parameters for the possible fields.
+   *
+   * The `payment` property should be an *object* where the keys are the payment method specific parameters you want to pass.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=payment#parameters
    */
   payment?: Partial<PaymentData>;
   /**
-   * For digital goods, you must make sure to apply the VAT rate from your customer's country in most jurisdictions.
-   * Use this parameter to restrict the payment methods available to your customer to methods from the billing country
-   * only.
+   * For digital goods, you must make sure to apply the VAT rate from your customer's country in most jurisdictions. Use this parameter to restrict the payment methods available to your customer to
+   * methods from the billing country only.
+   *
+   * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=shopperCountryMustMatchBillingCountry#parameters
    */
   shopperCountryMustMatchBillingCountry?: boolean;
   embed?: OrderEmbed.payments[];

--- a/src/resources/orders/shipments/OrdersShipmentsResource.ts
+++ b/src/resources/orders/shipments/OrdersShipmentsResource.ts
@@ -19,36 +19,28 @@ export default class OrdersShipmentsResource extends ParentedResource<ShipmentDa
   }
 
   /**
-   * List order shipments
+   * Retrieve all shipments for an order.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
   public all: OrdersShipmentsResource['list'] = this.list;
   /**
-   * List order shipments
+   * Retrieve all shipments for an order.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
   public page: OrdersShipmentsResource['list'] = this.list;
 
   /**
-   * In addition to the
-   * {@link https://docs.mollie.com/reference/v2/orders-api/create-order Orders API},
-   * the create shipment endpoint can be used to ship order lines.
+   * The **Create Shipment API** is used to ship order lines created by the /reference/v2/orders-api/create-order.
    *
-   * When using Klarna Pay later and Klarna Slice it this is mandatory
-   * for the order amount to be captured. An capture will automatically
-   * be created for the shipment.
+   * When using *Klarna Pay later* and *Klarna Slice it* this is mandatory for the order amount to be captured. A capture will automatically be created for the shipment.
    *
-   * The word “shipping” is used in the figurative sense here. It can also
-   * mean that a service was provided or digital content was delivered.
+   * The word "shipping" is used in the figurative sense here. It can also mean that a service was provided or digital content was delivered.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment
    */
   public create(parameters: CreateParameters): Promise<Shipment>;
@@ -64,10 +56,9 @@ export default class OrdersShipmentsResource extends ParentedResource<ShipmentDa
   }
 
   /**
-   * Get a Shipment by ID
+   * Retrieve a single shipment and the order lines shipped by a shipment's ID.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment
    */
   public get(id: string, parameters: GetParameters): Promise<Shipment>;
@@ -87,10 +78,9 @@ export default class OrdersShipmentsResource extends ParentedResource<ShipmentDa
   }
 
   /**
-   * Update a Shipment
+   * This endpoint can be used to update the tracking information of a shipment.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/shipments-api/update-shipment
    */
   public update(id: string, parameters: UpdateParameters): Promise<Shipment>;
@@ -109,10 +99,9 @@ export default class OrdersShipmentsResource extends ParentedResource<ShipmentDa
   }
 
   /**
-   * List order shipments
+   * Retrieve all shipments for an order.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
   public list(parameters: ListParameters): Promise<List<Shipment>>;

--- a/src/resources/orders/shipments/parameters.ts
+++ b/src/resources/orders/shipments/parameters.ts
@@ -10,9 +10,10 @@ interface ContextParameters {
 export type CreateParameters = ContextParameters &
   Pick<ShipmentData, 'tracking'> & {
     /**
-     * An array of objects containing the order line details you want to create a shipment for. If you send an empty
-     * array, the entire order will be shipped. If the order is already partially shipped, any remaining lines will be
-     * shipped.
+     * An array of objects containing the order line details you want to create a shipment for. If you leave out this parameter, the entire order will be shipped. If the order is already partially
+     * shipped, any remaining lines will be shipped.
+     *
+     * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment?path=lines#parameters
      */
     lines?: {
       /**

--- a/src/resources/orders/shipments/parameters.ts
+++ b/src/resources/orders/shipments/parameters.ts
@@ -17,14 +17,17 @@ export type CreateParameters = ContextParameters &
      */
     lines?: {
       /**
-       * The API resource token of the order line, for example: `'odl_jp31jz'`.
+       * The API resource token of the order line, for example: `odl_jp31jz`.
+       *
+       * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment?path=lines/id#parameters
        */
       id: string;
       /**
-       * The number of items that should be shipped for this order line. When this parameter is omitted, the whole order
-       * line will be shipped.
+       * The number of items that should be shipped for this order line. When this parameter is omitted, the whole order line will be shipped.
        *
        * Must be less than the number of items already shipped for this order line.
+       *
+       * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment?path=lines/quantity#parameters
        */
       quantity?: number;
       /**
@@ -32,15 +35,14 @@ export type CreateParameters = ContextParameters &
        *
        * The amount is required only if you are *partially* shipping an order line which has a non-zero `discountAmount`.
        *
-       * The amount you can ship depends on various properties of the order line and the create shipment request. The
-       * maximum that can be shipped is `unit price x quantity to ship`.
+       * The amount you can ship depends on various properties of the order line and the create shipment request. The maximum that can be shipped is `unit price x quantity to ship`.
        *
-       * The minimum amount depends on the discount applied to the line, the quantity already shipped or canceled, the
-       * amounts already shipped or canceled and the quantity you want to ship.
+       * The minimum amount depends on the discount applied to the line, the quantity already shipped or canceled, the amounts already shipped or canceled and the quantity you want to ship.
        *
-       * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the
-       * amount cannot be determined automatically. The error will contain the `extra.minimumAmount` and
-       * `extra.maximumAmount` properties that allow you pick the right amount.
+       * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the amount cannot be determined automatically. The error will contain the
+       * `extra.minimumAmount` and `extra.maximumAmount` properties that allow you pick the right amount.
+       *
+       * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment?path=lines/amount#parameters
        */
       amount?: Amount;
     }[];
@@ -51,40 +53,3 @@ export type GetParameters = ContextParameters;
 export type ListParameters = ContextParameters;
 
 export type UpdateParameters = ContextParameters & PickRequired<ShipmentData, 'tracking'>;
-
-export type CancelParameters = ContextParameters & {
-  /**
-   * An array of objects containing the order line details you want to cancel.
-   */
-  lines: {
-    /**
-     * The API resource token of the order line, for example: `'odl_jp31jz'`.
-     */
-    id: string;
-    /**
-     * The number of items that should be canceled for this order line. When this parameter is omitted, the whole order
-     * line will be canceled. When part of the line has been shipped, it will cancel the remainder and the order line
-     * will be completed.
-     *
-     * Must be less than the number of items already shipped or canceled for this order line.
-     */
-    quantity?: number;
-    /**
-     * The amount that you want to cancel. In almost all cases, Mollie can determine the amount automatically.
-     *
-     * The amount is required only if you are *partially* canceling an order line which has a non-zero
-     * `discountAmount`.
-     *
-     * The amount you can cancel depends on various properties of the order line and the cancel order lines request.
-     * The maximum that can be canceled is `unit price x quantity to cancel`.
-     *
-     * The minimum amount depends on the discount applied to the line, the quantity already shipped or canceled, the
-     * amounts already shipped or canceled and the quantity you want to cancel.
-     *
-     * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the
-     * amount cannot be determined automatically. The error will contain the `extra.minimumAmount` and
-     * `extra.maximumAmount` properties that allow you pick the right amount.
-     */
-    amount?: Amount;
-  }[];
-};

--- a/src/resources/organizations/OrganizationsResource.ts
+++ b/src/resources/organizations/OrganizationsResource.ts
@@ -19,8 +19,9 @@ export default class OrganizationsResource extends Resource<OrganizationData, Or
   /**
    * Retrieve an organization by its ID.
    *
-   * @since 3.2.0
+   * If you do not know the organization's ID, you can use the organizations list endpoint to retrieve all organizations that are accessible.
    *
+   * @since 3.2.0
    * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization
    */
   public get(id: string): Promise<Organization>;
@@ -37,7 +38,6 @@ export default class OrganizationsResource extends Resource<OrganizationData, Or
    * Retrieve the currently authenticated organization.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/organizations-api/current-organization
    */
   public getCurrent(): Promise<Organization>;

--- a/src/resources/payments/PaymentsResource.ts
+++ b/src/resources/payments/PaymentsResource.ts
@@ -21,38 +21,41 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
 
   /**
    * Retrieve all payments created with the current website profile, ordered from newest to oldest.
-   * This is just an alias of the `list` method.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
   public all: PaymentsResource['list'] = this.list;
   /**
    * Retrieve all payments created with the current website profile, ordered from newest to oldest.
-   * This is just an alias of the `list` method.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
   public page: PaymentsResource['list'] = this.list;
   /**
-   * Delete the given Payment. This is just an alias of the 'cancel' method.
+   * Some payment methods can be canceled by the merchant for a certain amount of time, usually until the next business day. Or as long as the payment status is `open`. Payments may be canceled
+   * manually from the Mollie Dashboard, or programmatically by using this endpoint.
    *
-   * Will throw an ApiError if the payment ID is invalid or if the resource cannot be found.
+   * The `isCancelable` property on the Payment object will indicate if the payment can be canceled.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/cancel-payment
    */
   public delete: PaymentsResource['cancel'] = this.cancel;
 
   /**
-   * Create a payment in Mollie.
+   * Payment creation is elemental to the Mollie API: this is where most payment implementations start off.
+   *
+   * Once you have created a payment, you should redirect your customer to the URL in the `_links.checkout` property from the response.
+   *
+   * To wrap your head around the payment process, an explanation and flow charts can be found in the Payments API Overview.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/create-payment
    */
   public create(parameters: CreateParameters): Promise<Payment>;
@@ -65,10 +68,9 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
   }
 
   /**
-   * Retrieve a single payment from Mollie.
+   * Retrieve a single payment object by its payment token.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment
    */
   public get(id: string, parameters?: GetParameters): Promise<Payment>;
@@ -84,8 +86,9 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
   /**
    * Retrieve all payments created with the current website profile, ordered from newest to oldest.
    *
-   * @since 3.0.0
+   * The results are paginated. See pagination for more information.
    *
+   * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
   public list(parameters?: ListParameters): Promise<List<Payment>>;
@@ -96,10 +99,9 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
   }
 
   /**
-   * Update some details of a created payment.
+   * This endpoint can be used to update some details of a created payment.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/update-payment
    */
   public update(id: string, parameters: UpdateParameters): Promise<Payment>;
@@ -113,13 +115,12 @@ export default class PaymentsResource extends Resource<PaymentData, Payment> {
   }
 
   /**
-   * Cancel the given payment.
+   * Some payment methods can be canceled by the merchant for a certain amount of time, usually until the next business day. Or as long as the payment status is `open`. Payments may be canceled
+   * manually from the Mollie Dashboard, or programmatically by using this endpoint.
    *
-   * Will throw an ApiError if the payment id is invalid or the resource cannot be found.
-   * Returns with HTTP status No Content (204) if successful.
+   * The `isCancelable` property on the Payment object will indicate if the payment can be canceled.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/payments-api/cancel-payment
    */
   public cancel(id: string, parameters?: CancelParameters): Promise<Payment>;

--- a/src/resources/payments/captures/PaymentsCapturesResource.ts
+++ b/src/resources/payments/captures/PaymentsCapturesResource.ts
@@ -19,28 +19,31 @@ export default class PaymentsCapturesResource extends ParentedResource<CaptureDa
   }
 
   /**
-   * Retrieve a list of Payment Captures
+   * Retrieve all captures for a certain payment.
+   *
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
   public all: PaymentsCapturesResource['list'] = this.list;
   /**
-   * Retrieve a list of Payment Captures
+   * Retrieve all captures for a certain payment.
+   *
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
   public page: PaymentsCapturesResource['list'] = this.list;
 
   /**
-   * Get a Payment Capture by ID
+   * Retrieve a single capture by its ID. Note the original payment's ID is needed as well.
+   *
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are **Klarna Pay later** and **Klarna Slice it**.
    *
    * @since 1.1.1
-   *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-Capture
+   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture
    */
   public get(id: string, parameters: GetParameters): Promise<Capture>;
   public get(id: string, parameters: GetParameters, callback: Callback<Capture>): void;
@@ -59,10 +62,11 @@ export default class PaymentsCapturesResource extends ParentedResource<CaptureDa
   }
 
   /**
-   * Retrieve a list of Payment Captures
+   * Retrieve all captures for a certain payment.
+   *
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
   public list(parameters: ListParameters): Promise<List<Capture>>;

--- a/src/resources/payments/chargebacks/PaymentsChargebacksResource.ts
+++ b/src/resources/payments/chargebacks/PaymentsChargebacksResource.ts
@@ -19,27 +19,30 @@ export default class PaymentsChargebacksResource extends ParentedResource<Charge
   }
 
   /**
-   * Retrieve a list of Payment Chargebacks
+   * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
   public all: PaymentsChargebacksResource['list'] = this.list;
   /**
-   * Retrieve a list of Payment Chargebacks
+   * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
   public page: PaymentsChargebacksResource['list'] = this.list;
 
   /**
-   * Get a Payment Chargeback by ID
+   * Retrieve a single chargeback by its ID. Note the original payment's ID is needed as well.
+   *
+   * If you do not know the original payment's ID, you can use the chargebacks list endpoint.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback
    */
   public get(id: string, parameters: GetParameters): Promise<Chargeback>;
@@ -59,10 +62,11 @@ export default class PaymentsChargebacksResource extends ParentedResource<Charge
   }
 
   /**
-   * Retrieve a list of Payment Chargebacks
+   * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
   public list(parameters: ListParameters): Promise<List<Chargeback>>;

--- a/src/resources/payments/orders/OrdersPaymentsResource.ts
+++ b/src/resources/payments/orders/OrdersPaymentsResource.ts
@@ -19,10 +19,13 @@ export default class OrdersPaymentsResource extends ParentedResource<PaymentData
   }
 
   /**
-   * Create order payment
+   * An order has an automatically created payment that your customer can use to pay for the order. When the payment expires you can create a new payment for the order using this endpoint.
+   *
+   * A new payment can only be created while the status of the order is `created`, and when the status of the existing payment is either `expired`, `canceled` or `failed`.
+   *
+   * Note that order details (for example `amount` or `webhookUrl`) can not be changed using this endpoint.
    *
    * @since 3.1.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order-payment
    */
   public create(parameters: CreateParameters): Promise<Payment>;

--- a/src/resources/payments/orders/parameters.ts
+++ b/src/resources/payments/orders/parameters.ts
@@ -9,18 +9,22 @@ interface ContextParameters {
 export type CreateParameters = ContextParameters &
   Pick<PaymentData, 'mandateId' | 'applicationFee'> & {
     /**
-     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment
-     * method and your customer will skip the selection screen and is sent directly to the chosen payment method. The
-     * parameter enables you to fully integrate the payment method selection into your website.
+     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
+     * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
      *
-     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen
-     * but will only show the methods specified in the array. For example, you can use this functionality to only show
-     * payment methods from a specific country to your customer `["bancontact", "belfius", "inghomepay"]`.
+     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
+     * this functionality to only show payment methods from a specific country to your customer `["bancontact", "belfius", "inghomepay"]`.
+     *
+     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `klarnapaylater` `klarnasliceit` `paypal`
+     * `paysafecard` `przelewy24` `sofort`
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/create-order-payment?path=method#parameters
      */
     method?: PaymentMethod | PaymentMethod[];
     /**
-     * The ID of the Customer for whom the payment is being created. This is used for recurring payments and single click
-     * payments.
+     * The ID of the Customer for whom the payment is being created. This is used for recurring payments and single click payments.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/create-order-payment?path=customerId#parameters
      */
     customerId?: string;
   };

--- a/src/resources/payments/parameters.ts
+++ b/src/resources/payments/parameters.ts
@@ -50,7 +50,7 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      */
     issuer?: Issuer;
     /**
-     * Used for consumer identification. Use the following guidelines to create your `customerReference`:  
+     * Used for consumer identification. Use the following guidelines to create your `customerReference`:
      * -   Has to be unique per shopper
      * -   Has to remain the same for one shopper
      * -   Should be as disconnected from personal data as possible
@@ -100,7 +100,19 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee#access-token-parameters
      */
     applicationFee?: {
+      /**
+       * The amount in that the app wants to charge, e.g. `{"currency":"EUR", "value":"10.00"}` if the app would want to charge €10.00.
+       *
+       * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee/amount#access-token-parameters
+       */
       amount: Amount;
+      /**
+       * The description of the application fee. This will appear on settlement reports to the merchant and to you.
+       *
+       * The maximum length is 255 characters.
+       *
+       * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee/description#access-token-parameters
+       */
       description: string;
     };
   };

--- a/src/resources/payments/parameters.ts
+++ b/src/resources/payments/parameters.ts
@@ -7,44 +7,98 @@ import PickOptional from '../../types/PickOptional';
 export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'redirectUrl' | 'webhookUrl' | 'customerId' | 'mandateId'> &
   PickOptional<PaymentData, 'locale' | 'metadata' | 'sequenceType'> & {
     /**
-     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment
-     * method and your customer will skip the selection screen and is sent directly to the chosen payment method. The
-     * parameter enables you to fully integrate the payment method selection into your website.
+     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
+     * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
      *
-     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen
-     * but will only show the methods specified in the array. For example, you can use this functionality to only show
-     * payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
+     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+     *
+     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `mybank` `paypal` `paysafecard` `przelewy24`
+     * `sofort`
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=method#parameters
      */
     method?: PaymentMethod | PaymentMethod[];
     /**
-     * For digital goods in most jurisdictions, you must apply the VAT rate from your customer's country. Choose the VAT
-     * rates you have used for the order to ensure your customer's country matches the VAT country. Use this parameter to
-     * restrict the payment methods available to your customer to those from a single country.
+     * For digital goods in most jurisdictions, you must apply the VAT rate from your customer's country. Choose the VAT rates you have used for the order to ensure your customer's country matches the
+     * VAT country.
+     *
+     * Use this parameter to restrict the payment methods available to your customer to those from a single country.
      *
      * If available, the credit card method will still be offered, but only cards from the allowed country are accepted.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=restrictPaymentMethodsToCountry#parameters
      */
     restrictPaymentMethodsToCountry?: string;
     billingEmail?: string;
+    /**
+     * The date the payment should expire, in `YYYY-MM-DD` format. **Please note:** the minimum date is tomorrow and the maximum date is 100 days after tomorrow.
+     *
+     * After you created the payment, you can still update the `dueDate` via the /reference/v2/payments-api/update-payment.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=dueDate#bank-transfer
+     */
     dueDate?: string;
     billingAddress?: Address;
     shippingAddress?: Address;
-    /**
-     * Indicate if you're about to deliver digital goods, like for example a license. Setting this parameter can have
-     * consequences for your Seller Protection by PayPal. Please see PayPal's help article about Seller Protection for
-     * more information.
-     */
     digitalGoods?: boolean;
+    /**
+     * An iDEAL issuer ID, for example `ideal_INGBNL2A`. The returned payment URL will deep-link into the specific banking website (ING Bank, in this example). The full list of issuers can be
+     * retrieved via the Methods API by using the optional `issuers` include.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=issuer#ideal
+     */
     issuer?: Issuer;
+    /**
+     * Used for consumer identification. Use the following guidelines to create your `customerReference`:  
+     * -   Has to be unique per shopper
+     * -   Has to remain the same for one shopper
+     * -   Should be as disconnected from personal data as possible
+     * -   Must not contain customer sensitive data
+     * -   Must not contain the timestamp
+     * -   Must not contain the IP address
+     *
+     * Due to data privacy regulations, make sure not to use any personal identifiable information in this parameter.
+     *
+     * If not provided, Mollie will send a hashed version of the shopper IP address.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=customerReference#paysafecard
+     */
     customerReference?: string;
+    /**
+     * Beneficiary name of the account holder. Only available if one-off payments are enabled on your account. Will pre-fill the beneficiary name in the checkout screen if present.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=consumerName#sepa-direct-debit
+     */
     consumerName?: string;
+    /**
+     * IBAN of the account holder. Only available if one-off payments are enabled on your account. Will pre-fill the IBAN in the checkout screen if present.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=consumerAccount#sepa-direct-debit
+     */
     consumerAccount?: string;
+    /**
+     * The card number on the gift card.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=voucherNumber#gift-cards
+     */
     voucherNumber?: string;
+    /**
+     * The PIN code on the gift card. Only required if there is a PIN code printed on the gift card.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=voucherPin#gift-cards
+     */
     voucherPin?: string;
 
     include?: PaymentInclude[] | PaymentInclude;
 
     profileId?: string;
     testmode?: boolean;
+    /**
+     * Adding an application fee allows you to charge the merchant a small sum for the payment and transfer this to your own account.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee#access-token-parameters
+     */
     applicationFee?: {
       amount: Amount;
       description: string;
@@ -65,11 +119,14 @@ export type ListParameters = CommonListParameters & {
 export type UpdateParameters = Pick<PaymentData, 'redirectUrl' | 'webhookUrl'> &
   PickOptional<PaymentData, 'description' | 'metadata'> & {
     /**
-     * For digital goods in most jurisdictions, you must apply the VAT rate from your customer's country. Choose the VAT
-     * rates you have used for the order to ensure your customer's country matches the VAT country. Use this parameter to
-     * restrict the payment methods available to your customer to those from a single country.
+     * For digital goods in most jurisdictions, you must apply the VAT rate from your customer's country. Choose the VAT rates you have used for the order to ensure your customer's country matches the
+     * VAT country.
+     *
+     * Use this parameter to restrict the payment methods available to your customer to those from a single country.
      *
      * If available, the credit card method will still be offered, but only cards from the allowed country are accepted.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/update-payment?path=restrictPaymentMethodsToCountry#parameters
      */
     restrictPaymentMethodsToCountry?: string;
   };

--- a/src/resources/payments/refunds/PaymentRefundsResource.ts
+++ b/src/resources/payments/refunds/PaymentRefundsResource.ts
@@ -20,33 +20,47 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
   }
 
   /**
-   * Get all payment refunds. Alias of list.
+   * Retrieve Refunds.
+   *
+   * -   If the payment-specific endpoint is used, only Refunds for that specific Payment are returned.
+   * -   When using the top level endpoint `v2/refunds` with an API key, only refunds for the corresponding website profile and mode are returned.
+   * -   When using the top level endpoint with OAuth, you can specify the profile and mode with the `profileId` and `testmode` parameters respectively. If you omit `profileId`, you will get all
+   *     Refunds for the Organization.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
   public all: PaymentsRefundsResource['list'] = this.list;
   /**
-   * Get all payment refunds. Alias of list.
+   * Retrieve Refunds.
+   *
+   * -   If the payment-specific endpoint is used, only Refunds for that specific Payment are returned.
+   * -   When using the top level endpoint `v2/refunds` with an API key, only refunds for the corresponding website profile and mode are returned.
+   * -   When using the top level endpoint with OAuth, you can specify the profile and mode with the `profileId` and `testmode` parameters respectively. If you omit `profileId`, you will get all
+   *     Refunds for the Organization.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
   public page: PaymentsRefundsResource['list'] = this.list;
   /**
-   * Cancel a Payment Refund by ID
+   * For certain payment methods, like iDEAL, the underlying banking system will delay refunds until the next day. Until that time, refunds may be canceled manually in the [Mollie
+   * Dashboard](https://www.mollie.com/dashboard), or programmatically by using this endpoint.
+   *
+   * A Refund can only be canceled while its `status` field is either `queued` or `pending`. See the /reference/v2/refunds-api/get-refund for more information.
    *
    * @see https://docs.mollie.com/reference/v2/refunds-api/cancel-refund
    */
   public delete: PaymentsRefundsResource['cancel'] = this.cancel;
 
   /**
-   * Create a payment refund
+   * Creates a Refund on the Payment. The refunded amount is credited to your customer.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/create-refund
    */
   public create(parameters: CreateParameters): Promise<Refund>;
@@ -62,10 +76,11 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
   }
 
   /**
-   * Get a payment refund by ID
+   * Retrieve a single Refund by its ID. Note the Payment's ID is needed as well.
+   *
+   * If you do not know the original payment's ID, you can use the /reference/v2/refunds-api/list-refunds.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/get-refund
    */
   public get(id: string, parameters: GetParameters): Promise<Refund>;
@@ -85,10 +100,16 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
   }
 
   /**
-   * Get all payment refunds.
+   * Retrieve Refunds.
+   *
+   * -   If the payment-specific endpoint is used, only Refunds for that specific Payment are returned.
+   * -   When using the top level endpoint `v2/refunds` with an API key, only refunds for the corresponding website profile and mode are returned.
+   * -   When using the top level endpoint with OAuth, you can specify the profile and mode with the `profileId` and `testmode` parameters respectively. If you omit `profileId`, you will get all
+   *     Refunds for the Organization.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
   public list(parameters: ListParameters): Promise<List<Refund>>;
@@ -105,10 +126,12 @@ export default class PaymentsRefundsResource extends ParentedResource<RefundData
   }
 
   /**
-   * Cancel a payment refund by ID
+   * For certain payment methods, like iDEAL, the underlying banking system will delay refunds until the next day. Until that time, refunds may be canceled manually in the [Mollie
+   * Dashboard](https://www.mollie.com/dashboard), or programmatically by using this endpoint.
+   *
+   * A Refund can only be canceled while its `status` field is either `queued` or `pending`. See the /reference/v2/refunds-api/get-refund for more information.
    *
    * @since 1.1.1
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/cancel-refund
    */
   public cancel(id: string, parameters: CancelParameters): Promise<true>;

--- a/src/resources/permissions/PermissionResource.ts
+++ b/src/resources/permissions/PermissionResource.ts
@@ -18,12 +18,10 @@ export default class PermissionsResource extends Resource<PermissionData, Permis
   }
 
   /**
-   * All API actions through OAuth are by default protected for privacy and/or money related reasons and therefore
-   * require specific permissions. These permissions can be requested by apps during the OAuth authorization flow. The
-   * Permissions resource allows the app to check whether an API action is (still) allowed by the authorization.
+   * All API actions through OAuth are by default protected for privacy and/or money related reasons and therefore require specific permissions. These permissions can be requested by apps during the
+   * OAuth authorization flow. The Permissions resource allows the app to check whether an API action is (still) allowed by the authorization.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission
    */
   public get(id: string): Promise<Permission>;
@@ -40,7 +38,6 @@ export default class PermissionsResource extends Resource<PermissionData, Permis
    * List all permissions available with the current app access token. The list is not paginated.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
    */
   public list(): Promise<List<Permission>>;

--- a/src/resources/profiles/ProfilesResource.ts
+++ b/src/resources/profiles/ProfilesResource.ts
@@ -20,11 +20,10 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   }
 
   /**
-   * In order to process payments, you need to create a website profile. A website profile can easily be created via
-   * the Dashboard manually. However, the Mollie API also allows automatic profile creation via the Profiles API.
+   * In order to process payments, you need to create a website profile. A website profile can easily be created via the Dashboard manually. However, the Mollie API also allows automatic profile
+   * creation via the Profiles API.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/profiles-api/create-profile
    */
   public create(parameters: CreateParameters): Promise<Profile>;
@@ -38,7 +37,6 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
    * Retrieve details of a profile, using the profile's identifier.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile
    */
   public get(id: string): Promise<Profile>;
@@ -52,11 +50,12 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   }
 
   /**
-   * Use this API if you are creating a plugin or SaaS application that allows users to enter a Mollie API key, and you
-   * want to give a confirmation of the website profile that will be used in your plugin or application.
+   * Use this API if you are creating a plugin or SaaS application that allows users to enter a Mollie API key, and you want to give a confirmation of the website profile that will be used in your
+   * plugin or application.
+   *
+   * This is similar to the Get current organization endpoint for OAuth.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile-me
    */
   public getCurrent(): Promise<Profile>;
@@ -69,8 +68,9 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   /**
    * Retrieve all profiles available on the account.
    *
-   * @since 3.2.0
+   * The results are paginated. See pagination for more information.
    *
+   * @since 3.2.0
    * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
    */
   public list(parameters?: ListParameters): Promise<List<Profile>>;
@@ -81,11 +81,10 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
   }
 
   /**
-   * A profile is required to process payments. A profile can easily be created and updated via the Dashboard manually.
-   * However, the Mollie API also allows automatic profile creation and updates via the Profiles API.
+   * A profile is required to process payments. A profile can easily be created and updated via the Dashboard manually. However, the Mollie API also allows automatic profile creation and updates via
+   * the Profiles API.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/profiles-api/update-profile
    */
   public update(id: string, parameters: UpdateParameters): Promise<Profile>;
@@ -102,7 +101,6 @@ export default class ProfilesResource extends Resource<ProfileData, Profile> {
    * This endpoint enables profile deletions, rendering the profile unavailable for further API calls and transactions.
    *
    * @since 3.2.0
-   *
    * @see https://docs.mollie.com/reference/v2/profiles-api/delete-profile
    */
   public delete(id: string): Promise<true>;

--- a/src/resources/profiles/methods/ProfileMethodsResource.ts
+++ b/src/resources/profiles/methods/ProfileMethodsResource.ts
@@ -1,3 +1,0 @@
-import Resource from '../../Resource';
-
-export default class ProfileMethodsResource extends Resource<ProfileData, Profile> {}

--- a/src/resources/refunds/RefundsResource.ts
+++ b/src/resources/refunds/RefundsResource.ts
@@ -18,27 +18,45 @@ export default class RefundsResource extends Resource<RefundData, Refund> {
   }
 
   /**
-   * List Refunds
+   * Retrieve Refunds.
+   *
+   * -   If the payment-specific endpoint is used, only Refunds for that specific Payment are returned.
+   * -   When using the top level endpoint `v2/refunds` with an API key, only refunds for the corresponding website profile and mode are returned.
+   * -   When using the top level endpoint with OAuth, you can specify the profile and mode with the `profileId` and `testmode` parameters respectively. If you omit `profileId`, you will get all
+   *     Refunds for the Organization.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
   public all: RefundsResource['list'] = this.list;
   /**
-   * List Refunds
+   * Retrieve Refunds.
+   *
+   * -   If the payment-specific endpoint is used, only Refunds for that specific Payment are returned.
+   * -   When using the top level endpoint `v2/refunds` with an API key, only refunds for the corresponding website profile and mode are returned.
+   * -   When using the top level endpoint with OAuth, you can specify the profile and mode with the `profileId` and `testmode` parameters respectively. If you omit `profileId`, you will get all
+   *     Refunds for the Organization.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
   public page: RefundsResource['list'] = this.list;
 
   /**
-   * List Refunds
+   * Retrieve Refunds.
+   *
+   * -   If the payment-specific endpoint is used, only Refunds for that specific Payment are returned.
+   * -   When using the top level endpoint `v2/refunds` with an API key, only refunds for the corresponding website profile and mode are returned.
+   * -   When using the top level endpoint with OAuth, you can specify the profile and mode with the `profileId` and `testmode` parameters respectively. If you omit `profileId`, you will get all
+   *     Refunds for the Organization.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
   public list(parameters?: ListParameters): Promise<List<Refund>>;

--- a/src/resources/refunds/orders/OrdersRefundsResource.ts
+++ b/src/resources/refunds/orders/OrdersRefundsResource.ts
@@ -20,27 +20,35 @@ export default class RefundsResource extends ParentedResource<RefundData, Refund
   }
 
   /**
-   * Get all order refunds
+   * Retrieve all order refunds.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
    */
   public all: RefundsResource['list'] = this.list;
   /**
-   * Get all order refunds
+   * Retrieve all order refunds.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
    */
   public page: RefundsResource['list'] = this.list;
 
   /**
-   * Create an order refund
+   * When using the Orders API, refunds should be made against the Order. When using *pay after delivery* payment methods such as *Klarna Pay later* and *Klarna Slice it*, this ensures that your
+   * customer will receive credit invoices with the correct product information on them and generally have a great experience.
+   *
+   * However, if you want to refund arbitrary amounts you can use the /reference/v2/refunds-api/create-refund for Pay later and Slice it.
+   *
+   * If an order line is still in the `authorized` status, it cannot be refunded. You should cancel it instead. Order lines that are `paid`, `shipping` or `completed` can be refunded.
+   *
+   * For more details on how refunds work, see /payments/refunds.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order-refund
    */
   public create(parameters: CreateParameters): Promise<Refund>;
@@ -56,10 +64,11 @@ export default class RefundsResource extends ParentedResource<RefundData, Refund
   }
 
   /**
-   * Get all order refunds
+   * Retrieve all order refunds.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   *
    * @see https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
    */
   public list(parameters: ListParameters): Promise<List<Refund>>;

--- a/src/resources/refunds/orders/parameters.ts
+++ b/src/resources/refunds/orders/parameters.ts
@@ -9,6 +9,11 @@ interface ContextParameters {
 
 export type CreateParameters = ContextParameters &
   Pick<RefundData, 'description'> & {
+    /**
+     * An array of objects containing the order line details you want to create a refund for. If you send an empty array, the entire order will be refunded.
+     *
+     * @see https://docs.mollie.com/reference/v2/orders-api/create-order-refund?path=lines#parameters
+     */
     lines: {
       /**
        * The API resource token of the order line, for example: `'odl_jp31jz'`.

--- a/src/resources/refunds/orders/parameters.ts
+++ b/src/resources/refunds/orders/parameters.ts
@@ -16,14 +16,17 @@ export type CreateParameters = ContextParameters &
      */
     lines: {
       /**
-       * The API resource token of the order line, for example: `'odl_jp31jz'`.
+       * The API resource token of the order line, for example: `odl_jp31jz`.
+       *
+       * @see https://docs.mollie.com/reference/v2/orders-api/create-order-refund?path=lines/id#parameters
        */
       id: string;
       /**
-       * The number of items that should be refunded for this order line. When this parameter is omitted, the whole order
-       * line will be refunded.
+       * The number of items that should be refunded for this order line. When this parameter is omitted, the whole order line will be refunded.
        *
        * Must be less than the number of items already refunded for this order line.
+       *
+       * @see https://docs.mollie.com/reference/v2/orders-api/create-order-refund?path=lines/quantity#parameters
        */
       quantity?: number;
       /**
@@ -31,15 +34,14 @@ export type CreateParameters = ContextParameters &
        *
        * The amount is required only if you are *partially* refunding an order line which has a non-zero `discountAmount`.
        *
-       * The amount you can refund depends on various properties of the order line and the create order refund request.
-       * The maximum that can be refunded is `unit price x quantity to ship`.
+       * The amount you can refund depends on various properties of the order line and the create order refund request. The maximum that can be refunded is `unit price x quantity to ship`.
        *
-       * The minimum amount depends on the discount applied to the line, the quantity already refunded or shipped, the
-       * amounts already refunded or shipped and the quantity you want to refund.
+       * The minimum amount depends on the discount applied to the line, the quantity already refunded or shipped, the amounts already refunded or shipped and the quantity you want to refund.
        *
-       * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the
-       * amount cannot be determined automatically. The error will contain the `extra.minimumAmount` and
-       * `extra.maximumAmount` properties that allow you pick the right amount.
+       * If you do not send an amount, Mollie will determine the amount automatically or respond with an error if the amount cannot be determined automatically. The error will contain the
+       * `extra.minimumAmount` and `extra.maximumAmount` properties that allow you pick the right amount.
+       *
+       * @see https://docs.mollie.com/reference/v2/orders-api/create-order-refund?path=lines/amount#parameters
        */
       amount?: Amount;
     }[];

--- a/src/resources/subscriptions/SubscriptionsResource.ts
+++ b/src/resources/subscriptions/SubscriptionsResource.ts
@@ -18,9 +18,11 @@ export default class SubscriptionsResource extends ParentedResource<Subscription
   }
 
   /**
-   * Retrieves all subscriptions, ordered from newest to oldest.
+   * Retrieve all subscriptions, ordered from newest to oldest. By using an API key all the subscriptions created with the current website profile will be returned. In the case of an OAuth Access
+   * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
    *
    * @since 3.2.0
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
    */
   public list(parameters?: ListParameters): Promise<List<Subscription>>;
   public list(parameters: ListParameters, callback: Callback<List<Subscription>>): void;

--- a/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
+++ b/src/resources/subscriptions/payments/SubscriptionsPaymentsResource.ts
@@ -23,7 +23,6 @@ export default class SubscriptionsPaymentsResource extends ParentedResource<Paym
    * Retrieve all payments of a specific subscriptions of a customer.
    *
    * @since 3.3.0
-   *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
    */
   public list(parameters: ListParameters): Promise<List<Payment>>;


### PR DESCRIPTION
I copied documentation from [docs.mollie.com](https://docs.mollie.com) into the source code using my new experimental tool [atsee](https://github.com/Pimm/atsee).

Before this pull request, this library had some of the documentation on docs.mollie.com copied into the source code by hand, while some methods/properties were "naked": lacking any documentation.

Naked methods/properties are unfortunate, as developers might have to take a trip out of their IDE to look something up. However, copying over documentation by hand has the risk of the copy in the source code becoming outdated. (Copying over things by hand is not being a particularly fun chore, either).

This might be a healthy compromise. The copied-over documentation should improve the user experience, while the automation of the copying process makes it easy to keep the source code in sync with docs.mollie.com.