### PR TITLE
Update order and payment types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mollie/api-client",
-  "version": "3.6.0-beta.1",
+  "version": "3.6.0-beta.2",
   "license": "BSD-3-Clause",
   "description": "Official Mollie API client for Node",
   "repository": {

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -80,8 +80,8 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
   public list: OrdersBinder['page'] = this.page;
 
   /**
-   * Using the Orders API is the preferred approach when integrating the Mollie API into e-commerce applications such as webshops. If you want to use *Klarna Pay later*, *Klarna Slice it*, *Klarna Pay
-   * now* or *Vouchers*, using the Orders API is mandatory.
+   * Using the Orders API is the preferred approach when integrating the Mollie API into e-commerce applications such as webshops. If you want to use *Klarna Pay now*, *Klarna Pay later*, *Klarna
+   * Slice it* or *Vouchers*, using the Orders API is mandatory.
    *
    * Creating an Order will automatically create the required Payment to allow your customer to pay for the order.
    *

--- a/src/binders/orders/parameters.ts
+++ b/src/binders/orders/parameters.ts
@@ -3,6 +3,7 @@ import { OrderAddress, OrderData, OrderEmbed } from '../../data/orders/data';
 import { OrderLineData } from '../../data/orders/orderlines/OrderLine';
 import { PaymentData } from '../../data/payments/data';
 import { PaginationParameters } from '../../types/parameters';
+import { CreateParameters as PaymentCreateParameters } from '../payments/parameters';
 import PickOptional from '../../types/PickOptional';
 
 export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billingAddress' | 'webhookUrl' | 'locale' | 'metadata' | 'expiresAt'> & {
@@ -70,7 +71,21 @@ export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billi
    *
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=payment#parameters
    */
-  payment?: Partial<PaymentData>;
+  payment?: Pick<
+    PaymentCreateParameters,
+    | 'applePayPaymentToken'
+    | 'cardToken'
+    | 'consumerAccount'
+    | 'customerId'
+    | 'customerReference'
+    | 'issuer'
+    | 'mandateId'
+    | 'sequenceType'
+    | 'voucherNumber'
+    | 'voucherPin'
+    | 'webhookUrl'
+    | 'applicationFee'
+  >;
   /**
    * For digital goods, you must make sure to apply the VAT rate from your customer's country in most jurisdictions. Use this parameter to restrict the payment methods available to your customer to
    * methods from the billing country only.

--- a/src/binders/orders/parameters.ts
+++ b/src/binders/orders/parameters.ts
@@ -40,7 +40,8 @@ export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'billi
   /**
    * The shipping address for the order.
    *
-   * Please refer to the documentation of the address object for more information on which formats are accepted.
+   * This field is optional, but if it is provided, then the full name and address have to be in a valid format. Please refer to the documentation of the address object for more information on which
+   * formats are accepted.
    *
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order?path=shippingAddress#parameters
    */

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -37,7 +37,8 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
   /**
    * Create a shipment for specific order lines of an order.
    *
-   * When using *Klarna Pay later* and *Klarna Slice it*, using this endpoint is mandatory for the order amount to be captured. A capture will automatically be created for the shipment.
+   * When using *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice it*, using this endpoint is mandatory for the order amount to be captured. A capture will automatically be created for the
+   * shipment.
    *
    * The word "shipping" is used in the figurative sense here. It can also mean that a service was provided or digital content was delivered.
    *

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -21,7 +21,8 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
   /**
    * Retrieve all captures for a certain payment.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
+   * it*.
    *
    * @since 1.1.1
    * @deprecated Use `page` instead.
@@ -31,7 +32,8 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
   /**
    * Retrieve all captures for a certain payment.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
+   * it*.
    *
    * @since 3.0.0
    * @deprecated Use `page` instead.
@@ -42,7 +44,8 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
   /**
    * Retrieve a single capture by its ID. Note the original payment's ID is needed as well.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are **Klarna Pay later** and **Klarna Slice it**.
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are **Klarna Pay now**, **Klarna Pay later** and **Klarna
+   * Slice it**.
    *
    * @since 1.1.1
    * @see https://docs.mollie.com/reference/v2/captures-api/get-capture
@@ -66,7 +69,8 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
   /**
    * Retrieve all captures for a certain payment.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
+   * it*.
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
@@ -87,7 +91,8 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
   /**
    * Retrieve all captures for a certain payment.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay later* and *Klarna Slice it*.
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
+   * it*.
    *
    * @since 3.6.0
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures

--- a/src/binders/payments/captures/parameters.ts
+++ b/src/binders/payments/captures/parameters.ts
@@ -10,6 +10,7 @@ export type GetParameters = ContextParameters & {
   embed?: CaptureEmbed[];
 };
 
-export type ListParameters = ContextParameters & PaginationParameters & {
-  embed?: CaptureEmbed[];
-};
+export type ListParameters = ContextParameters &
+  PaginationParameters & {
+    embed?: CaptureEmbed[];
+  };

--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -29,18 +29,6 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=restrictPaymentMethodsToCountry#parameters
      */
     restrictPaymentMethodsToCountry?: string;
-    billingEmail?: string;
-    /**
-     * The date the payment should expire, in `YYYY-MM-DD` format. **Please note:** the minimum date is tomorrow and the maximum date is 100 days after tomorrow.
-     *
-     * After you created the payment, you can still update the `dueDate` via /reference/v2/payments-api/update-payment.
-     *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=dueDate#bank-transfer
-     */
-    dueDate?: string;
-    billingAddress?: Address;
-    shippingAddress?: Address;
-    digitalGoods?: boolean;
     /**
      * The [Apple Pay Payment Token](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypayment/1916095-token) object (encoded as JSON) that is part of the result of authorizing a
      * payment request. The token contains the payment information needed to authorize the payment.
@@ -54,13 +42,65 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applePayPaymentToken#apple-pay
      */
     applePayPaymentToken?: string;
+    billingEmail?: string;
     /**
-     * An iDEAL issuer ID, for example `ideal_INGBNL2A`. This is useful when you want to embed the issuer selection on your own checkout screen. When supplying an issuer ID, the returned payment URL
-     * will deep-link to the specific banking website (ING Bank, in this example). The full list of issuers can be retrieved via the Methods API by using the optional `issuers` include.
+     * The date the payment should expire, in `YYYY-MM-DD` format. **Please note:** the minimum date is tomorrow and the maximum date is 100 days after tomorrow.
      *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=issuer#ideal
+     * After you created the payment, you can still update the `dueDate` via /reference/v2/payments-api/update-payment.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=dueDate#bank-transfer
      */
+    dueDate?: string;
+    /**
+     * The card holder's address details. We advise to provide these details to improve the credit card fraud protection, and thus improve conversion.
+     *
+     * If an address is provided, then the address has to be in a valid format. Please refer to the documentation of the address object for more information on which formats are accepted.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=billingAddress#credit-card
+     */
+    billingAddress?: Address;
+    /**
+     * The card token you got from Mollie Components. The token contains the card information (such as card holder, card number, and expiry date) needed to complete the payment.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=cardToken#credit-card
+     */
+    cardToken?: string;
+    shippingAddress?: Address & {
+      // Note that this field is required for PayPal payments; but is disregarded for credit card payments.
+      givenName?: string;
+      // Note that this field is required for PayPal payments; but is disregarded for credit card payments.
+      familyName?: string;
+    };
     issuer?: Issuer;
+    /**
+     * The card number on the gift card. You can supply this to prefill the card number.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=voucherNumber#gift-cards
+     */
+    voucherNumber?: string;
+    /**
+     * The PIN code on the gift card. You can supply this to prefill the PIN, if the card has any.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=voucherPin#gift-cards
+     */
+    voucherPin?: string;
+    /**
+     * The unique ID you have used for the PayPal fraud library. You should include this if you use PayPal for an on-demand payment. The maximum character length is 32.
+     *
+     * Please refer to the Recurring payments guide for more information on how to implement the fraud library.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=sessionId#paypal-method-details
+     */
+    sessionId?: string;
+    /**
+     * Indicate if you are about to deliver digital goods, like for example a license. Setting this parameter can have consequences for your Seller Protection by PayPal. Please see [PayPal's help
+     * article](https://www.paypal.com/us/brc/article/seller-protection) about Seller Protection for more information.
+     *
+     * Default: `false`
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=digitalGoods#paypal-method-details
+     */
+    digitalGoods?: boolean;
     /**
      * Used for consumer identification. Use the following guidelines to create your `customerReference`:
      *
@@ -90,21 +130,7 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=consumerAccount#sepa-direct-debit
      */
     consumerAccount?: string;
-    /**
-     * The card number on the gift card. You can supply this to prefill the card number.
-     *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=voucherNumber#gift-cards
-     */
-    voucherNumber?: string;
-    /**
-     * The PIN code on the gift card. You can supply this to prefill the PIN, if the card has any.
-     *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=voucherPin#gift-cards
-     */
-    voucherPin?: string;
-
     include?: PaymentInclude[] | PaymentInclude;
-
     profileId?: string;
     testmode?: boolean;
     /**

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -42,8 +42,6 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
   /**
    * When using the Orders API, refunds should be made for a specific order.
    *
-   * When using *pay after delivery* payment methods such as *Klarna Pay later* and *Klarna Slice it*, your customer will receive a credit invoice with more information about the refunded products.
-   *
    * If you want to refund arbitrary amounts, however, you can also use the Create payment refund endpoint for Pay later and Slice it by creating a refund on the payment itself.
    *
    * If an order line is still in the `authorized` status, it cannot be refunded. You should cancel it instead. Order lines that are `paid`, `shipping` or `completed` can be refunded.

--- a/src/data/Issuer.ts
+++ b/src/data/Issuer.ts
@@ -35,4 +35,6 @@ export type GiftcardIssuer =
 
 export type KbcIssuer = 'kbc' | 'cbc';
 
-export type Issuer = IdealIssuer | GiftcardIssuer | KbcIssuer;
+type VoucherIssuer = string;
+
+export type Issuer = IdealIssuer | GiftcardIssuer | KbcIssuer | VoucherIssuer;

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -111,7 +111,7 @@ export interface Address {
   country: string;
 }
 
-export type CardLabel = 'American Express' | 'Carta Si' | 'Carte Bleue' | 'Dankort' | 'Diners' | 'Club' | 'Discover' | 'JCB' | 'Laser' | 'Maestro' | 'Mastercard' | 'Unionpay' | 'Visa';
+export type CardLabel = 'American Express' | 'Carta Si' | 'Carte Bleue' | 'Dankort' | 'Diners Club' | 'Discover' | 'JCB' | 'Laser' | 'Maestro' | 'Mastercard' | 'Unionpay' | 'Visa';
 
 export type CardFailureReason =
   | 'authentication_abandoned'
@@ -132,7 +132,7 @@ export type CardFailureReason =
 
 export type CardAudience = 'consumer' | 'business';
 
-export type FeeRegion = 'american-express' | 'carte-bancaire' | 'intra-eu' | 'maestro' | 'other';
+export type FeeRegion = 'american-express' | 'amex-intra-eea' | 'carte-bancaire' | 'intra-eu' | 'intra-eu-corporate' | 'domestic' | 'maestro' | 'other';
 
 export enum SequenceType {
   oneoff = 'oneoff',

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -223,7 +223,22 @@ export interface PaymentData extends Model<'payment'> {
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details#ideal
    */
-  details?: Details; // TODO: check if this should become a required field, even as an embedded object
+  details?:
+    | BancontactDetails
+    | BankTransferDetails
+    | BelfiusPayButtonDetails
+    | BitcoinDetails
+    | CreditCardDetails
+    | GiftCardDetails
+    | IdealDetails
+    | IngHomePayDetails
+    | KbcCbcPaymentButtonDetails
+    | KlarnaDetails
+    | PayPalDetails
+    | PaysafecardDetails
+    | SepaDirectDebitDetails
+    | SofortBankingDetails
+    | VoucherDetails;
   _embedded?: {
     refunds?: Omit<RefundData, '_embedded'>[];
     chargebacks?: Omit<ChargebackData, '_embedded'>[];
@@ -297,22 +312,6 @@ interface PaymentLinks extends Links {
   order?: Url;
 }
 
-export type Details =
-  | BancontactDetails
-  | BankTransferDetails
-  | BelfiusPayButtonDetails
-  | BitcoinDetails
-  | CreditCardDetails
-  | GiftCardDetails
-  | IdealDetails
-  | IngHomePayDetails
-  | KbcCbcPaymentButtonDetails
-  | KlarnaDetails
-  | PayPalDetails
-  | PaysafecardDetails
-  | SepaDirectDebitDetails
-  | SofortBankingDetails;
-
 export interface BancontactDetails {
   /**
    * Only available if the payment is completed - The last four digits of the card number.
@@ -323,6 +322,7 @@ export interface BancontactDetails {
   /**
    * Only available if the payment is completed - Unique alphanumeric representation of card, usable for identifying returning customers.
    *
+   * @deprecated Use `consumerAccount` instead.
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardFingerprint#bancontact
    */
   cardFingerprint: string;
@@ -350,6 +350,12 @@ export interface BancontactDetails {
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#bancontact
    */
   consumerBic: string;
+  /**
+   * The reason why the payment did not succeed. Only available when there's a reason known.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/failureReason#bancontact
+   */
+  failureReason: string;
 }
 
 export interface BankTransferLinks extends Links {
@@ -495,7 +501,7 @@ export interface CreditCardDetails {
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/cardSecurity#Credit%20card%20v2
    */
-  cardSecurity: string;
+  cardSecurity: 'normal' | '3dsecure';
   /**
    * Only available if the payment has been completed – The fee region for the payment. The `intra-eu` value is for consumer cards from the EEA.
    *
@@ -513,6 +519,22 @@ export interface CreditCardDetails {
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/failureReason#Credit%20card%20v2
    */
   failureReason: CardFailureReason;
+  /**
+   * A localized message that can be shown to your customer, depending on the `failureReason`.
+   *
+   * Example value: `Der Kontostand Ihrer Kreditkarte ist unzureichend. Bitte verwenden Sie eine andere Karte.`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/failureMessage#Credit%20card%20v2
+   */
+  failureMessage: string;
+  /**
+   * The wallet used when creating the payment.
+   *
+   * Possible values: `applepay`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/wallet#Credit%20card%20v2
+   */
+  wallet?: 'applepay';
 }
 
 export interface GiftCardDetails {
@@ -634,7 +656,7 @@ export interface PayPalDetails {
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/shippingAddress#paypal
    */
-  shippingAddress: Address & { givenName?: string; familyName?: string };
+  shippingAddress?: Address;
   /**
    * The amount of fee PayPal will charge for this transaction. This field is omitted if PayPal will not charge a fee for this transaction.
    *
@@ -752,6 +774,46 @@ export interface SofortBankingDetails {
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/consumerBic#sofort-banking
    */
   consumerBic: string;
+}
+
+export interface VoucherDetails {
+  /**
+   * The ID of the voucher brand that was used during the payment. When multiple vouchers are used, this is the issuer of the first voucher.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/issuer#vouchers
+   */
+  issuer: string;
+  /**
+   * A list of details of all vouchers that are used for this payment. Each object will contain the following properties.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/vouchers#vouchers
+   */
+  vouchers: {
+    /**
+     * The ID of the voucher brand that was used during the payment.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/vouchers/issuer#vouchers
+     */
+    issuer: string;
+    /**
+     * The amount that was paid with this voucher.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/vouchers/amount#vouchers
+     */
+    amount: Amount;
+  }[];
+  /**
+   * Only available if another payment method was used to pay the remainder amount – The amount that was paid with another payment method for the remainder amount.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/remainderAmount#vouchers
+   */
+  remainderAmount: Amount;
+  /**
+   * Only available if another payment method was used to pay the remainder amount – The payment method that was used to pay the remainder amount.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/remainderMethod#vouchers
+   */
+  remainderMethod: string;
 }
 
 export interface QrCode {


### PR DESCRIPTION
This PR includes a few updates to the types for orders and payments. Most notably, the `payment` field for the order creation parameters is more accurate[[doc]](https://docs.mollie.com/reference/v2/orders-api/create-order#payment-parameters).

Additionally, this PR bumps the version to 3.6.0-beta.2, as I intend to publish immediately (on the _beta_ tag).