### PR TITLE
Made list the preferred method for endpoints which don't paginate

### DIFF
--- a/src/binders/customers/payments/parameters.ts
+++ b/src/binders/customers/payments/parameters.ts
@@ -1,5 +1,6 @@
 import { PaymentMethod } from '../../../data/global';
 import { PaymentData } from '../../../data/payments/data';
+import { PaginationParameters } from '../../../types/parameters';
 import PickOptional from '../../../types/PickOptional';
 
 interface ContextParameters {
@@ -23,4 +24,4 @@ export type CreateParameters = ContextParameters &
     method: PaymentMethod | PaymentMethod[];
   };
 
-export type ListParameters = ContextParameters;
+export type ListParameters = ContextParameters & PaginationParameters;

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -31,7 +31,7 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public all: MethodsBinder['page'] = this.page;
+  public all: MethodsBinder['list'] = this.list;
   /**
    * Retrieve all enabled payment methods. The results are not paginated.
    *
@@ -46,10 +46,10 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * how they can be used for recurring payments.
    *
    * @since 3.0.0
-   * @deprecated Use `page` instead.
+   * @deprecated Use `list` instead.
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public list: MethodsBinder['page'] = this.page;
+  public page: MethodsBinder['list'] = this.list;
 
   /**
    * Retrieve a single method by its ID. Note that if a method is not available on the website profile a status `404 Not found` is returned. When the method is not enabled, a status `403 Forbidden` is
@@ -85,10 +85,10 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public page(parameters?: ListParameters): Promise<List<Method>>;
-  public page(parameters: ListParameters, callback: Callback<List<Method>>): void;
-  public page(parameters: ListParameters = {}) {
-    if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<MethodData, Method>(pathSegment, 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  public list(parameters?: ListParameters): Promise<List<Method>>;
+  public list(parameters: ListParameters, callback: Callback<List<Method>>): void;
+  public list(parameters: ListParameters = {}) {
+    if (renege(this, this.list, ...arguments)) return;
+    return this.networkClient.list<MethodData, Method>(pathSegment, 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 }

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -28,7 +28,7 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * how they can be used for recurring payments.
    *
    * @since 2.0.0
-   * @deprecated Use `page` instead.
+   * @deprecated Use `list` instead.
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
   public all: MethodsBinder['list'] = this.list;

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -98,22 +98,6 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
   }
 
   /**
-   * Retrieve all shipments for an order.
-   *
-   * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
-   */
-  public iterate(parameters: Omit<ListParameters, 'limit'>) {
-    // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
-    const orderId = this.getParentId((parameters ?? {}).orderId);
-    if (!checkId(orderId, 'order')) {
-      throw new ApiError('The order id is invalid');
-    }
-    const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.iterate<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', { ...query, limit: 64 });
-  }
-
-  /**
    * This endpoint can be used to update the tracking information of a shipment.
    *
    * @since 3.0.0

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -21,7 +21,7 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
    * Retrieve all shipments for an order.
    *
    * @since 3.0.0
-   * @deprecated Use `page` instead.
+   * @deprecated Use `list` instead.
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
   public all: OrderShipmentsBinder['list'] = this.list;

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -24,15 +24,15 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
    * @deprecated Use `page` instead.
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
-  public all: OrderShipmentsBinder['page'] = this.page;
+  public all: OrderShipmentsBinder['list'] = this.list;
   /**
    * Retrieve all shipments for an order.
    *
    * @since 3.0.0
-   * @deprecated Use `page` instead.
+   * @deprecated Use `list` instead.
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
-  public list: OrderShipmentsBinder['page'] = this.page;
+  public page: OrderShipmentsBinder['list'] = this.list;
 
   /**
    * Create a shipment for specific order lines of an order.
@@ -84,17 +84,17 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
-  public page(parameters: ListParameters): Promise<List<Shipment>>;
-  public page(parameters: ListParameters, callback: Callback<List<Shipment>>): void;
-  public page(parameters: ListParameters) {
-    if (renege(this, this.page, ...arguments)) return;
+  public list(parameters: ListParameters): Promise<List<Shipment>>;
+  public list(parameters: ListParameters, callback: Callback<List<Shipment>>): void;
+  public list(parameters: ListParameters) {
+    if (renege(this, this.list, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const orderId = this.getParentId((parameters ?? {}).orderId);
     if (!checkId(orderId, 'order')) {
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.list<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
   }
 
   /**

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -48,10 +48,12 @@ export default class PaymentsLinksBinder extends Binder<PaymentLinkData, Payment
   }
 
   /**
-   * Retrieve a single payment link object by its token.
+   * Retrieve all payments links created with the current website profile, ordered from newest to oldest.
+   *
+   * The results are paginated. See pagination for more information.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
    */
   public page(parameters?: ListParameters): Promise<List<PaymentLink>>;
   public page(parameters: ListParameters, callback: Callback<List<PaymentLink>>): void;

--- a/src/binders/payments/captures/parameters.ts
+++ b/src/binders/payments/captures/parameters.ts
@@ -1,4 +1,5 @@
 import { CaptureEmbed } from '../../../data/payments/captures/data';
+import { PaginationParameters } from '../../../types/parameters';
 
 interface ContextParameters {
   paymentId: string;
@@ -9,6 +10,6 @@ export type GetParameters = ContextParameters & {
   embed?: CaptureEmbed[];
 };
 
-export type ListParameters = ContextParameters & {
+export type ListParameters = ContextParameters & PaginationParameters & {
   embed?: CaptureEmbed[];
 };

--- a/src/binders/permissions/PermissionBinder.ts
+++ b/src/binders/permissions/PermissionBinder.ts
@@ -18,10 +18,10 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
    * List all permissions available with the current app access token. The list is not paginated.
    *
    * @since 3.2.0
-   * @deprecated Use `page` instead.
+   * @deprecated Use `list` instead.
    * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
    */
-  public list: PermissionsBinder['page'] = this.page;
+  public page: PermissionsBinder['list'] = this.list;
 
   /**
    * Retrieve the details on a specific permission, and see if the permission is granted to the current app access token.
@@ -42,13 +42,13 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
   /**
    * List all permissions available with the current app access token. The list is not paginated.
    *
-   * @since 3.2.0 (as `list`)
+   * @since 3.2.0
    * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
    */
-  public page(): Promise<List<Permission>>;
-  public page(callback: Callback<List<Permission>>): void;
-  public page() {
-    if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<PermissionData, Permission>(pathSegment, 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.page, undefined));
+  public list(): Promise<List<Permission>>;
+  public list(callback: Callback<List<Permission>>): void;
+  public list() {
+    if (renege(this, this.list, ...arguments)) return;
+    return this.networkClient.list<PermissionData, Permission>(pathSegment, 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.list, undefined));
   }
 }


### PR DESCRIPTION
`page` was selected as the preferred method name over `list` and `all` in #234. This PR re-introduces `list` as the preferred method name _for endpoints which don't paginate_.

Those endpoints are:
* [List methods](https://docs.mollie.com/reference/v2/methods-api/list-methods)
* [List shipments](https://docs.mollie.com/reference/v2/shipments-api/list-shipments) (for which the documentation does not explicitly mention that it does not paginate, but according to my tests it doesn't)
* [List permissions](https://docs.mollie.com/reference/v2/permissions-api/list-permissions)

The `iterate` method does not exist for these endpoints, either.