### PR TITLE
Fix bug on Node.js < 12

### DIFF
--- a/src/data/Helper.ts
+++ b/src/data/Helper.ts
@@ -1,6 +1,8 @@
 import { inspect, InspectOptionsStylized } from 'util';
 import TransformingNetworkClient from '../communication/TransformingNetworkClient';
+import buildFromEntries from '../plumbing/buildFromEntries';
 import capitalize from '../plumbing/capitalize';
+import getEntries from '../plumbing/getEntries';
 import renege from '../plumbing/renege';
 import Callback from '../types/Callback';
 import Maybe from '../types/Maybe';
@@ -20,7 +22,7 @@ function convertToString(subject: Model<string>, tag: string, depth: number, opt
   if (depth < 0) {
     return options.stylize(`[${parts.join(' ')}]`, 'special');
   }
-  parts.push(inspect(Object.fromEntries(Object.entries(subject).filter(([key]) => stringRepresentationBlacklist.has(key) === false)), { ...options, depth: 1, sorted: true }));
+  parts.push(inspect(buildFromEntries(getEntries<any>(subject).filter(([key]) => stringRepresentationBlacklist.has(key) === false)), { ...options, depth: 1, sorted: true }));
   return parts.join(' ');
 }
 

--- a/tests/unit/inspect.test.ts
+++ b/tests/unit/inspect.test.ts
@@ -1,0 +1,73 @@
+import { inspect } from 'util';
+import wireMockClient from '../wireMockClient';
+
+declare global {
+  namespace jest {
+    interface Matchers<R, T> {
+      toStartWith(expected: string): Promise<CustomMatcherResult>;
+    }
+  }
+}
+
+test('inspect', async () => {
+  const { adapter, client } = wireMockClient();
+
+  expect.extend({
+    async toStartWith(received: string, expected: string): Promise<jest.CustomMatcherResult> {
+      if (received.startsWith(expected)) {
+        return {
+          pass: true,
+          message: () => '',
+        };
+      }
+      return {
+        pass: false,
+        message: () => `String does not start with ${expected}`,
+      };
+    },
+  });
+
+  adapter.onGet('/methods/ideal').reply(200, {
+    resource: 'method',
+    id: 'ideal',
+    description: 'iDEAL',
+    minimumAmount: {
+      value: '0.01',
+      currency: 'EUR',
+    },
+    maximumAmount: {
+      value: '50000.00',
+      currency: 'EUR',
+    },
+    image: {
+      size1x: 'https://www.mollie.com/external/icons/payment-methods/ideal.png',
+      size2x: 'https://www.mollie.com/external/icons/payment-methods/ideal%402x.png',
+      svg: 'https://www.mollie.com/external/icons/payment-methods/ideal.svg',
+    },
+    status: 'activated',
+    pricing: [
+      {
+        description: 'Netherlands',
+        fixed: {
+          value: '0.29',
+          currency: 'EUR',
+        },
+        variable: '0',
+      },
+    ],
+    _links: {
+      self: {
+        href: 'https://api.mollie.com/v2/methods/ideal?include=pricing',
+        type: 'application/hal+json',
+      },
+      documentation: {
+        href: 'https://docs.mollie.com/reference/v2/methods-api/get-method',
+        type: 'text/html',
+      },
+    },
+  });
+
+  const method = await client.methods.get('ideal');
+
+  expect(inspect(method)).toStartWith('Method ideal {');
+});


### PR DESCRIPTION
Inspecting objects (payments, customers, subscriptions, etc.) would throw an error on Node.js < 12, because the `inspect.custom` implementation relied on both `Object.entries` and `Object.fromEntries`.