### PR TITLE
Deprecate payment.getPaymentUrl

### DIFF
--- a/src/data/payments/PaymentHelper.ts
+++ b/src/data/payments/PaymentHelper.ts
@@ -75,6 +75,8 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
 
   /**
    * Returns the URL the customer should visit to make the payment. This is to where you should redirect the consumer.
+   *
+   * @deprecated Use `payment.getCheckoutUrl()` instead.
    */
   public getPaymentUrl(): Nullable<string> {
     return this.links.checkout?.href ?? null;
@@ -141,10 +143,7 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/checkout#response
    */
   public getCheckoutUrl(): Nullable<string> {
-    if (this.links.checkout == undefined) {
-      return null;
-    }
-    return this.links.checkout.href;
+    return this.links.checkout?.href ?? null;
   }
 
   public canBeRefunded(this: PaymentData): boolean {

--- a/src/data/payments/PaymentHelper.ts
+++ b/src/data/payments/PaymentHelper.ts
@@ -79,7 +79,7 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
    * @deprecated Use `payment.getCheckoutUrl()` instead.
    */
   public getPaymentUrl(): Nullable<string> {
-    return this.links.checkout?.href ?? null;
+    return this.getCheckoutUrl();
   }
 
   /**


### PR DESCRIPTION
Deprecated `payment.getPaymentUrl()`.

A breaking change, but:
 * As this is synonymous with `payment.getCheckoutUrl()`, it is a potential cause for confusion.
 * Since the  PHP client only has `getCheckoutUrl`, this removal make this library more consistent with the PHP client.