### PR TITLE
Update API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const nockfulTests = ['iteration'];
+const nockfulTests = ['iteration', 'paymentLinks'];
 
 function createProject(displayName, testRegex, rest) {
   return Object.assign({}, rest, {

--- a/src/binders/Binder.ts
+++ b/src/binders/Binder.ts
@@ -6,7 +6,7 @@ import Maybe from '../types/Maybe';
  * A binder is the interface for a certain type of information. There is a binder for orders, and one for customers, et
  * cetera.
  */
-export default class Binder<R, T extends R> {
+export default class Binder<R, T extends Omit<R, '_links' | '_embedded'>> {
   /**
    * Injects `nextPage`, `nextPageCursor`, `previousPage`, and `previousPageCursor` into the passed list.
    */

--- a/src/binders/customers/subscriptions/parameters.ts
+++ b/src/binders/customers/subscriptions/parameters.ts
@@ -8,8 +8,8 @@ interface ContextParameters {
 }
 
 export type CreateParameters = ContextParameters &
-  Pick<SubscriptionData, 'amount' | 'interval' | 'startDate' | 'description' | 'mandateId'> &
-  PickOptional<SubscriptionData, 'times' | 'method' | 'webhookUrl' | 'metadata'>;
+  Pick<SubscriptionData, 'amount' | 'interval' | 'description' | 'mandateId'> &
+  PickOptional<SubscriptionData, 'times' | 'startDate' | 'method' | 'webhookUrl' | 'metadata'>;
 
 export type GetParameters = ContextParameters;
 

--- a/src/binders/orders/orderlines/parameters.ts
+++ b/src/binders/orders/orderlines/parameters.ts
@@ -8,7 +8,7 @@ interface ContextParameters {
 }
 
 export type UpdateParameters = ContextParameters &
-  PickOptional<OrderLineData, 'name' | 'quantity' | 'unitPrice' | 'discountAmount' | 'totalAmount' | 'vatAmount' | 'vatRate'> & {
+  PickOptional<OrderLineData, 'name' | 'quantity' | 'unitPrice' | 'discountAmount' | 'sku' | 'totalAmount' | 'vatAmount' | 'vatRate'> & {
     /**
      * A link pointing to an image of the product sold.
      *

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -1,0 +1,72 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import List from '../../data/list/List';
+import { PaymentLinkData } from '../../data/paymentLink/data';
+import PaymentLink from '../../data/paymentLink/PaymentLink';
+import ApiError from '../../errors/ApiError';
+import checkId from '../../plumbing/checkId';
+import HelpfulIterator from '../../plumbing/HelpfulIterator';
+import renege from '../../plumbing/renege';
+import Callback from '../../types/Callback';
+import Binder from '../Binder';
+import { CreateParameters, GetParameters, ListParameters } from './parameters';
+
+const pathSegment = 'payment-links';
+
+export default class PaymentsLinksBinder extends Binder<PaymentLinkData, PaymentLink> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * With the Payment links API you can generate payment links that by default, unlike regular payments, do not expire. The payment link can be shared with your customers and will redirect them to
+   * them the payment page where they can complete the payment. A /reference/v2/payments-api/get-payment will only be created once the customer initiates the payment.
+   *
+   * @since 3.6.0
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/create-payment-link
+   */
+  public create(parameters: CreateParameters): Promise<PaymentLink>;
+  public create(parameters: CreateParameters, callback: Callback<PaymentLink>): void;
+  public create(parameters: CreateParameters) {
+    if (renege(this, this.create, ...arguments)) return;
+    return this.networkClient.post<PaymentLinkData, PaymentLink>(pathSegment, parameters);
+  }
+
+  /**
+   * Retrieve a single payment object by its payment token.
+   *
+   * @since 3.6.0
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment
+   */
+  public get(id: string, parameters?: GetParameters): Promise<PaymentLink>;
+  public get(id: string, parameters: GetParameters, callback: Callback<PaymentLink>): void;
+  public get(id: string, parameters?: GetParameters) {
+    if (renege(this, this.get, ...arguments)) return;
+    if (!checkId(id, 'payment-link')) {
+      throw new ApiError('The payment link id is invalid');
+    }
+    return this.networkClient.get<PaymentLinkData, PaymentLink>(`${pathSegment}/${id}`, parameters);
+  }
+
+  /**
+   * Retrieve a single payment link object by its token.
+   *
+   * @since 3.6.0
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+   */
+  public page(parameters?: ListParameters): Promise<List<PaymentLink>>;
+  public page(parameters: ListParameters, callback: Callback<List<PaymentLink>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<PaymentLinkData, PaymentLink>(pathSegment, 'payment_links', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve a single payment link object by its token.
+   *
+   * @since 3.6.0
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+   */
+  public iterate(parameters?: Omit<ListParameters, 'limit'>): HelpfulIterator<PaymentLink> {
+    return this.networkClient.iterate<PaymentLinkData, PaymentLink>(pathSegment, 'payment_links', { ...parameters, limit: 64 });
+  }
+}

--- a/src/binders/paymentLinks/parameters.ts
+++ b/src/binders/paymentLinks/parameters.ts
@@ -1,0 +1,16 @@
+import { PaymentLinkData } from '../../data/paymentLink/data';
+import { PaginationParameters } from '../../types/parameters';
+
+export type CreateParameters = Pick<PaymentLinkData, 'description' | 'amount' | 'redirectUrl' | 'webhookUrl' | 'expiresAt'> & {
+  profileId?: string;
+  testmode?: boolean;
+};
+
+export interface GetParameters {
+  testmode?: boolean;
+}
+
+export type ListParameters = PaginationParameters & {
+  profileId?: string;
+  testmode?: boolean;
+};

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -5,7 +5,6 @@ import Payment from '../../data/payments/Payment';
 import ApiError from '../../errors/ApiError';
 import checkId from '../../plumbing/checkId';
 import HelpfulIterator from '../../plumbing/HelpfulIterator';
-import makeIterable from '../../plumbing/makeIterable';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';

--- a/src/binders/profiles/parameters.ts
+++ b/src/binders/profiles/parameters.ts
@@ -2,8 +2,8 @@ import { ProfileData } from '../../data/profiles/data';
 import { PaginationParameters } from '../../types/parameters';
 import PickOptional from '../../types/PickOptional';
 
-export type CreateParameters = Pick<ProfileData, 'name' | 'website' | 'email' | 'phone'> & PickOptional<ProfileData, 'categoryCode' | 'mode'>;
+export type CreateParameters = Pick<ProfileData, 'name' | 'website' | 'email' | 'phone'> & PickOptional<ProfileData, 'businessCategory' | 'categoryCode' | 'mode'>;
 
 export type ListParameters = PaginationParameters;
 
-export type UpdateParameters = PickOptional<ProfileData, 'name' | 'website' | 'email' | 'phone' | 'categoryCode' | 'mode'>;
+export type UpdateParameters = PickOptional<ProfileData, 'name' | 'website' | 'email' | 'phone' | 'businessCategory' | 'categoryCode' | 'mode'>;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -21,6 +21,7 @@ import { transform as transformPermission } from './data/permissions/Permission'
 import { transform as transformOrganization } from './data/organizations/Organizations';
 import { transform as transformProfile } from './data/profiles/Profile';
 import { transform as transformOnboarding } from './data/onboarding/Onboarding';
+import { transform as transformPaymentLink } from './data/paymentLink/PaymentLink';
 
 // Binders
 import ApplePayBinder from './binders/applePay/ApplePayBinder';
@@ -39,6 +40,7 @@ import OrderShipmentsBinder from './binders/orders/shipments/OrderShipmentsBinde
 import OrganizationsBinder from './binders/organizations/OrganizationsBinder';
 import PaymentCapturesBinder from './binders/payments/captures/PaymentCapturesBinder';
 import PaymentChargebacksBinder from './binders/payments/chargebacks/PaymentChargebacksBinder';
+import PaymentLinksBinder from './binders/paymentLinks/PaymentLinksBinder';
 import PaymentRefundsBinder from './binders/payments/refunds/PaymentRefundsBinder';
 import PaymentsBinder from './binders/payments/PaymentsBinder';
 import PermissionsBinder from './binders/permissions/PermissionBinder';
@@ -88,7 +90,8 @@ export default function createMollieClient(options: Options) {
       .add('permission', transformPermission)
       .add('organization', transformOrganization)
       .add('profile', transformProfile)
-      .add('onboarding', transformOnboarding),
+      .add('onboarding', transformOnboarding)
+      .add('payment-link', transformPaymentLink),
   );
 
   return {
@@ -144,6 +147,9 @@ export default function createMollieClient(options: Options) {
 
     // Apple Pay.
     applePay: new ApplePayBinder(networkClient),
+
+    // Payment links.
+    paymentLinks: new PaymentLinksBinder(transformingNetworkClient),
   };
 }
 

--- a/src/data/Issuer.ts
+++ b/src/data/Issuer.ts
@@ -1,19 +1,37 @@
 export type IdealIssuer = string;
 
 export type GiftcardIssuer =
+  | 'beautycadeaukaart'
+  | 'bloemencadeaukaart'
+  | 'bloemplantgiftcard'
+  | 'boekenbon'
+  | 'decadeaukaart'
+  | 'delokalecadeaukaart'
+  | 'dinercadeau'
   | 'fashioncheque'
+  | 'festivalcadeau'
+  | 'good4fun'
+  | 'huistuincadeaukaart'
+  | 'jewelcard'
+  | 'kluscadeau'
+  | 'kunstencultuurcadeaukaart'
   | 'nationalebioscoopbon'
   | 'nationaleentertainmentcard'
-  | 'kunstencultuurcadeaukaart'
+  | 'nationalegolfbon'
+  | 'ohmygood'
   | 'podiumcadeaukaart'
+  | 'reiscadeau'
+  | 'restaurantcadeau'
+  | 'sodexosportculturepass'
+  | 'sportenfitcadeau'
+  | 'sustainablefashion'
+  | 'travelcheq'
   | 'vvvgiftcard'
   | 'vvvdinercheque'
   | 'vvvlekkerweg'
   | 'webshopgiftcard'
-  | 'yourgift'
-  | 'travelcheq'
-  | 'nationalegolfbon'
-  | 'sportenfitcadeau';
+  | 'wijncadeaukaart'
+  | 'yourgift';
 
 export type KbcIssuer = 'kbc' | 'cbc';
 

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -35,7 +35,9 @@ export enum PaymentMethod {
   ideal = 'ideal',
   kbc = 'kbc',
   klarnapaylater = 'klarnapaylater',
+  klarnapaynow = 'klarnapaynow',
   klarnasliceit = 'klarnasliceit',
+  mybank = 'mybank',
   paypal = 'paypal',
   paysafecard = 'paysafecard',
   przelewy24 = 'przelewy24',
@@ -112,14 +114,18 @@ export interface Address {
 export type CardLabel = 'American Express' | 'Carta Si' | 'Carte Bleue' | 'Dankort' | 'Diners' | 'Club' | 'Discover' | 'JCB' | 'Laser' | 'Maestro' | 'Mastercard' | 'Unionpay' | 'Visa';
 
 export type CardFailureReason =
+  | 'authentication_abandoned'
   | 'authentication_failed'
+  | 'authentication_required'
+  | 'authentication_unavailable_acs'
+  | 'card_declined'
   | 'card_expired'
   | 'inactive_card'
   | 'insufficient_funds'
+  | 'invalid_cvv'
   | 'invalid_card_holder_name'
   | 'invalid_card_number'
   | 'invalid_card_type'
-  | 'invalid_cvv'
   | 'possible_fraud'
   | 'refused_by_issuer'
   | 'unknown_reason';

--- a/src/data/paymentLink/PaymentLink.ts
+++ b/src/data/paymentLink/PaymentLink.ts
@@ -1,0 +1,12 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import Seal from '../../types/Seal';
+import { PaymentLinkData } from './data';
+import PaymentLinkHelper from './PaymentLinkHelper';
+
+type PaymentLink = Seal<Omit<PaymentLinkData, '_links'>, PaymentLinkHelper>;
+
+export default PaymentLink;
+
+export function transform(networkClient: TransformingNetworkClient, input: PaymentLinkData): PaymentLink {
+  return Object.assign(Object.create(new PaymentLinkHelper(networkClient, input._links)), input);
+}

--- a/src/data/paymentLink/PaymentLinkHelper.ts
+++ b/src/data/paymentLink/PaymentLinkHelper.ts
@@ -1,0 +1,19 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import Helper from '../Helper';
+import { PaymentLinkData } from './data';
+import PaymentLink from './PaymentLink';
+
+export default class PaymentLinkHelper extends Helper<PaymentLinkData, PaymentLink> {
+  constructor(networkClient: TransformingNetworkClient, protected readonly links: PaymentLinkData['_links']) {
+    super(networkClient, links);
+  }
+
+  /**
+   * Returns a direct link to the payment link.
+   *
+   * @since 3.6.0
+   */
+  public getPaymentUrl(): string {
+    return this.links.paymentLink.href;
+  }
+}

--- a/src/data/paymentLink/data.ts
+++ b/src/data/paymentLink/data.ts
@@ -1,0 +1,69 @@
+import { Amount, ApiMode, Links, Url } from '../global';
+import Model from '../Model';
+
+export interface PaymentLinkData extends Model<'payment-link'> {
+  /**
+   * A short description of the payment link. The description is visible in the Dashboard and will be shown on the customer's bank or card statement when possible. This description will eventual been
+   * used as payment description.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=description#response
+   */
+  description: string;
+  /**
+   * The mode used to create this payment link. Mode determines whether a payment link is *real* (live mode) or a *test* payment link.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=mode#response
+   */
+  mode: ApiMode;
+  /**
+   * The identifier referring to the profile this payment link was created on. For example, `pfl_QkEhN94Ba`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=profileId#response
+   */
+  profileId: string;
+  /**
+   * The amount of the payment link, e.g. `{"currency":"EUR", "value":"100.00"}` for a €100.00 payment link.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=amount#response
+   */
+  amount: Amount;
+  /**
+   * The URL your customer will be redirected to after completing the payment process.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=redirectUrl#response
+   */
+  redirectUrl?: string;
+  /**
+   * The URL your customer will be redirected to after completing the payment process.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=redirectUrl#response
+   */
+  webhookUrl?: string;
+  /**
+   * The payment link's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=createdAt#response
+   */
+  createdAt: string;
+  /**
+   * The date and time the payment link became paid, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=paidAt#response
+   */
+  paidAt?: string;
+  /**
+   * The date and time the payment link last status change, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=updatedAt#response
+   */
+  updatedAt?: string;
+  /**
+   * The expiry date and time of the payment link, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=expiresAt#response
+   */
+  expiresAt?: string;
+  _links: Links & { paymentLink: Url };
+}

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -93,6 +93,12 @@ export interface PaymentData extends Model<'payment'> {
    */
   amountCaptured?: Amount;
   /**
+   * The total amount that was charged back for this payment. Only available when the total charged back amount is not zero.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=amountChargedBack#response
+   */
+  amountChargedBack?: Amount;
+  /**
    * A short description of the payment. The description is visible in the Dashboard and will be shown on the customer's bank or card statement when possible.
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=description#response
@@ -628,7 +634,7 @@ export interface PayPalDetails {
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/shippingAddress#paypal
    */
-  shippingAddress: Address;
+  shippingAddress: Address & { givenName?: string; familyName?: string };
   /**
    * The amount of fee PayPal will charge for this transaction. This field is omitted if PayPal will not charge a fee for this transaction.
    *

--- a/src/data/profiles/data.ts
+++ b/src/data/profiles/data.ts
@@ -41,6 +41,14 @@ export interface ProfileData extends Model<'profile'> {
   /**
    * The industry associated with the profile's trade name or brand.
    *
+   * Please refer to the documentation of the business category for more information on which values are accepted.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=businessCategory#response
+   */
+  businessCategory: string;
+  /**
+   * The industry associated with the profile's trade name or brand.
+   *
    * Possible values:
    *
    * -   `5192` Books, magazines and newspapers

--- a/src/errors/ApiError.ts
+++ b/src/errors/ApiError.ts
@@ -95,12 +95,6 @@ export default class ApiError extends Error {
    * @since 3.0.0
    */
   public static createFromResponse(response: AxiosResponse): ApiError {
-    return new ApiError(
-      response.data.detail ?? 'Received an error without a message',
-      response.data.title,
-      response.data.status,
-      response.data.field,
-      response.data._links,
-    );
+    return new ApiError(response.data.detail ?? 'Received an error without a message', response.data.title, response.data.status, response.data.field, response.data._links);
   }
 }

--- a/src/plumbing/capitalize.ts
+++ b/src/plumbing/capitalize.ts
@@ -1,6 +1,9 @@
+const replaceArguments = [/(?:^|-+)(\w?)/g, (_: string, character: string) => character.toUpperCase()] as const;
+
 /**
- * Returns the passed input with the first character converted to upper case. `'bananas'` → `'Bananas'`.
+ * Returns the passed input with all dashes (`'-'`) removed, and the first character as well as any character which
+ * appears directly after a dash converted to upper case. `'bananas'` → `'Bananas'`. `'summer-day'` → `'SummerDay'`.
  */
 export default function capitalize(input: string) {
-  return input.charAt(0).toUpperCase() + input.substring(1);
+  return input.replace(...replaceArguments);
 }

--- a/src/plumbing/checkId.ts
+++ b/src/plumbing/checkId.ts
@@ -1,4 +1,18 @@
-type ResourceKind = 'capture' | 'chargeback' | 'customer' | 'mandate' | 'order' | 'orderline' | 'organization' | 'payment' | 'permission' | 'profile' | 'refund' | 'shipment' | 'subscription';
+type ResourceKind =
+  | 'capture'
+  | 'chargeback'
+  | 'customer'
+  | 'mandate'
+  | 'order'
+  | 'orderline'
+  | 'organization'
+  | 'payment'
+  | 'payment-link'
+  | 'permission'
+  | 'profile'
+  | 'refund'
+  | 'shipment'
+  | 'subscription';
 
 const prefixes = new Map<ResourceKind, string>([
   ['capture', 'cpt_'],
@@ -9,6 +23,7 @@ const prefixes = new Map<ResourceKind, string>([
   ['orderline', 'odl_'],
   ['organization', 'org_'],
   ['payment', 'tr_'],
+  ['payment-link', 'pl_'],
   ['profile', 'pfl_'],
   ['refund', 're_'],
   ['shipment', 'shp_'],

--- a/tests/__nock-fixtures__/paymentLinks.json
+++ b/tests/__nock-fixtures__/paymentLinks.json
@@ -1,0 +1,118 @@
+[
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "POST",
+        "path": "/v2/payment-links",
+        "body": {
+            "amount": {
+                "currency": "EUR",
+                "value": "6.99"
+            },
+            "description": "Hair pin"
+        },
+        "status": 201,
+        "response": {
+            "resource": "payment-link",
+            "id": "pl_aTMXG7OQ2CS6VhsktUiSB",
+            "description": "Hair pin",
+            "mode": "test",
+            "profileId": "pfl_nsyuznnvpc",
+            "amount": {
+                "value": "6.99",
+                "currency": "EUR"
+            },
+            "webhookUrl": null,
+            "redirectUrl": null,
+            "createdAt": "2021-11-24T11:44:29+00:00",
+            "paidAt": null,
+            "updatedAt": null,
+            "expiresAt": null,
+            "_links": {
+                "self": {
+                    "href": "https://api.mollie.com/v2/payment-links/pl_aTMXG7OQ2CS6VhsktUiSB",
+                    "type": "application/hal+json"
+                },
+                "paymentLink": {
+                    "href": "https://paymentlink.mollie.com/payment/aTMXG7OQ2CS6VhsktUiSB/",
+                    "type": "text/html"
+                },
+                "documentation": {
+                    "href": "https://docs.mollie.com/reference/v2/payment-links-api/create-payment-link",
+                    "type": "text/html"
+                }
+            }
+        },
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Wed, 24 Nov 2021 11:44:29 GMT",
+            "Content-Type",
+            "application/hal+json",
+            "Content-Length",
+            "646",
+            "Connection",
+            "close",
+            "X-Robots-Tag",
+            "noindex",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "GET",
+        "path": "/v2/payment-links/pl_aTMXG7OQ2CS6VhsktUiSB",
+        "body": "",
+        "status": 200,
+        "response": {
+            "resource": "payment-link",
+            "id": "pl_aTMXG7OQ2CS6VhsktUiSB",
+            "description": "Hair pin",
+            "mode": "test",
+            "profileId": "pfl_nsyuznnvpc",
+            "amount": {
+                "value": "6.99",
+                "currency": "EUR"
+            },
+            "webhookUrl": null,
+            "redirectUrl": null,
+            "createdAt": "2021-11-24T11:44:29+00:00",
+            "paidAt": null,
+            "updatedAt": null,
+            "expiresAt": null,
+            "_links": {
+                "self": {
+                    "href": "https://api.mollie.com/v2/payment-links/pl_aTMXG7OQ2CS6VhsktUiSB",
+                    "type": "application/hal+json"
+                },
+                "paymentLink": {
+                    "href": "https://paymentlink.mollie.com/payment/aTMXG7OQ2CS6VhsktUiSB/",
+                    "type": "text/html"
+                },
+                "documentation": {
+                    "href": "https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link",
+                    "type": "text/html"
+                }
+            }
+        },
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Wed, 24 Nov 2021 11:44:29 GMT",
+            "Content-Type",
+            "application/hal+json",
+            "Content-Length",
+            "643",
+            "Connection",
+            "close",
+            "X-Robots-Tag",
+            "noindex",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload"
+        ],
+        "responseIsBinary": false
+    }
+]

--- a/tests/paymentLinks/paymentLinks.test.ts
+++ b/tests/paymentLinks/paymentLinks.test.ts
@@ -1,0 +1,30 @@
+import { MollieClient } from '../../dist/types/src/types';
+import NetworkMocker, { apiKeyClientFactory } from '../NetworkMocker';
+
+// false ‒ This test interacts with the real Mollie API over the network, and records the communication.
+// true  ‒ This test uses existing recordings to simulate the network.
+const mockNetwork = true;
+
+describe('paymentLinks', () => {
+  const networkMocker = new NetworkMocker(mockNetwork, apiKeyClientFactory, 'paymentLinks');
+  let mollieClient: MollieClient;
+
+  beforeAll(async () => {
+    mollieClient = await networkMocker.prepare();
+  });
+
+  test('paymentLinks', async () => {
+    let paymentLink = await mollieClient.paymentLinks.create({
+      amount: {
+        currency: 'EUR',
+        value: '6.99',
+      },
+      description: 'Hair pin',
+    });
+    expect(paymentLink.getPaymentUrl()).toMatch(/^https:\/\/paymentlink\.mollie\.com\//);
+    paymentLink = await mollieClient.paymentLinks.get(paymentLink.id);
+    expect(paymentLink.amount.value).toBe('6.99');
+  });
+
+  afterAll(() => networkMocker.cleanup());
+});


### PR DESCRIPTION
Update the API [according to the changelog](https://docs.mollie.com/changelog/v2/changelog).

This closes #209, #216, #227, and #242.

The `PaymentLink` objects don't contain the `_links` property at all (according to the TypeScript types, at least). This is inconsistent, but will be consistent once we remove `_links` everywhere in 4.0.0.