### PR TITLE
Update documentation from docs.mollie.com.

### DIFF
--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -35,7 +35,6 @@ export enum PaymentMethod {
   giftcard = 'giftcard',
   giropay = 'giropay',
   ideal = 'ideal',
-  inghomepay = 'inghomepay',
   kbc = 'kbc',
   klarnapaylater = 'klarnapaylater',
   klarnasliceit = 'klarnasliceit',
@@ -47,6 +46,7 @@ export enum PaymentMethod {
 
 export enum HistoricPaymentMethod {
   bitcoin = 'bitcoin',
+  inghomepay = 'inghomepay',
 }
 
 export enum ApiMode {

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -115,8 +115,8 @@ export interface PaymentData extends Model<'payment'> {
    *
    * If the payment is only partially paid with a gift card, the method remains `giftcard`.
    *
-   * Possible values: `null` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `klarnapaylater` `klarnasliceit` `mybank` `paypal`
-   * `paysafecard` `przelewy24` `sofort`
+   * Possible values: `null` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `klarnapaylater` `klarnasliceit` `mybank` `paypal` `paysafecard`
+   * `przelewy24` `sofort`
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=method#response
    */
@@ -558,23 +558,8 @@ export interface IdealDetails {
 }
 
 export interface IngHomePayDetails {
-  /**
-   * Only available one banking day after the payment has been completed – The consumer's name.
-   *
-   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerName#ing-homepay
-   */
   consumerName: string;
-  /**
-   * Only available one banking day after the payment has been completed – The consumer's IBAN.
-   *
-   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerAccount#ing-homepay
-   */
   consumerAccount: string;
-  /**
-   * Only available one banking day after the payment has been completed – `BBRUBEBB`.
-   *
-   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#ing-homepay
-   */
   consumerBic: string;
 }
 

--- a/src/resources/customers/payments/parameters.ts
+++ b/src/resources/customers/payments/parameters.ts
@@ -14,10 +14,9 @@ export type CreateParameters = ContextParameters &
      * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
      *
      * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
-     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius']`.
      *
-     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `mybank` `paypal` `paysafecard` `przelewy24`
-     * `sofort`
+     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `mybank` `paypal` `paysafecard` `przelewy24` `sofort`
      *
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=method#parameters
      */

--- a/src/resources/orders/parameters.ts
+++ b/src/resources/orders/parameters.ts
@@ -53,10 +53,10 @@ export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billi
    * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
    *
    * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
-   * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+   * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius']`.
    *
-   * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `klarnapaylater` `klarnasliceit` `mybank`
-   * `paypal` `paysafecard` `przelewy24` `sofort` `voucher`
+   * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `klarnapaylater` `klarnasliceit` `mybank` `paypal`
+   * `paysafecard` `przelewy24` `sofort` `voucher`
    *
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=method#parameters
    */

--- a/src/resources/payments/orders/parameters.ts
+++ b/src/resources/payments/orders/parameters.ts
@@ -13,10 +13,10 @@ export type CreateParameters = ContextParameters &
      * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
      *
      * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
-     * this functionality to only show payment methods from a specific country to your customer `["bancontact", "belfius", "inghomepay"]`.
+     * this functionality to only show payment methods from a specific country to your customer `["bancontact", "belfius"]`.
      *
-     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `klarnapaylater` `klarnasliceit` `paypal`
-     * `paysafecard` `przelewy24` `sofort`
+     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `klarnapaylater` `klarnasliceit` `paypal` `paysafecard`
+     * `przelewy24` `sofort`
      *
      * @see https://docs.mollie.com/reference/v2/orders-api/create-order-payment?path=method#parameters
      */

--- a/src/resources/payments/parameters.ts
+++ b/src/resources/payments/parameters.ts
@@ -11,10 +11,9 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
      *
      * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
-     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius', 'inghomepay']`.
+     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius']`.
      *
-     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `inghomepay` `kbc` `mybank` `paypal` `paysafecard` `przelewy24`
-     * `sofort`
+     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `mybank` `paypal` `paysafecard` `przelewy24` `sofort`
      *
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=method#parameters
      */
@@ -110,13 +109,13 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
     /**
      * Adding an application fee allows you to charge the merchant a small sum for the payment and transfer this to your own account.
      *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee#access-token-parameters
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee#mollie-connect-parameters
      */
     applicationFee?: {
       /**
        * The amount in that the app wants to charge, e.g. `{"currency":"EUR", "value":"10.00"}` if the app would want to charge €10.00.
        *
-       * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee/amount#access-token-parameters
+       * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee/amount#mollie-connect-parameters
        */
       amount: Amount;
       /**
@@ -124,7 +123,7 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
        *
        * The maximum length is 255 characters.
        *
-       * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee/description#access-token-parameters
+       * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applicationFee/description#mollie-connect-parameters
        */
       description: string;
     };


### PR DESCRIPTION
This reflects [the discontinuation of ING Home'Pay](https://docs.mollie.com/changelog/v2/changelog#february-2021) in the library.