### PR TITLE
ApiError improvement + fix

### DIFF
--- a/src/NetworkClient.ts
+++ b/src/NetworkClient.ts
@@ -95,10 +95,10 @@ const throwApiError = (() => {
     return typeof value == 'object' && value != null && name in value;
   }
   return function throwApiError(cause: unknown) {
-    if (findProperty(cause, 'response')) {
+    if (findProperty(cause, 'response') && cause.response != undefined) {
       throw ApiError.createFromResponse(cause.response as AxiosResponse<any>);
     }
-    throw new ApiError(findProperty(cause, 'message') ? (cause.message as string) : 'An unknown error has occurred');
+    throw new ApiError(findProperty(cause, 'message') ? String(cause.message) : 'An unknown error has occurred');
   };
 })();
 

--- a/src/errors/ApiError.ts
+++ b/src/errors/ApiError.ts
@@ -99,7 +99,7 @@ export default class ApiError extends Error {
     return new ApiError(
       get(response, 'data.detail', 'Received an error without a message'),
       get(response, 'data.title'),
-      get(response, 'data.statusCode'),
+      get(response, 'data.status'),
       get(response, 'data.field'),
       cloneDeep(get(response, 'data._links')),
     );


### PR DESCRIPTION
1. If an error is thrown where the cause has a `response` property ‒ probably because it's an `AxiosError` ‒ the thrown error only uses that `response` property _if it is not `undefined`_. This should reduce the unhelpful `'error without a message'` errors by using the `message` property instead.
2. Fixed a refactoring mistake I made in #233. (Luckily, I can put some of the blame on my IDE.)