### PR TITLE
Make message of ApiError instances enumerable

### DIFF
--- a/src/errors/ApiError.ts
+++ b/src/errors/ApiError.ts
@@ -6,7 +6,10 @@ import Maybe from '../types/Maybe';
 export default class ApiError extends Error {
   public constructor(message: string, protected title?: string, protected status?: number, protected field?: string, protected links?: MollieApiErrorLinks) {
     super(message);
+    // Set the name to ApiError.
     this.name = 'ApiError';
+    // Ensure the message is enumerable, making it more likely to survive serialisation.
+    Object.defineProperty(this, 'message', { enumerable: true });
   }
 
   /**

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -2,7 +2,7 @@ import { PaymentCreateParams } from '../..';
 import wireMockClient from '../wireMockClient';
 
 test('errorHandling', async () => {
-  expect.assertions(5);
+  expect.assertions(6);
 
   const { adapter, client } = wireMockClient();
 
@@ -18,6 +18,8 @@ test('errorHandling', async () => {
   } catch (error) {
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe('No customer exists with token cst_chinchilla.');
+    // Ensure the message property survives conversion to and from JSON.
+    expect(JSON.parse(JSON.stringify(error)).message).toBe('No customer exists with token cst_chinchilla.');
   }
 
   adapter.onPost('/payments').reply(422, {


### PR DESCRIPTION
This makes it more likely that the message survives serialisation. (`message` is not enumerable by default<sup>[[source]](https://tc39.es/ecma262/#sec-error-message)</sup>.)

Given that this client is designed for Node.js, consumers might convert errors to JSON. This way, the message ends up in the resulting JSON document.