### PR TITLE
Add Paypal Support

### DIFF
--- a/src/resources/customers/mandates/parameters.ts
+++ b/src/resources/customers/mandates/parameters.ts
@@ -31,6 +31,14 @@ export type CreateParameters = ContextParameters &
      *
      * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
      */
+
+    /**
+     * The consumer’s email address. Required for paypal mandates
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
+     */
+    consumerEmail?: string;
+
     signatureDate?: string;
     /**
      * A custom mandate reference. Use an unique `mandateReference` as some banks decline a Direct Debit payment if the `mandateReference` is not unique.
@@ -38,6 +46,14 @@ export type CreateParameters = ContextParameters &
      * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=mandateReference#parameters
      */
     mandateReference?: string;
+
+    /**
+     * The billing agreement ID given by PayPal. For example: "B-12A34567B8901234CD".
+     * Required for paypal mandates
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
+     */
+    paypalBillingAgreementId?: string;
   };
 
 export type GetParameters = ContextParameters;

--- a/src/resources/customers/mandates/parameters.ts
+++ b/src/resources/customers/mandates/parameters.ts
@@ -27,18 +27,16 @@ export type CreateParameters = ContextParameters &
      */
     consumerBic?: string;
     /**
+     * The consumer’s email address. Required for paypal mandates
+     *
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=consumerEmail#parameters
+     */
+    consumerEmail?: string;
+    /**
      * The date when the mandate was signed in `YYYY-MM-DD` format.
      *
      * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
      */
-
-    /**
-     * The consumer’s email address. Required for paypal mandates
-     *
-     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
-     */
-    consumerEmail?: string;
-
     signatureDate?: string;
     /**
      * A custom mandate reference. Use an unique `mandateReference` as some banks decline a Direct Debit payment if the `mandateReference` is not unique.
@@ -46,12 +44,11 @@ export type CreateParameters = ContextParameters &
      * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=mandateReference#parameters
      */
     mandateReference?: string;
-
     /**
      * The billing agreement ID given by PayPal. For example: "B-12A34567B8901234CD".
      * Required for paypal mandates
      *
-     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=signatureDate#parameters
+     * @see https://docs.mollie.com/reference/v2/mandates-api/create-mandate?path=paypalBillingAgreementId#parameters
      */
     paypalBillingAgreementId?: string;
   };


### PR DESCRIPTION
Updated the CreateParameters for mandates to support PayPal option.
Like here: 
https://docs.mollie.com/reference/v2/mandates-api/create-mandate