### PR TITLE
Change orderLineCategories in the methods binder to an array

### DIFF
--- a/src/binders/methods/parameters.ts
+++ b/src/binders/methods/parameters.ts
@@ -102,7 +102,7 @@ export interface ListParameters {
    *
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods?path=orderLineCategories#parameters
    */
-  orderLineCategories?: string;
+  orderLineCategories?: string[];
   include?: MethodInclude[] | MethodInclude;
   profileId?: string;
   testmode?: boolean;


### PR DESCRIPTION
The Mollie API expects `orderLineCategories` in the list methods endpoint to be [a comma-separated list](https://docs.mollie.com/reference/v2/methods-api/list-methods#parameters). However, an array of strings is the more JavaScript-native type here, and the `NetworkClient` will join it anyway.

This is not a breaking change, as `orderLineCategories` was introduced in #279, which has not yet been released.