### PR TITLE
Replace Node.js URL API for WHATWG URL API.

### DIFF
--- a/src/NetworkClient.ts
+++ b/src/NetworkClient.ts
@@ -34,7 +34,8 @@ const camelCase = (() => {
   };
 })();
 /**
- * Converts `{ id: 5 }` to `'?id=5'`.
+ * Returns a stringified version of the passed query to be used as the search portion of a URL. For example:
+ * `{ id: 5 }` is converted to `'?id=5'` (and `{}` is converted to `''`).
  */
 function stringifyQuery(input: Record<string, any>): string {
   const entries = getEntries(input);

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -11,7 +11,8 @@ import TransformingNetworkClient from '../TransformingNetworkClient';
  */
 function parseQueryInUrl(url: string) {
   const result: Record<string, string> = {};
-  return new URL(url).searchParams.forEach((value, key) => result[key] = value), result;
+  new URL(url).searchParams.forEach((value, key) => (result[key] = value));
+  return result;
 }
 export default class Resource<R, T extends R> {
   constructor(protected readonly networkClient: TransformingNetworkClient<R, T>) {}

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,8 +1,18 @@
-import { parse as parseUrl } from 'url';
 import List from '../data/list/List';
 import Maybe from '../types/Maybe';
 import TransformingNetworkClient from '../TransformingNetworkClient';
 
+/**
+ * Returns the parsed search parameters from the passed URL. For example: `'https://example.com?id=5'` is converted to
+ * `{ id: 5 }` (and `'https://example.com'` is converted to `{}`).
+ *
+ * If multiple parameters have the same key (`'https://example.com?id=5&id=6'`), exactly one of them will be
+ * represented in the returned object.
+ */
+function parseQueryInUrl(url: string) {
+  const result: Record<string, string> = {};
+  return new URL(url).searchParams.forEach((value, key) => result[key] = value), result;
+}
 export default class Resource<R, T extends R> {
   constructor(protected readonly networkClient: TransformingNetworkClient<R, T>) {}
   /**
@@ -13,22 +23,22 @@ export default class Resource<R, T extends R> {
     let nextPage: Maybe<() => Promise<List<T>>>;
     let nextPageCursor: Maybe<string>;
     if (links.next != null) {
-      const { query } = parseUrl(links.next.href, true);
+      const query = parseQueryInUrl(links.next.href);
       nextPage = list.bind(this, {
         ...selfParameters,
         ...query,
       });
-      nextPageCursor = query.from as string;
+      nextPageCursor = query.from;
     }
     let previousPage: Maybe<() => Promise<List<T>>>;
     let previousPageCursor: Maybe<string>;
     if (links.previous != null) {
-      const { query } = parseUrl(links.previous.href, true);
+      const query = parseQueryInUrl(links.previous.href);
       previousPage = list.bind(this, {
         ...selfParameters,
         ...query,
       });
-      previousPageCursor = query.from as string;
+      previousPageCursor = query.from;
     }
     return Object.assign(input, {
       nextPage,


### PR DESCRIPTION
The [Node.js URL API](https://nodejs.org/api/url.html#url_legacy_urlobject) was deprecated in Node.js 11, while the [WHATWG counterpart](https://url.spec.whatwg.org/) is supported since Node.js 7 and 6.13.

Our lowest supported Node.js version is currently 6.14.