### PR TITLE
Isolate buildFromEntries

### DIFF
--- a/src/plumbing/buildFromEntries.ts
+++ b/src/plumbing/buildFromEntries.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns an object generated from the passed a list of key-value pairs.
+ *
+ * If support for Node.js < 12.0.0 is ever dropped, this function can be removed in favour of `Object.fromEntries`.
+ */
+export default ((): (<T>(input: Iterable<readonly [string, T]>) => Record<string, T>) => {
+  if (Object.fromEntries != undefined) {
+    return Object.fromEntries;
+  }
+  return function buildFromEntries<T>(input: Iterable<readonly [string, T]>) {
+    const result: Record<string, T> = {};
+    Array.from(input, ([key, value]) => (result[key] = value));
+    return result;
+  };
+})();

--- a/src/plumbing/getEntries.ts
+++ b/src/plumbing/getEntries.ts
@@ -8,6 +8,6 @@ export default ((): (<T>(input: Record<string, T>) => [string, T][]) => {
     return Object.entries;
   }
   return function getEntries<T>(input: Record<string, T>) {
-    return Object.keys(input).map((key: string): [string, T] => [key, input[key]]);
+    return Object.keys(input).map(key => [key, input[key]]);
   };
 })();

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,6 +1,7 @@
 import List from '../data/list/List';
 import Maybe from '../types/Maybe';
 import TransformingNetworkClient from '../TransformingNetworkClient';
+import buildFromEntries from '../plumbing/buildFromEntries';
 
 /**
  * Returns the parsed search parameters from the passed URL. For example: `'https://example.com?id=5'` is converted to
@@ -10,9 +11,7 @@ import TransformingNetworkClient from '../TransformingNetworkClient';
  * represented in the returned object.
  */
 function parseQueryInUrl(url: string) {
-  const result: Record<string, string> = {};
-  new URL(url).searchParams.forEach((value, key) => (result[key] = value));
-  return result;
+  return buildFromEntries(new URL(url).searchParams);
 }
 export default class Resource<R, T extends R> {
   constructor(protected readonly networkClient: TransformingNetworkClient<R, T>) {}


### PR DESCRIPTION
This makes it clearer why we're not using `Object.fromEntries` directly, and allows us to use `Object.fromEntries` under the hood when available.