### PR TITLE
Fix URL import for Node.js < 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "typescript": "^4.3.5"
   },
   "jest": {
+    "testEnvironment": "node",
     "moduleDirectories": [
       "node_modules",
       "dist",

--- a/src/binders/Binder.ts
+++ b/src/binders/Binder.ts
@@ -1,6 +1,8 @@
+// If support for Node.js < 10.0.0 is ever dropped, this import can be removed.
+import { URL } from 'url';
+
 import List from '../data/list/List';
 import buildFromEntries from '../plumbing/buildFromEntries';
-import TransformingNetworkClient from '../TransformingNetworkClient';
 import Maybe from '../types/Maybe';
 
 /**


### PR DESCRIPTION
Fixes a bug I introduced in #196.

That PR started using [the WHATWG `URL`](https://nodejs.org/api/url.html#the-whatwg-url-api). That API has been available since Node.js 7 and 6.13. However, it has only been available _on the global object_ (in other words: without importing it explicitly) since Node.js 10.

### So why haven't our tests caught this?!

Well, it looks like Jest "fixed" this for us. Jest polyfilled `URL`, which meant the test passed on Node 6 even though the actual library did not work.