### PR TITLE
Deprecate endpoint aliases

### DIFF
--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -19,18 +19,20 @@ export default class ChargebacksBinder extends InnerBinder<ChargebackData, Charg
    * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public all: ChargebacksBinder['list'] = this.list;
+  public all: ChargebacksBinder['page'] = this.page;
   /**
    * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public page: ChargebacksBinder['list'] = this.list;
+  public list: ChargebacksBinder['page'] = this.page;
 
   /**
    * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
@@ -40,10 +42,10 @@ export default class ChargebacksBinder extends InnerBinder<ChargebackData, Charg
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public list(parameters?: ListParameters): Promise<List<Chargeback>>;
-  public list(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<ChargebackData, Chargeback>(pathSegment, 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Chargeback>>;
+  public page(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<ChargebackData, Chargeback>(pathSegment, 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -21,22 +21,25 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
-  public all: CustomersBinder['list'] = this.list;
+  public all: CustomersBinder['page'] = this.page;
   /**
    * Retrieve all customers created.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
-  public page: CustomersBinder['list'] = this.list;
+  public list: CustomersBinder['page'] = this.page;
   /**
    * Delete a customer. All mandates and subscriptions created for this customer will be canceled as well.
    *
    * @since 2.0.0
+   * @deprecated Use `delete` instead.
    * @see https://docs.mollie.com/reference/v2/customers-api/delete-customer
    */
   public cancel: CustomersBinder['delete'] = this.delete;
@@ -79,11 +82,11 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
-  public list(parameters?: ListParameters): Promise<List<Customer>>;
-  public list(parameters: ListParameters, callback: Callback<List<Customer>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<CustomerData, Customer>(pathSegment, 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Customer>>;
+  public page(parameters: ListParameters, callback: Callback<List<Customer>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<CustomerData, Customer>(pathSegment, 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -24,22 +24,25 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
    * The results are paginated. See pagination for more information.
    *
    * @since 1.2.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
-  public all: CustomerMandatesBinder['list'] = this.list;
+  public all: CustomerMandatesBinder['page'] = this.page;
   /**
    * Retrieve all mandates for the given `customerId`, ordered from newest to oldest.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
-  public page: CustomerMandatesBinder['list'] = this.list;
+  public list: CustomerMandatesBinder['page'] = this.page;
   /**
    * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
    *
    * @since 1.3.2
+   * @deprecated Use `revoke` instead.
    * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
    */
   public cancel: CustomerMandatesBinder['revoke'] = this.revoke;
@@ -47,6 +50,7 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
    * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
    *
    * @since 2.0.0
+   * @deprecated Use `revoke` instead.
    * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
    */
   public delete: CustomerMandatesBinder['revoke'] = this.revoke;
@@ -102,17 +106,17 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
-  public list(parameters: ListParameters): Promise<List<Mandate>>;
-  public list(parameters: ListParameters, callback: Callback<List<Mandate>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Mandate>>;
+  public page(parameters: ListParameters, callback: Callback<List<Mandate>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
     const { customerId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<MandateData, Mandate>(getPathSegments(customerId), 'mandates', query).then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
+    return this.networkClient.list<MandateData, Mandate>(getPathSegments(customerId), 'mandates', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 
   /**

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -22,16 +22,18 @@ export default class CustomerPaymentsBinder extends InnerBinder<PaymentData, Pay
    * Retrieve all Payments linked to the Customer.
    *
    * @since 1.1.1
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
-  public all: CustomerPaymentsBinder['list'] = this.list;
+  public all: CustomerPaymentsBinder['page'] = this.page;
   /**
    * Retrieve all Payments linked to the Customer.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
-  public page: CustomerPaymentsBinder['list'] = this.list;
+  public list: CustomerPaymentsBinder['page'] = this.page;
 
   /**
    * Creates a payment for the customer.
@@ -64,16 +66,16 @@ export default class CustomerPaymentsBinder extends InnerBinder<PaymentData, Pay
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
-  public list(parameters: ListParameters): Promise<List<Payment>>;
-  public list(parameters: ListParameters, callback: Callback<List<Payment>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
     }
     const { customerId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<PaymentData, Payment>(getPathSegments(customerId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
+    return this.networkClient.list<PaymentData, Payment>(getPathSegments(customerId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 }

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -22,6 +22,7 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
    * A subscription can be canceled any time by calling `DELETE` on the resource endpoint.
    *
    * @since 1.3.2
+   * @deprecated Use `cancel` instead.
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
    */
   public delete: CustomerSubscriptionsBinder['cancel'] = this.cancel;
@@ -29,16 +30,18 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
    * Retrieve all subscriptions of a customer.
    *
    * @since 1.3.2
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
-  public all: CustomerSubscriptionsBinder['list'] = this.list;
+  public all: CustomerSubscriptionsBinder['page'] = this.page;
   /**
    * Retrieve all subscriptions of a customer.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
-  public page: CustomerSubscriptionsBinder['list'] = this.list;
+  public list: CustomerSubscriptionsBinder['page'] = this.page;
 
   /**
    * With subscriptions, you can schedule recurring payments to take place at regular intervals.
@@ -96,10 +99,10 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
-  public list(parameters: ListParameters): Promise<List<Subscription>>;
-  public list(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Subscription>>;
+  public page(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const customerId = this.getParentId((parameters ?? {}).customerId);
     if (!checkId(customerId, 'customer')) {
@@ -108,7 +111,7 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
     const { customerId: _, ...query } = parameters ?? {};
     return this.networkClient
       .list<SubscriptionData, Subscription>(getPathSegments(customerId), 'subscriptions', query)
-      .then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
+      .then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 
   /**

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -28,9 +28,10 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * how they can be used for recurring payments.
    *
    * @since 2.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public all: MethodsBinder['list'] = this.list;
+  public all: MethodsBinder['page'] = this.page;
   /**
    * Retrieve all enabled payment methods. The results are not paginated.
    *
@@ -45,9 +46,10 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * how they can be used for recurring payments.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public page: MethodsBinder['list'] = this.list;
+  public list: MethodsBinder['page'] = this.page;
 
   /**
    * Retrieve a single method by its ID. Note that if a method is not available on the website profile a status `404 Not found` is returned. When the method is not enabled, a status `403 Forbidden` is
@@ -83,10 +85,10 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public list(parameters?: ListParameters): Promise<List<Method>>;
-  public list(parameters: ListParameters, callback: Callback<List<Method>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<MethodData, Method>(pathSegment, 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Method>>;
+  public page(parameters: ListParameters, callback: Callback<List<Method>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<MethodData, Method>(pathSegment, 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -50,6 +50,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    * lines are not shipped yet. In this case, the order cannot be canceled. You should create refunds for these order lines instead.
    *
    * @since 3.0.0
+   * @deprecated Use `cancel` instead.
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
    */
   public delete: OrdersBinder['cancel'] = this.cancel;
@@ -59,18 +60,20 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
-  public all: OrdersBinder['list'] = this.list;
+  public all: OrdersBinder['page'] = this.page;
   /**
    * Retrieve all orders.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
-  public page: OrdersBinder['list'] = this.list;
+  public list: OrdersBinder['page'] = this.page;
 
   /**
    * Using the Orders API is the preferred approach when integrating the Mollie API into e-commerce applications such as webshops. If you want to use *pay after delivery* methods such as *Klarna Pay
@@ -119,11 +122,11 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
-  public list(parameters?: ListParameters): Promise<List<Order>>;
-  public list(parameters: ListParameters, callback: Callback<List<Order>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<OrderData, Order>(pathSegment, 'orders', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Order>>;
+  public page(parameters: ListParameters, callback: Callback<List<Order>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<OrderData, Order>(pathSegment, 'orders', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/orders/orderlines/OrderLinesBinder.ts
+++ b/src/binders/orders/orderlines/OrderLinesBinder.ts
@@ -34,6 +34,7 @@ export default class OrderLinesBinder extends InnerBinder<OrderData, Order> {
    * For more information about the status transitions please check our order status changes guide.
    *
    * @since 3.0.0
+   * @deprecated Use `cancel` instead.
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
    */
   public delete: OrderLinesBinder['cancel'] = this.cancel;

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -21,16 +21,18 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
    * Retrieve all shipments for an order.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
-  public all: OrderShipmentsBinder['list'] = this.list;
+  public all: OrderShipmentsBinder['page'] = this.page;
   /**
    * Retrieve all shipments for an order.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
-  public page: OrderShipmentsBinder['list'] = this.list;
+  public list: OrderShipmentsBinder['page'] = this.page;
 
   /**
    * The **Create Shipment API** is used to ship order lines created by the /reference/v2/orders-api/create-order.
@@ -77,6 +79,25 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
   }
 
   /**
+   * Retrieve all shipments for an order.
+   *
+   * @since 3.0.0
+   * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
+   */
+  public page(parameters: ListParameters): Promise<List<Shipment>>;
+  public page(parameters: ListParameters, callback: Callback<List<Shipment>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
+    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
+    const orderId = this.getParentId((parameters ?? {}).orderId);
+    if (!checkId(orderId, 'order')) {
+      throw new ApiError('The order id is invalid');
+    }
+    const { orderId: _, ...query } = parameters ?? {};
+    return this.networkClient.list<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
    * This endpoint can be used to update the tracking information of a shipment.
    *
    * @since 3.0.0
@@ -95,24 +116,5 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
     }
     const { orderId: _, ...data } = parameters;
     return this.networkClient.patch<ShipmentData, Shipment>(`${getPathSegments(orderId)}/${id}`, data);
-  }
-
-  /**
-   * Retrieve all shipments for an order.
-   *
-   * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
-   */
-  public list(parameters: ListParameters): Promise<List<Shipment>>;
-  public list(parameters: ListParameters, callback: Callback<List<Shipment>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
-    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
-    const orderId = this.getParentId((parameters ?? {}).orderId);
-    if (!checkId(orderId, 'order')) {
-      throw new ApiError('The order id is invalid');
-    }
-    const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -22,18 +22,20 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
    * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
-  public all: PaymentsBinder['list'] = this.list;
+  public all: PaymentsBinder['page'] = this.page;
   /**
    * Retrieve all payments created with the current website profile, ordered from newest to oldest.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
-  public page: PaymentsBinder['list'] = this.list;
+  public list: PaymentsBinder['page'] = this.page;
   /**
    * Some payment methods can be canceled by the merchant for a certain amount of time, usually until the next business day. Or as long as the payment status is `open`. Payments may be canceled
    * manually from the Mollie Dashboard, or programmatically by using this endpoint.
@@ -41,6 +43,7 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
    * The `isCancelable` property on the Payment object will indicate if the payment can be canceled.
    *
    * @since 2.0.0
+   * @deprecated Use `cancel` instead.
    * @see https://docs.mollie.com/reference/v2/payments-api/cancel-payment
    */
   public delete: PaymentsBinder['cancel'] = this.cancel;
@@ -88,11 +91,11 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
-  public list(parameters?: ListParameters): Promise<List<Payment>>;
-  public list(parameters: ListParameters, callback: Callback<List<Payment>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<PaymentData, Payment>(pathSegment, 'payments', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<PaymentData, Payment>(pathSegment, 'payments', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -24,18 +24,20 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
    * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
    *
    * @since 1.1.1
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
-  public all: PaymentCapturesBinder['list'] = this.list;
+  public all: PaymentCapturesBinder['page'] = this.page;
   /**
    * Retrieve all captures for a certain payment.
    *
    * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
-  public page: PaymentCapturesBinder['list'] = this.list;
+  public list: PaymentCapturesBinder['page'] = this.page;
 
   /**
    * Retrieve a single capture by its ID. Note the original payment's ID is needed as well.
@@ -69,16 +71,16 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
-  public list(parameters: ListParameters): Promise<List<Capture>>;
-  public list(parameters: ListParameters, callback: Callback<List<Capture>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Capture>>;
+  public page(parameters: ListParameters, callback: Callback<List<Capture>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.networkClient.list<CaptureData, Capture>(getPathSegments(paymentId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list<CaptureData, Capture>(getPathSegments(paymentId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -23,18 +23,20 @@ export default class PaymentChargebacksBinder extends InnerBinder<ChargebackData
    * The results are paginated. See pagination for more information.
    *
    * @since 1.1.1
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public all: PaymentChargebacksBinder['list'] = this.list;
+  public all: PaymentChargebacksBinder['page'] = this.page;
   /**
    * Retrieve all received chargebacks. If the payment-specific endpoint is used, only chargebacks for that specific payment are returned.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public page: PaymentChargebacksBinder['list'] = this.list;
+  public list: PaymentChargebacksBinder['page'] = this.page;
 
   /**
    * Retrieve a single chargeback by its ID. Note the original payment's ID is needed as well.
@@ -68,16 +70,16 @@ export default class PaymentChargebacksBinder extends InnerBinder<ChargebackData
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public list(parameters: ListParameters): Promise<List<Chargeback>>;
-  public list(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Chargeback>>;
+  public page(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.networkClient.list<ChargebackData, Chargeback>(getPathSegments(paymentId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list<ChargebackData, Chargeback>(getPathSegments(paymentId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -29,9 +29,10 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
    * The results are paginated. See pagination for more information.
    *
    * @since 1.1.1
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public all: PaymentRefundsBinder['list'] = this.list;
+  public all: PaymentRefundsBinder['page'] = this.page;
   /**
    * Retrieve Refunds.
    *
@@ -43,15 +44,17 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public page: PaymentRefundsBinder['list'] = this.list;
+  public list: PaymentRefundsBinder['page'] = this.page;
   /**
    * For certain payment methods, like iDEAL, the underlying banking system will delay refunds until the next day. Until that time, refunds may be canceled manually in the [Mollie
    * Dashboard](https://www.mollie.com/dashboard), or programmatically by using this endpoint.
    *
    * A Refund can only be canceled while its `status` field is either `queued` or `pending`. See the /reference/v2/refunds-api/get-refund for more information.
    *
+   * @deprecated Use `cancel` instead.
    * @see https://docs.mollie.com/reference/v2/refunds-api/cancel-refund
    */
   public delete: PaymentRefundsBinder['cancel'] = this.cancel;
@@ -111,17 +114,17 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public list(parameters: ListParameters): Promise<List<Refund>>;
-  public list(parameters: ListParameters, callback: Callback<List<Refund>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const paymentId = this.getParentId((parameters ?? {}).paymentId);
     if (!checkId(paymentId, 'payment')) {
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.networkClient.list<RefundData, Refund>(getPathSegments(paymentId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list<RefundData, Refund>(getPathSegments(paymentId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/permissions/PermissionBinder.ts
+++ b/src/binders/permissions/PermissionBinder.ts
@@ -15,6 +15,15 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
   }
 
   /**
+   * List all permissions available with the current app access token. The list is not paginated.
+   *
+   * @since 3.2.0
+   * @deprecated Use `page` instead.
+   * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
+   */
+  public list: PermissionsBinder['page'] = this.page;
+
+  /**
    * All API actions through OAuth are by default protected for privacy and/or money related reasons and therefore require specific permissions. These permissions can be requested by apps during the
    * OAuth authorization flow. The Permissions resource allows the app to check whether an API action is (still) allowed by the authorization.
    *
@@ -34,13 +43,13 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
   /**
    * List all permissions available with the current app access token. The list is not paginated.
    *
-   * @since 3.2.0
+   * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
    */
-  public list(): Promise<List<Permission>>;
-  public list(callback: Callback<List<Permission>>): void;
-  public list() {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<PermissionData, Permission>(pathSegment, 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.list, undefined));
+  public page(): Promise<List<Permission>>;
+  public page(callback: Callback<List<Permission>>): void;
+  public page() {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<PermissionData, Permission>(pathSegment, 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.page, undefined));
   }
 }

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -17,6 +17,17 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
   }
 
   /**
+   * Retrieve all profiles available on the account.
+   *
+   * The results are paginated. See pagination for more information.
+   *
+   * @since 3.2.0
+   * @deprecated Use `page` instead.
+   * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
+   */
+  public list: ProfilesBinder['page'] = this.page;
+
+  /**
    * In order to process payments, you need to create a website profile. A website profile can easily be created via the Dashboard manually. However, the Mollie API also allows automatic profile
    * creation via the Profiles API.
    *
@@ -67,14 +78,14 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    *
    * The results are paginated. See pagination for more information.
    *
-   * @since 3.2.0
+   * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
    */
-  public list(parameters?: ListParameters): Promise<List<Profile>>;
-  public list(parameters: ListParameters, callback: Callback<List<Profile>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<ProfileData, Profile>(pathSegment, 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Profile>>;
+  public page(parameters: ListParameters, callback: Callback<List<Profile>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<ProfileData, Profile>(pathSegment, 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -25,9 +25,10 @@ export default class RefundsBinder extends Binder<RefundData, Refund> {
    * The results are paginated. See pagination for more information.
    *
    * @since 2.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public all: RefundsBinder['list'] = this.list;
+  public all: RefundsBinder['page'] = this.page;
   /**
    * Retrieve Refunds.
    *
@@ -39,9 +40,10 @@ export default class RefundsBinder extends Binder<RefundData, Refund> {
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public page: RefundsBinder['list'] = this.list;
+  public list: RefundsBinder['page'] = this.page;
 
   /**
    * Retrieve Refunds.
@@ -56,10 +58,10 @@ export default class RefundsBinder extends Binder<RefundData, Refund> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public list(parameters?: ListParameters): Promise<List<Refund>>;
-  public list(parameters: ListParameters, callback: Callback<List<Refund>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<RefundData, Refund>(pathSegment, 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public page(parameters?: ListParameters): Promise<List<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<RefundData, Refund>(pathSegment, 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -24,18 +24,20 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
    */
-  public all: OrderRefundsBinder['list'] = this.list;
+  public all: OrderRefundsBinder['page'] = this.page;
   /**
    * Retrieve all order refunds.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
    */
-  public page: OrderRefundsBinder['list'] = this.list;
+  public list: OrderRefundsBinder['page'] = this.page;
 
   /**
    * When using the Orders API, refunds should be made against the Order. When using *pay after delivery* payment methods such as *Klarna Pay later* and *Klarna Slice it*, this ensures that your
@@ -70,16 +72,16 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
    */
-  public list(parameters: ListParameters): Promise<List<Refund>>;
-  public list(parameters: ListParameters, callback: Callback<List<Refund>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public page(parameters: ListParameters): Promise<List<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const orderId = this.getParentId((parameters ?? {}).orderId);
     if (!checkId(orderId, 'order')) {
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<RefundData, Refund>(getPathSegments(orderId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.list, parameters ?? {}));
+    return this.networkClient.list<RefundData, Refund>(getPathSegments(orderId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 }

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -19,12 +19,22 @@ export default class SubscriptionsBinder extends InnerBinder<SubscriptionData, S
    * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
    *
    * @since 3.2.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
    */
-  public list(parameters?: ListParameters): Promise<List<Subscription>>;
-  public list(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
-  public list(parameters: ListParameters = {}) {
-    if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<SubscriptionData, Subscription>(pathSegment, 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+  public list: SubscriptionsBinder['page'] = this.page;
+
+  /**
+   * Retrieve all subscriptions, ordered from newest to oldest. By using an API key all the subscriptions created with the current website profile will be returned. In the case of an OAuth Access
+   * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
+   *
+   * @since 3.2.0 (as `list`)
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
+   */
+  public page(parameters?: ListParameters): Promise<List<Subscription>>;
+  public page(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<SubscriptionData, Subscription>(pathSegment, 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -22,12 +22,21 @@ export default class SubscriptionPaymentsBinder extends InnerBinder<PaymentData,
    * Retrieve all payments of a specific subscriptions of a customer.
    *
    * @since 3.3.0
+   * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
    */
-  public list(parameters: ListParameters): Promise<List<Payment>>;
-  public list(parameters: ListParameters, callback: Callback<List<Payment>>): void;
-  public list(parameters: ListParameters) {
-    if (renege(this, this.list, ...arguments)) return;
+  public list: SubscriptionPaymentsBinder['page'] = this.page;
+
+  /**
+   * Retrieve all payments of a specific subscriptions of a customer.
+   *
+   * @since 3.3.0 (as `list`)
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
+   */
+  public page(parameters: ListParameters): Promise<List<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
     const customerId = this.getParentId(parameters.customerId);
     if (!checkId(customerId, 'customer')) {
       throw new ApiError('The customer id is invalid');
@@ -37,6 +46,6 @@ export default class SubscriptionPaymentsBinder extends InnerBinder<PaymentData,
       throw new ApiError('The subscription id is invalid');
     }
     const { customerId: _, subscriptionId: __, ...query } = parameters;
-    return this.networkClient.list<PaymentData, Payment>(getPathSegments(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list<PaymentData, Payment>(getPathSegments(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 }


### PR DESCRIPTION
Deprecated endpoint aliases such as:
* `client.payments.all` (which is synonymous with `client.payments.page`)
* `client.payments.delete` (which is synonymous with `client.payments.cancel`)

### Con

This is another breaking change.

### Pros

The pros of #233 apply here as well:
1. Aliases are a potential cause for confusion.
2. A narrower API promotes discoverability.
3. This removal promotes consistency in code which uses this library.

### `page` vs `all` or `list`

I've chosen `page` over `all` or `list`. I don't like `all`, because the name is misleading: endpoints apply pagination, therefore `all` sometimes returns "some" instead of "all". `list` is a decent name; but `page` has the advantages of being consistent with the PHP client, and making it even more obvious that there is pagination in effect.