### PR TITLE
Add profile methods/giftcard issuers/voucher issuers and settlements

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-const nockfulTests = ['iteration', 'paymentLinks'];
+const nockfulTests = ['iteration', 'paymentLinks', 'profiles', 'settlements'];
 
 function createProject(displayName, testRegex, rest) {
   return Object.assign({}, rest, {

--- a/src/binders/profiles/giftcardIssuers/ProfileGiftcardIssuersBinder.ts
+++ b/src/binders/profiles/giftcardIssuers/ProfileGiftcardIssuersBinder.ts
@@ -1,0 +1,50 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import IssuerModel, { IssuerData } from '../../../data/issuer/IssuerModel';
+import ApiError from '../../../errors/ApiError';
+import renege from '../../../plumbing/renege';
+import checkId from '../../../plumbing/checkId';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { Parameters } from './parameters';
+
+function getPathSegments(profileId: string) {
+  return `profiles/${profileId}/methods/giftcard/issuers`;
+}
+
+export default class ProfileGiftcardIssuersBinder extends Binder<IssuerData, IssuerModel> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Enable a gift card issuer on a specific or authenticated profile to use it with payments.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
+   */
+  public enable(parameters: Parameters): Promise<IssuerModel>;
+  public enable(parameters: Parameters, callback: Callback<IssuerModel>): void;
+  public enable(parameters: Parameters) {
+    if (renege(this, this.enable, ...arguments)) return;
+    if (!checkId(parameters.profileId, 'profile')) {
+      throw new ApiError('The profile id is invalid');
+    }
+    return this.networkClient.post(`${getPathSegments(parameters.profileId)}/${parameters.id}`, undefined);
+  }
+
+  /**
+   * Disable a gift card issuer on a specific or authenticated profile.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
+   */
+  public disable(parameters: Parameters): Promise<true>;
+  public disable(parameters: Parameters, callback: Callback<true>): void;
+  public disable(parameters: Parameters) {
+    if (renege(this, this.enable, ...arguments)) return;
+    if (!checkId(parameters.profileId, 'profile')) {
+      throw new ApiError('The profile id is invalid');
+    }
+    return this.networkClient.delete<IssuerData, true>(`${getPathSegments(parameters.profileId)}/${parameters.id}`);
+  }
+}

--- a/src/binders/profiles/giftcardIssuers/parameters.ts
+++ b/src/binders/profiles/giftcardIssuers/parameters.ts
@@ -1,0 +1,10 @@
+export interface Parameters {
+  /**
+   * The ID of the profile, for example `pfl_v9hTwCvYqw`.
+   */
+  profileId: string;
+  /**
+   * The ID of the issuer, for example `festivalcadeau`.
+   */
+  id: string;
+}

--- a/src/binders/profiles/methods/ProfileMethodsBinder.ts
+++ b/src/binders/profiles/methods/ProfileMethodsBinder.ts
@@ -1,0 +1,53 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import { MethodData } from '../../../data/methods/data';
+import Method from '../../../data/methods/Method';
+import ApiError from '../../../errors/ApiError';
+import renege from '../../../plumbing/renege';
+import checkId from '../../../plumbing/checkId';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { Parameters } from './parameters';
+
+function getPathSegments(profileId: string) {
+  return `profiles/${profileId}/methods`;
+}
+
+export default class ProfileMethodsBinder extends Binder<MethodData, Method> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Enable a payment method on a specific or authenticated profile to use it with payments.
+   *
+   * The payment method `vouchers` cannot be enabled via this API. Instead, refer to /reference/v2/profiles-api/enable-voucher-issuer.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-method
+   */
+  public enable(parameters: Parameters): Promise<Method>;
+  public enable(parameters: Parameters, callback: Callback<Method>): void;
+  public enable(parameters: Parameters) {
+    if (renege(this, this.enable, ...arguments)) return;
+    if (!checkId(parameters.profileId, 'profile')) {
+      throw new ApiError('The profile id is invalid');
+    }
+    return this.networkClient.post(`${getPathSegments(parameters.profileId)}/${parameters.id}`, undefined);
+  }
+
+  /**
+   * Disable a payment method on a specific or authenticated profile.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/profiles-api/disable-method
+   */
+  public disable(parameters: Parameters): Promise<true>;
+  public disable(parameters: Parameters, callback: Callback<true>): void;
+  public disable(parameters: Parameters) {
+    if (renege(this, this.disable, ...arguments)) return;
+    if (!checkId(parameters.profileId, 'profile')) {
+      throw new ApiError('The profile id is invalid');
+    }
+    return this.networkClient.delete<MethodData, true>(`${getPathSegments(parameters.profileId)}/${parameters.id}`);
+  }
+}

--- a/src/binders/profiles/methods/parameters.ts
+++ b/src/binders/profiles/methods/parameters.ts
@@ -1,0 +1,12 @@
+import { PaymentMethod } from '../../../types';
+
+export interface Parameters {
+  /**
+   * The ID of the profile, for example `pfl_v9hTwCvYqw`.
+   */
+  profileId: string;
+  /**
+   * The ID of the method, for example `ideal`.
+   */
+  id: `${PaymentMethod}`;
+}

--- a/src/binders/profiles/voucherIssuers/ProfileVoucherIssuersBinder.ts
+++ b/src/binders/profiles/voucherIssuers/ProfileVoucherIssuersBinder.ts
@@ -1,0 +1,51 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import IssuerModel, { IssuerData } from '../../../data/issuer/IssuerModel';
+import ApiError from '../../../errors/ApiError';
+import renege from '../../../plumbing/renege';
+import checkId from '../../../plumbing/checkId';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { CreateParameters, Parameters } from './parameters';
+
+function getPathSegments(profileId: string) {
+  return `profiles/${profileId}/methods/voucher/issuers`;
+}
+
+export default class ProfileVoucherIssuersBinder extends Binder<IssuerData, IssuerModel> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Enable a voucher issuer on a specific or authenticated profile to use it with payments.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer
+   */
+  public enable(parameters: CreateParameters): Promise<IssuerModel>;
+  public enable(parameters: CreateParameters, callback: Callback<IssuerModel>): void;
+  public enable(parameters: CreateParameters) {
+    if (renege(this, this.enable, ...arguments)) return;
+    const { profileId, id, ...data } = parameters;
+    if (!checkId(profileId, 'profile')) {
+      throw new ApiError('The profile id is invalid');
+    }
+    return this.networkClient.post(`${getPathSegments(profileId)}/${id}`, data);
+  }
+
+  /**
+   * Disable a voucher issuer on a specific or authenticated profile.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/profiles-api/disable-voucher-issuer
+   */
+  public disable(parameters: Parameters): Promise<true>;
+  public disable(parameters: Parameters, callback: Callback<true>): void;
+  public disable(parameters: Parameters) {
+    if (renege(this, this.disable, ...arguments)) return;
+    if (!checkId(parameters.profileId, 'profile')) {
+      throw new ApiError('The profile id is invalid');
+    }
+    return this.networkClient.delete<IssuerData, true>(`${getPathSegments(parameters.profileId)}/${parameters.id}`);
+  }
+}

--- a/src/binders/profiles/voucherIssuers/parameters.ts
+++ b/src/binders/profiles/voucherIssuers/parameters.ts
@@ -1,0 +1,21 @@
+export interface Parameters {
+  /**
+   * The ID of the profile, for example `pfl_v9hTwCvYqw`.
+   */
+  profileId: string;
+  /**
+   * The ID of the issuer, for example `appetiz`.
+   */
+  id: string;
+}
+
+export type CreateParameters = Pick<Parameters, 'profileId' | 'id'> & {
+  /**
+   * The contract id of the related contractor. Please note, for the first call that will be made to an issuer of the contractor, this field is required. You do not have to provide the same contract
+   * id for other issuers of the same contractor. Update of the contract id will be possible through making the same call again with different contract ID value until the contract id is approved by
+   * the contractor.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer?path=contractId#parameters
+   */
+  contractId?: string;
+};

--- a/src/binders/settlements/SettlementsBinder.ts
+++ b/src/binders/settlements/SettlementsBinder.ts
@@ -1,0 +1,85 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import List from '../../data/list/List';
+import { SettlementData } from '../../data/settlements/data';
+import SettlementModel from '../../data/settlements/SettlementModel';
+import renege from '../../plumbing/renege';
+import Callback from '../../types/Callback';
+import Binder from '../Binder';
+import { IterateParameters, ListParameters } from './parameters';
+
+const pathSegment = 'settlements';
+
+export default class SettlementsBinder extends Binder<SettlementData, SettlementModel> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Successful payments, together with refunds, captures and chargebacks are collected into *settlements*, which are then paid out according to your organization's payout schedule. By retrieving a
+   * single settlement, you can check which payments were paid out with it, when the settlement took place, and what invoices were created to invoice the costs in the settlement.
+   *
+   * Beside payments, settlements can be composed of other entities such as refunds, chargebacks or captures.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement
+   */
+  public get(id: string): Promise<SettlementModel>;
+  public get(id: string, callback: Callback<SettlementModel>): void;
+  public get(id: string) {
+    if (renege(this, this.get, ...arguments)) return;
+    // Don't check the ID, as the ID can be the bank reference.
+    return this.networkClient.get<SettlementData, SettlementModel>(`${pathSegment}/${id}`);
+  }
+
+  /**
+   * Retrieve the details of the current settlement that has not yet been paid out.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement
+   */
+  public getNext(): Promise<SettlementModel>;
+  public getNext(callback: Callback<SettlementModel>): void;
+  public getNext() {
+    if (renege(this, this.getNext, ...arguments)) return;
+    return this.networkClient.get<SettlementData, SettlementModel>(`${pathSegment}/next`);
+  }
+
+  /**
+   * Retrieve the details of the open balance of the organization. This will return a settlement object representing your organization's balance.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-open-settlement
+   */
+  public getOpen(): Promise<SettlementModel>;
+  public getOpen(callback: Callback<SettlementModel>): void;
+  public getOpen() {
+    if (renege(this, this.getOpen, ...arguments)) return;
+    return this.networkClient.get<SettlementData, SettlementModel>(`${pathSegment}/open`);
+  }
+
+  /**
+   * Retrieve all payments links created with the current website profile, ordered from newest to oldest.
+   *
+   * The results are paginated. See pagination for more information.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
+   */
+  public page(parameters?: ListParameters): Promise<List<SettlementModel>>;
+  public page(parameters: ListParameters, callback: Callback<List<SettlementModel>>): void;
+  public page(parameters: ListParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.list<SettlementData, SettlementModel>(pathSegment, 'settlements', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve a single payment link object by its token.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+   */
+  public iterate(parameters?: IterateParameters) {
+    const { valuesPerMinute, ...query } = parameters ?? {};
+    return this.networkClient.iterate<SettlementData, SettlementModel>(pathSegment, 'settlements', query, valuesPerMinute);
+  }
+}

--- a/src/binders/settlements/captures/SettlementCapturesBinder.ts
+++ b/src/binders/settlements/captures/SettlementCapturesBinder.ts
@@ -1,0 +1,49 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import List from '../../../data/list/List';
+import Capture from '../../../data/payments/captures/Capture';
+import { CaptureData } from '../../../data/payments/captures/data';
+import renege from '../../../plumbing/renege';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { IterateParameters, ListParameters } from './parameters';
+
+export function getPathSegments(settlementId: string) {
+  return `settlements/${settlementId}/captures`;
+}
+
+export default class SettlementCapturesBinder extends Binder<CaptureData, Capture> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Retrieve all captures in a certain settlement.
+   *
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
+   * it*. Captures are created when (part of) an Order is shipped. The capture is then settled to the merchant.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
+   */
+  public page(parameters: ListParameters): Promise<List<Capture>>;
+  public page(parameters: ListParameters, callback: Callback<List<Capture>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
+    const { settlementId, ...query } = parameters;
+    return this.networkClient.list<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve all captures in a certain settlement.
+   *
+   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
+   * it*. Captures are created when (part of) an Order is shipped. The capture is then settled to the merchant.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
+   */
+  public iterate(parameters: IterateParameters) {
+    const { settlementId, valuesPerMinute, ...query } = parameters;
+    return this.networkClient.iterate<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query, valuesPerMinute);
+  }
+}

--- a/src/binders/settlements/captures/parameters.ts
+++ b/src/binders/settlements/captures/parameters.ts
@@ -1,0 +1,8 @@
+import { ThrottlingParameters } from '../../../types/parameters';
+import { ListParameters as CaptureListParameters } from '../../payments/captures/parameters';
+
+export type ListParameters = Omit<CaptureListParameters, 'paymentId'> & {
+  settlementId: string;
+};
+
+export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameters;

--- a/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
+++ b/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
@@ -1,0 +1,42 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import Chargeback, { ChargebackData } from '../../../data/chargebacks/Chargeback';
+import List from '../../../data/list/List';
+import renege from '../../../plumbing/renege';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { IterateParameters, ListParameters } from './parameters';
+
+export function getPathSegments(settlementId: string) {
+  return `settlements/${settlementId}/chargebacks`;
+}
+
+export default class SettlementChargebacksBinder extends Binder<ChargebackData, Chargeback> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Retrieve all chargebacks included in a settlement.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
+   */
+  public page(parameters: ListParameters): Promise<List<Chargeback>>;
+  public page(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
+    const { settlementId, ...query } = parameters;
+    return this.networkClient.list<ChargebackData, Chargeback>(getPathSegments(settlementId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve all chargebacks included in a settlement.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
+   */
+  public iterate(parameters: IterateParameters) {
+    const { settlementId, valuesPerMinute, ...query } = parameters;
+    return this.networkClient.iterate<ChargebackData, Chargeback>(getPathSegments(settlementId), 'chargebacks', query, valuesPerMinute);
+  }
+}

--- a/src/binders/settlements/chargebacks/parameters.ts
+++ b/src/binders/settlements/chargebacks/parameters.ts
@@ -1,0 +1,8 @@
+import { ThrottlingParameters } from '../../../types/parameters';
+import { ListParameters as ChargebacksListParameters } from '../../chargebacks/parameters';
+
+export type ListParameters = ChargebacksListParameters & {
+  settlementId: string;
+};
+
+export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameters;

--- a/src/binders/settlements/parameters.ts
+++ b/src/binders/settlements/parameters.ts
@@ -1,0 +1,5 @@
+import { PaginationParameters, ThrottlingParameters } from '../../types/parameters';
+
+export type ListParameters = PaginationParameters;
+
+export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameters;

--- a/src/binders/settlements/payments/SettlementPaymentsBinder.ts
+++ b/src/binders/settlements/payments/SettlementPaymentsBinder.ts
@@ -1,0 +1,47 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import List from '../../../data/list/List';
+import { PaymentData } from '../../../data/payments/data';
+import Payment from '../../../data/payments/Payment';
+import renege from '../../../plumbing/renege';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { IterateParameters, ListParameters } from './parameters';
+
+export function getPathSegments(settlementId: string) {
+  return `settlements/${settlementId}/payments`;
+}
+
+export default class SettlementPaymentsBinder extends Binder<PaymentData, Payment> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Retrieve all Payments included in a Settlement.
+   *
+   * Note that payments for Klarna payment methods are not listed in here. These payment methods are settled using captures. To retrieve the captures, use the List settlement captures endpoint.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
+   */
+  public page(parameters: ListParameters): Promise<List<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
+    const { settlementId, ...query } = parameters;
+    return this.networkClient.list<PaymentData, Payment>(getPathSegments(settlementId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve all Payments included in a Settlement.
+   *
+   * Note that payments for Klarna payment methods are not listed in here. These payment methods are settled using captures. To retrieve the captures, use the List settlement captures endpoint.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
+   */
+  public iterate(parameters: IterateParameters) {
+    const { settlementId, valuesPerMinute, ...query } = parameters;
+    return this.networkClient.iterate<PaymentData, Payment>(getPathSegments(settlementId), 'payments', query, valuesPerMinute);
+  }
+}

--- a/src/binders/settlements/payments/parameters.ts
+++ b/src/binders/settlements/payments/parameters.ts
@@ -1,0 +1,8 @@
+import { ThrottlingParameters } from '../../../types/parameters';
+import { ListParameters as PaymentListParameters } from '../../payments/parameters';
+
+export type ListParameters = PaymentListParameters & {
+  settlementId: string;
+};
+
+export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameters;

--- a/src/binders/settlements/refunds/SettlementRefundsBinder.ts
+++ b/src/binders/settlements/refunds/SettlementRefundsBinder.ts
@@ -1,0 +1,43 @@
+import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import List from '../../../data/list/List';
+import { RefundData } from '../../../data/refunds/data';
+import Refund from '../../../data/refunds/Refund';
+import renege from '../../../plumbing/renege';
+import Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { IterateParameters, ListParameters } from './parameters';
+
+export function getPathSegments(settlementId: string) {
+  return `settlements/${settlementId}/refunds`;
+}
+
+export default class SettlementRefundsBinder extends Binder<RefundData, Refund> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Retrieve all refunds included in a settlement.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
+   */
+  public page(parameters: ListParameters): Promise<List<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters) {
+    if (renege(this, this.page, ...arguments)) return;
+    const { settlementId, ...query } = parameters;
+    return this.networkClient.list<RefundData, Refund>(getPathSegments(settlementId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve all refunds included in a settlement.
+   *
+   * @since 3.7.0
+   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
+   */
+  public iterate(parameters: IterateParameters) {
+    const { settlementId, valuesPerMinute, ...query } = parameters;
+    return this.networkClient.iterate<RefundData, Refund>(getPathSegments(settlementId), 'refunds', query, valuesPerMinute);
+  }
+}

--- a/src/binders/settlements/refunds/parameters.ts
+++ b/src/binders/settlements/refunds/parameters.ts
@@ -1,0 +1,8 @@
+import { ThrottlingParameters } from '../../../types/parameters';
+import { ListParameters as RefundsListParameters } from '../../refunds/parameters';
+
+export type ListParameters = RefundsListParameters & {
+  settlementId: string;
+};
+
+export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameters;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -22,6 +22,8 @@ import { transform as transformOrganization } from './data/organizations/Organiz
 import { transform as transformProfile } from './data/profiles/Profile';
 import { transform as transformOnboarding } from './data/onboarding/Onboarding';
 import { transform as transformPaymentLink } from './data/paymentLinks/PaymentLink';
+import { transform as transformIssuer } from './data/issuer/IssuerModel';
+import { transform as transformSettlement } from './data/settlements/SettlementModel';
 
 // Binders
 import ApplePayBinder from './binders/applePay/ApplePayBinder';
@@ -45,7 +47,15 @@ import PaymentRefundsBinder from './binders/payments/refunds/PaymentRefundsBinde
 import PaymentsBinder from './binders/payments/PaymentsBinder';
 import PermissionsBinder from './binders/permissions/PermissionsBinder';
 import ProfilesBinder from './binders/profiles/ProfilesBinder';
+import ProfileMethodsBinder from './binders/profiles/methods/ProfileMethodsBinder';
+import ProfileGiftcardIssuersBinder from './binders/profiles/giftcardIssuers/ProfileGiftcardIssuersBinder';
+import ProfileVoucherIssuersBinder from './binders/profiles/voucherIssuers/ProfileVoucherIssuersBinder';
 import RefundsBinder from './binders/refunds/RefundsBinder';
+import SettlementPaymentsBinder from './binders/settlements/payments/SettlementPaymentsBinder';
+import SettlementCapturesBinder from './binders/settlements/captures/SettlementCapturesBinder';
+import SettlementRefundsBinder from './binders/settlements/refunds/SettlementRefundsBinder';
+import SettlementChargebacksBinder from './binders/settlements/chargebacks/SettlementChargebacksBinder';
+import SettlementsBinder from './binders/settlements/SettlementsBinder';
 import SubscriptionsBinder from './binders/subscriptions/SubscriptionsBinder';
 import SubscriptionPaymentsBinder from './binders/subscriptions/payments/SubscriptionPaymentsBinder';
 
@@ -91,7 +101,9 @@ export default function createMollieClient(options: Options) {
       .add('organization', transformOrganization)
       .add('profile', transformProfile)
       .add('onboarding', transformOnboarding)
-      .add('payment-link', transformPaymentLink),
+      .add('payment-link', transformPaymentLink)
+      .add('issuer', transformIssuer)
+      .add('settlement', transformSettlement),
   );
 
   return {
@@ -141,6 +153,9 @@ export default function createMollieClient(options: Options) {
 
     // Profiles.
     profiles: new ProfilesBinder(transformingNetworkClient),
+    profileMethods: new ProfileMethodsBinder(transformingNetworkClient),
+    profileGiftcardIssuers: new ProfileGiftcardIssuersBinder(transformingNetworkClient),
+    profileVoucherIssuers: new ProfileVoucherIssuersBinder(transformingNetworkClient),
 
     // Onboarding.
     onboarding: new OnboardingBinder(transformingNetworkClient),
@@ -150,6 +165,13 @@ export default function createMollieClient(options: Options) {
 
     // Payment links.
     paymentLinks: new PaymentLinksBinder(transformingNetworkClient),
+
+    // Settlements
+    settlements: new SettlementsBinder(transformingNetworkClient),
+    settlementPayments: new SettlementPaymentsBinder(transformingNetworkClient),
+    settlementCaptures: new SettlementCapturesBinder(transformingNetworkClient),
+    settlementRefunds: new SettlementRefundsBinder(transformingNetworkClient),
+    settlementChargebacks: new SettlementChargebacksBinder(transformingNetworkClient),
   };
 }
 

--- a/src/data/issuer/IssuerModel.ts
+++ b/src/data/issuer/IssuerModel.ts
@@ -1,0 +1,38 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import Seal from '../../types/Seal';
+import { Links } from '../global';
+import Helper from '../Helper';
+import Model from '../Model';
+
+export interface IssuerData extends Model<'issuer'> {
+  /**
+   * The full name of the gift card or voucher issuer.
+   */
+  description: string;
+  /**
+   * The status that the issuer is in.
+   *
+   * Possible values:
+   *
+   * -   `activated`: The issuer is activated and ready for use.
+   * -   `pending-issuer`: Activation of this issuer relies on you taking action with the issuer itself.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer?path=status#response
+   */
+  status: 'activated' | 'pending-issuer';
+  /**
+   * An object with contractor information.
+   *
+   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer?path=contractor#response
+   */
+  contractor?: { id: string; name: string; contractId: string };
+  _links: Links;
+}
+
+type IssuerModel = Seal<IssuerData, Helper<IssuerData, IssuerModel>>;
+
+export default IssuerModel;
+
+export function transform(networkClient: TransformingNetworkClient, input: IssuerData): IssuerModel {
+  return Object.assign(Object.create(new Helper<IssuerData, IssuerModel>(networkClient, input._links)), input);
+}

--- a/src/data/settlements/SettlementHelper.ts
+++ b/src/data/settlements/SettlementHelper.ts
@@ -1,0 +1,54 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import { Capture } from '../../types';
+import { ThrottlingParameters } from '../../types/parameters';
+import Chargeback, { ChargebackData } from '../chargebacks/Chargeback';
+import Helper from '../Helper';
+import { CaptureData } from '../payments/captures/data';
+import { PaymentData } from '../payments/data';
+import Payment from '../payments/Payment';
+import { RefundData } from '../refunds/data';
+import Refund from '../refunds/Refund';
+import { SettlementData } from './data';
+import SettlementModel from './SettlementModel';
+
+export default class SettlementHelper extends Helper<SettlementData, SettlementModel> {
+  constructor(networkClient: TransformingNetworkClient, protected readonly links: SettlementData['_links']) {
+    super(networkClient, links);
+  }
+
+  /**
+   * Returns the payments that are included in this settlement.
+   *
+   * @since 3.7.0
+   */
+  public getPayments(parameters?: ThrottlingParameters) {
+    return this.networkClient.iterate<PaymentData, Payment>(this.links.payments.href, 'payments', undefined, parameters?.valuesPerMinute);
+  }
+
+  /**
+   * Returns the refunds that are included in this settlement.
+   *
+   * @since 3.7.0
+   */
+  public getRefunds(parameters?: ThrottlingParameters) {
+    return this.networkClient.iterate<RefundData, Refund>(this.links.refunds.href, 'refunds', undefined, parameters?.valuesPerMinute);
+  }
+
+  /**
+   * Returns the chargebacks that are included in this settlement.
+   *
+   * @since 3.7.0
+   */
+  public getChargebacks(parameters?: ThrottlingParameters) {
+    return this.networkClient.iterate<ChargebackData, Chargeback>(this.links.chargebacks.href, 'chargebacks', undefined, parameters?.valuesPerMinute);
+  }
+
+  /**
+   * Returns the captures that are included in this settlement.
+   *
+   * @since 3.7.0
+   */
+  public getCaptures(parameters?: ThrottlingParameters) {
+    return this.networkClient.iterate<CaptureData, Capture>(this.links.captures.href, 'captures', undefined, parameters?.valuesPerMinute);
+  }
+}

--- a/src/data/settlements/SettlementModel.ts
+++ b/src/data/settlements/SettlementModel.ts
@@ -1,0 +1,12 @@
+import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import Seal from '../../types/Seal';
+import { SettlementData } from './data';
+import SettlementHelper from './SettlementHelper';
+
+type SettlementModel = Seal<Omit<SettlementData, '_links'>, SettlementHelper>;
+
+export default SettlementModel;
+
+export function transform(networkClient: TransformingNetworkClient, input: SettlementData): SettlementModel {
+  return Object.assign(Object.create(new SettlementHelper(networkClient, input._links)), input);
+}

--- a/src/data/settlements/data.ts
+++ b/src/data/settlements/data.ts
@@ -1,0 +1,111 @@
+import Nullable from '../../types/Nullable';
+import { Amount, Links, Url } from '../global';
+import Model from '../Model';
+
+export interface SettlementData extends Model<'settlement'> {
+  /**
+   * The settlement's bank reference, as found in your Mollie account and on your bank statement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=reference#response
+   */
+  reference: string;
+  /**
+   * The date on which the settlement was created, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=createdAt#response
+   */
+  createdAt: string;
+  /**
+   * The date on which the settlement was settled, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. When requesting the open settlement or next settlement the return value is `null`.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=settledAt#response
+   */
+  settledAt: Nullable<string>;
+  /**
+   * The status of the settlement.
+   *
+   * Possible values:
+   *
+   * -   `open` The settlement has not been closed yet.
+   * -   `pending` The settlement has been closed and is being processed.
+   * -   `paidout` The settlement has been paid out.
+   * -   `failed` The settlement could not be paid out.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=status#response
+   */
+  status: 'open' | 'pending' | 'paidout' | 'failed';
+  /**
+   * The total amount paid out with this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=amount#response
+   */
+  amount: Amount;
+  /**
+   * The total amount paid out with this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=amount#response
+   */
+  periods: Record<string, Record<string, Period>>;
+  /**
+   * An object with several URL objects relevant to the settlement. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links#response
+   */
+  _links: SettlementLinks;
+}
+
+interface Period {
+  /**
+   * An array of revenue objects containing the total revenue for each payment method during this period. Each object has the following fields.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=periods/revenue#response
+   */
+  revenue: Array<{ description: string; method: string; count: number; amountNet: Amount; amountVat: Amount; amountGross: Amount }>;
+  /**
+   * An array of Cost objects, describing the fees withheld for each payment method during this period. Each object has the following fields.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=periods/costs#response
+   */
+  costs: Array<{ description: string; method: string; count: number; rate: { fixed: Amount; variable: string }; amountNet: Amount; amountVat: Amount; amountGross: Amount }>;
+  /**
+   * The ID of the invoice that was created to invoice specifically the costs in this month/period.
+   *
+   * If an individual month/period has not been invoiced yet, then this field will not be present until that invoice is created.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=periods/invoiceId#response
+   */
+  invoiceId: string;
+}
+
+interface SettlementLinks extends Links {
+  /**
+   * The API resource URL of the payments that are included in this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/payments#response
+   */
+  payments: Url;
+  /**
+   * The API resource URL of the refunds that are included in this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/refunds#response
+   */
+  refunds: Url;
+  /**
+   * The API resource URL of the chargebacks that are included in this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/chargebacks#response
+   */
+  chargebacks: Url;
+  /**
+   * The API resource URL of the captures that are included in this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/captures#response
+   */
+  captures: Url;
+  /**
+   * The API resource URL of the invoice that contains this settlement.
+   *
+   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/invoice#response
+   */
+  invoice: Url;
+}

--- a/tests/__nock-fixtures__/profiles.json
+++ b/tests/__nock-fixtures__/profiles.json
@@ -1,0 +1,352 @@
+[
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "POST",
+        "path": "/v2/profiles",
+        "body": {
+            "name": "Iteration test profile",
+            "email": "example@example.org",
+            "phone": "+31208202070",
+            "website": "https://example.org",
+            "mode": "test"
+        },
+        "status": 201,
+        "response": {
+            "resource": "profile",
+            "id": "pfl_XjBqKLWD7q",
+            "mode": "test",
+            "name": "Iteration test profile",
+            "website": "https://example.org",
+            "email": "example@example.org",
+            "phone": "+31208202070",
+            "categoryCode": 0,
+            "businessCategory": null,
+            "status": "unverified",
+            "createdAt": "2022-08-04T10:53:31+00:00",
+            "_links": {
+                "self": {
+                    "href": "https://api.mollie.com/v2/profiles/pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "dashboard": {
+                    "href": "https://www.mollie.com/dashboard/org_6227451/settings/profiles/pfl_XjBqKLWD7q",
+                    "type": "text/html"
+                },
+                "chargebacks": {
+                    "href": "https://api.mollie.com/v2/chargebacks?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "methods": {
+                    "href": "https://api.mollie.com/v2/methods?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "payments": {
+                    "href": "https://api.mollie.com/v2/payments?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "refunds": {
+                    "href": "https://api.mollie.com/v2/refunds?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "checkoutPreviewUrl": {
+                    "href": "https://www.mollie.com/checkout/preview/pfl_XjBqKLWD7q",
+                    "type": "text/html"
+                },
+                "documentation": {
+                    "href": "https://docs.mollie.com/reference/v2/profiles-api/create-profile",
+                    "type": "text/html"
+                }
+            }
+        },
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:31 GMT",
+            "Content-Type",
+            "application/hal+json",
+            "Content-Length",
+            "1174",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "PATCH",
+        "path": "/v2/profiles/pfl_XjBqKLWD7q",
+        "body": {
+            "businessCategory": "RESTAURANTS_NIGHTLIFE"
+        },
+        "status": 200,
+        "response": {
+            "resource": "profile",
+            "id": "pfl_XjBqKLWD7q",
+            "mode": "live",
+            "name": "Iteration test profile",
+            "website": "https://example.org",
+            "email": "example@example.org",
+            "phone": "+31208202070",
+            "categoryCode": 0,
+            "businessCategory": "RESTAURANTS_NIGHTLIFE",
+            "status": "unverified",
+            "createdAt": "2022-08-04T10:53:31+00:00",
+            "review": {
+                "status": "pending"
+            },
+            "_links": {
+                "self": {
+                    "href": "https://api.mollie.com/v2/profiles/pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "dashboard": {
+                    "href": "https://www.mollie.com/dashboard/org_6227451/settings/profiles/pfl_XjBqKLWD7q",
+                    "type": "text/html"
+                },
+                "chargebacks": {
+                    "href": "https://api.mollie.com/v2/chargebacks?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "methods": {
+                    "href": "https://api.mollie.com/v2/methods?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "payments": {
+                    "href": "https://api.mollie.com/v2/payments?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "refunds": {
+                    "href": "https://api.mollie.com/v2/refunds?profileId=pfl_XjBqKLWD7q",
+                    "type": "application/hal+json"
+                },
+                "checkoutPreviewUrl": {
+                    "href": "https://www.mollie.com/checkout/preview/pfl_XjBqKLWD7q",
+                    "type": "text/html"
+                },
+                "documentation": {
+                    "href": "https://docs.mollie.com/reference/v2/profiles-api/update-profile",
+                    "type": "text/html"
+                }
+            }
+        },
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:32 GMT",
+            "Content-Type",
+            "application/hal+json",
+            "Content-Length",
+            "1223",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "POST",
+        "path": "/v2/profiles/pfl_XjBqKLWD7q/methods/giftcard/issuers/festivalcadeau",
+        "body": "",
+        "status": 201,
+        "response": {
+            "resource": "issuer",
+            "id": "festivalcadeau",
+            "description": "FestivalCadeau Giftcard",
+            "status": "pending-issuer",
+            "_links": {
+                "self": {
+                    "href": "https://api.mollie.com/v2/issuer/festivalcadeau",
+                    "type": "application/hal+json"
+                },
+                "documentation": {
+                    "href": "https://docs.mollie.com/reference/v2/profiles-api/enable-giftcard-issuer",
+                    "type": "text/html"
+                }
+            }
+        },
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:32 GMT",
+            "Content-Type",
+            "application/hal+json",
+            "Content-Length",
+            "335",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "DELETE",
+        "path": "/v2/profiles/pfl_XjBqKLWD7q/methods/giftcard/issuers/festivalcadeau",
+        "body": "",
+        "status": 204,
+        "response": "",
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:32 GMT",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "POST",
+        "path": "/v2/profiles/pfl_XjBqKLWD7q/methods/voucher/issuers/appetiz",
+        "body": {
+            "contractId": "test_contract_id"
+        },
+        "status": 201,
+        "response": {
+            "resource": "issuer",
+            "id": "appetiz",
+            "name": "Appetiz",
+            "image": {
+                "size1x": "https://www.mollie.com/external/icons/voucher-issuers/appetiz.png",
+                "size2x": "https://www.mollie.com/external/icons/voucher-issuers/appetiz%402x.png",
+                "svg": "https://www.mollie.com/external/icons/voucher-issuers/appetiz.svg"
+            },
+            "status": "pending-issuer",
+            "contractor": {
+                "id": "Conecs",
+                "name": "Conecs",
+                "contractId": "test_contract_id"
+            },
+            "_links": {
+                "self": {
+                    "href": "https://api.mollie.com/v2/issuers/appetiz",
+                    "type": "application/hal+json"
+                },
+                "documentation": {
+                    "href": "https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer",
+                    "type": "text/html"
+                }
+            }
+        },
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:33 GMT",
+            "Content-Type",
+            "application/hal+json",
+            "Content-Length",
+            "618",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "DELETE",
+        "path": "/v2/profiles/pfl_XjBqKLWD7q/methods/voucher/issuers/appetiz",
+        "body": "",
+        "status": 204,
+        "response": "",
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:33 GMT",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://api.mollie.com:443",
+        "method": "DELETE",
+        "path": "/v2/profiles/pfl_XjBqKLWD7q",
+        "body": "",
+        "status": 204,
+        "response": "",
+        "rawHeaders": [
+            "Server",
+            "nginx",
+            "Date",
+            "Thu, 04 Aug 2022 10:53:33 GMT",
+            "X-Robots-Tag",
+            "noindex",
+            "X-XSS-Protection",
+            "1; mode=block",
+            "Via",
+            "1.1 google",
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains; preload",
+            "Alt-Svc",
+            "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    }
+]

--- a/tests/getHead.ts
+++ b/tests/getHead.ts
@@ -1,0 +1,34 @@
+/**
+ * Returns whether the passed input is thenable (`true`) or not (`false`).
+ */
+function checkThenable(input: any): input is Promise<any> {
+  try {
+    var { then } = input;
+  } catch (error) {
+    return false;
+  }
+  return 'function' == typeof then;
+}
+
+/**
+ * Returns the first:
+ *  * element of the array to which the passed promise resolves, or
+ *  * value produced by the passed async iterator.
+ */
+export default function getHead<T>(sequence: Promise<Array<T>> | AsyncIterator<T>) {
+  if (checkThenable(sequence)) {
+    return sequence.then(array => {
+      if (array.length == 0) {
+        throw new Error('The array to which this promise resolved is empty');
+      }
+      return array[0];
+    });
+  } /* if (checkThenable(sequence) == false) */ else {
+    return sequence.next().then(({ done, value }) => {
+      if (done) {
+        throw new Error('The passed iterator produced no values');
+      }
+      return value as T;
+    });
+  }
+}

--- a/tests/iteration/iteration.test.ts
+++ b/tests/iteration/iteration.test.ts
@@ -1,13 +1,12 @@
 import { ApiMode, MollieClient, Payment, PaymentMethod } from '../..';
-import axios from 'axios';
-import NetworkMocker, { getAccessTokenClientMode, record, replay } from '../NetworkMocker';
+import NetworkMocker, { getAccessTokenClientProvider } from '../NetworkMocker';
 
-// false ‒ This test interacts with the real Mollie API over the network, and records the communication.
-// true  ‒ This test uses existing recordings to simulate the network.
-const mockNetwork = true;
+// 'record' ‒ This test interacts with the real Mollie API over the network, and records the communication.
+// 'replay' ‒ This test uses existing recordings to simulate the network.
+const networkMode = 'replay';
 
 describe('iteration', () => {
-  const networkMocker = new NetworkMocker((mockNetwork ? replay : record)(getAccessTokenClientMode, 'iteration'));
+  const networkMocker = new NetworkMocker.Auto(networkMode, getAccessTokenClientProvider, 'iteration');
   let mollieClient: MollieClient;
   let profileId: string;
 
@@ -23,10 +22,8 @@ describe('iteration', () => {
         mode: ApiMode.test,
       })
     ).id;
-    // Enable iDEAL for the test profile. TODO (implement and) use the library API for this.
-    await axios.post(`https://api.mollie.com/v2/profiles/${profileId}/methods/${PaymentMethod.ideal}`, undefined, {
-      headers: { Authorization: `Bearer ${(mollieClient as { accessToken?: string }).accessToken}` },
-    });
+    // Enable iDEAL for the test profile.
+    await mollieClient.profileMethods.enable({ profileId, id: PaymentMethod.ideal });
     // Create some payments.
     await [
       ['for book #1', '20.00'],

--- a/tests/paymentLinks/paymentLinks.test.ts
+++ b/tests/paymentLinks/paymentLinks.test.ts
@@ -1,12 +1,12 @@
-import { MollieClient } from '../../dist/types/src/types';
-import NetworkMocker, { getAccessTokenClientMode, record, replay } from '../NetworkMocker';
+import { MollieClient } from '../..';
+import NetworkMocker, { getAccessTokenClientProvider } from '../NetworkMocker';
 
-// false ‒ This test interacts with the real Mollie API over the network, and records the communication.
-// true  ‒ This test uses existing recordings to simulate the network.
-const mockNetwork = true;
+// 'record' ‒ This test interacts with the real Mollie API over the network, and records the communication.
+// 'replay' ‒ This test uses existing recordings to simulate the network.
+const networkMode = 'replay';
 
 describe('paymentLinks', () => {
-  const networkMocker = new NetworkMocker((mockNetwork ? replay : record)(getAccessTokenClientMode, 'paymentLinks'));
+  const networkMocker = new NetworkMocker.Auto(networkMode, getAccessTokenClientProvider, 'paymentLinks');
   let mollieClient: MollieClient;
 
   beforeAll(async () => {

--- a/tests/profiles/profiles.test.ts
+++ b/tests/profiles/profiles.test.ts
@@ -1,0 +1,33 @@
+import { ApiMode, MollieClient } from '../..';
+import NetworkMocker, { getAccessTokenClientProvider } from '../NetworkMocker';
+
+// 'record' ‒ This test interacts with the real Mollie API over the network, and records the communication.
+// 'replay' ‒ This test uses existing recordings to simulate the network.
+const networkMode = 'replay';
+
+test('profiles', async () => {
+  const networkMocker = new NetworkMocker.Auto(networkMode, getAccessTokenClientProvider, 'profiles');
+  const mollieClient = await networkMocker.prepare();
+
+  // Create the profile.
+  let profile = await mollieClient.profiles.create({
+    name: 'Iteration test profile',
+    email: 'example@example.org',
+    phone: '+31208202070',
+    website: 'https://example.org',
+    mode: ApiMode.test,
+  });
+  // Update the profile.
+  profile = await mollieClient.profiles.update(profile.id, { businessCategory: 'RESTAURANTS_NIGHTLIFE' });
+  expect(profile.businessCategory).toBe('RESTAURANTS_NIGHTLIFE');
+  // Enable and disable giftcard issuer.
+  const giftcardIssuer = await mollieClient.profileGiftcardIssuers.enable({ profileId: profile.id, id: 'festivalcadeau' });
+  await mollieClient.profileGiftcardIssuers.disable({ profileId: profile.id, id: giftcardIssuer.id });
+  // Enable and disable voucher issuer.
+  const voucherIssuer = await mollieClient.profileVoucherIssuers.enable({ profileId: profile.id, id: 'appetiz', contractId: 'test_contract_id' });
+  await mollieClient.profileVoucherIssuers.disable({ profileId: profile.id, id: voucherIssuer.id });
+  // Delete the profile.
+  expect(await mollieClient.profiles.delete(profile.id)).toBe(true);
+
+  networkMocker.cleanup();
+});

--- a/tests/settlements/settlements.test.ts
+++ b/tests/settlements/settlements.test.ts
@@ -1,0 +1,414 @@
+import { MollieClient } from '../..';
+import getHead from '../getHead';
+import NetworkMocker, { getAccessTokenClientProvider } from '../NetworkMocker';
+
+// Note that ‒ as the test suite cannot create settlements ‒ specific settlements are expected to be in place.
+describe('settlements', () => {
+  const networkMocker = new NetworkMocker(getAccessTokenClientProvider(true));
+  let mollieClient: MollieClient;
+
+  beforeAll(async () => {
+    mollieClient = await networkMocker.prepare();
+
+    networkMocker
+      .intercept(/\/settlements\/(stl_jDk30akdN|1234567\.1804\.03)$/, 'GET')
+      .reply(200, {
+        resource: 'settlement',
+        id: 'stl_jDk30akdN',
+        reference: '1234567.1804.03',
+        createdAt: '2018-04-06T06:00:01.0Z',
+        settledAt: '2018-04-06T09:41:44.0Z',
+        status: 'paidout',
+        amount: {
+          value: '39.75',
+          currency: 'EUR',
+        },
+        periods: {
+          '2018': {
+            '04': {
+              revenue: [
+                {
+                  description: 'iDEAL',
+                  method: 'ideal',
+                  count: 6,
+                  amountNet: {
+                    value: '86.1000',
+                    currency: 'EUR',
+                  },
+                  amountVat: null,
+                  amountGross: {
+                    value: '86.1000',
+                    currency: 'EUR',
+                  },
+                },
+                {
+                  description: 'Refunds iDEAL',
+                  method: 'refund',
+                  count: 2,
+                  amountNet: {
+                    value: '-43.2000',
+                    currency: 'EUR',
+                  },
+                  amountVat: null,
+                  amountGross: {
+                    value: '43.2000',
+                    currency: 'EUR',
+                  },
+                },
+              ],
+              costs: [
+                {
+                  description: 'iDEAL',
+                  method: 'ideal',
+                  count: 6,
+                  rate: {
+                    fixed: {
+                      value: '0.3500',
+                      currency: 'EUR',
+                    },
+                    percentage: null,
+                  },
+                  amountNet: {
+                    value: '2.1000',
+                    currency: 'EUR',
+                  },
+                  amountVat: {
+                    value: '0.4410',
+                    currency: 'EUR',
+                  },
+                  amountGross: {
+                    value: '2.5410',
+                    currency: 'EUR',
+                  },
+                },
+                {
+                  description: 'Refunds iDEAL',
+                  method: 'refund',
+                  count: 2,
+                  rate: {
+                    fixed: {
+                      value: '0.2500',
+                      currency: 'EUR',
+                    },
+                    percentage: null,
+                  },
+                  amountNet: {
+                    value: '0.5000',
+                    currency: 'EUR',
+                  },
+                  amountVat: {
+                    value: '0.1050',
+                    currency: 'EUR',
+                  },
+                  amountGross: {
+                    value: '0.6050',
+                    currency: 'EUR',
+                  },
+                },
+              ],
+              invoiceId: 'inv_FrvewDA3Pr',
+            },
+          },
+        },
+        invoiceId: 'inv_FrvewDA3Pr',
+        _links: {
+          self: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN',
+            type: 'application/hal+json',
+          },
+          invoice: {
+            href: 'https://api.mollie.com/v2/invoices/inv_FrvewDA3Pr',
+            type: 'application/hal+json',
+          },
+          payments: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/payments',
+            type: 'application/hal+json',
+          },
+          refunds: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/refunds',
+            type: 'application/hal+json',
+          },
+          chargebacks: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/chargebacks',
+            type: 'application/hal+json',
+          },
+          captures: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/captures',
+            type: 'application/hal+json',
+          },
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/settlements-api/get-settlement',
+            type: 'text/html',
+          },
+        },
+      })
+      .persist();
+  });
+
+  test('settlements', async () => {
+    let settlement = await mollieClient.settlements.get('stl_jDk30akdN');
+    expect(settlement.id).toBe('stl_jDk30akdN');
+
+    settlement = await mollieClient.settlements.get('1234567.1804.03');
+    expect(settlement.reference).toBe('1234567.1804.03');
+  });
+
+  test('settlementPayments', async () => {
+    networkMocker
+      .intercept(/\/settlements\/stl_jDk30akdN\/payments\?limit=\d+$/, 'GET')
+      .reply(200, {
+        count: 1,
+        _embedded: {
+          payments: [
+            {
+              resource: 'payment',
+              id: 'tr_7UhSN1zuXS',
+              mode: 'test',
+              createdAt: '2018-02-12T11:58:35.0Z',
+              expiresAt: '2018-02-12T12:13:35.0Z',
+              status: 'open',
+              isCancelable: false,
+              amount: {
+                value: '75.00',
+                currency: 'GBP',
+              },
+              description: 'Order #12345',
+              method: 'ideal',
+              metadata: null,
+              details: null,
+              profileId: 'pfl_QkEhN94Ba',
+              settlementId: 'stl_jDk30akdN',
+              redirectUrl: 'https://webshop.example.org/order/12345/',
+              _links: {
+                self: {
+                  href: 'https://api.mollie.com/v2/payments/tr_7UhSN1zuXS',
+                  type: 'application/hal+json',
+                },
+                settlement: {
+                  href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN',
+                  type: 'application/hal+json',
+                },
+              },
+            },
+          ],
+        },
+        _links: {
+          self: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/payments?limit=x',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/payments?from=tr_SDkzMggpvx&limit=5',
+            type: 'application/hal+json',
+          },
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments',
+            type: 'text/html',
+          },
+        },
+      })
+      .persist();
+    let payment = await getHead(mollieClient.settlementPayments.page({ settlementId: 'stl_jDk30akdN', limit: 1 }));
+    expect(payment.id).toBe('tr_7UhSN1zuXS');
+
+    const settlement = await mollieClient.settlements.get('stl_jDk30akdN');
+    payment = await getHead(settlement.getPayments());
+    expect(payment.id).toBe('tr_7UhSN1zuXS');
+  });
+
+  test('settlementCaptures', async () => {
+    networkMocker
+      .intercept(/settlements\/stl_jDk30akdN\/captures\?limit=\d+$/, 'GET')
+      .reply(200, {
+        _embedded: {
+          captures: [
+            {
+              resource: 'capture',
+              id: 'cpt_4qqhO89gsT',
+              mode: 'live',
+              amount: {
+                value: '1027.99',
+                currency: 'EUR',
+              },
+              settlementAmount: {
+                value: '399.00',
+                currency: 'EUR',
+              },
+              paymentId: 'tr_WDqYK6vllg',
+              shipmentId: 'shp_3wmsgCJN4U',
+              settlementId: 'stl_jDk30akdN',
+              createdAt: '2018-08-02T09:29:56+00:00',
+              _links: {
+                self: {
+                  href: 'https://api.mollie.com/v2/payments/tr_WDqYK6vllg/captures/cpt_4qqhO89gsT',
+                  type: 'application/hal+json',
+                },
+                payment: {
+                  href: 'https://api.mollie.com/v2/payments/tr_WDqYK6vllg',
+                  type: 'application/hal+json',
+                },
+                shipment: {
+                  href: 'https://api.mollie.com/v2/orders/ord_8wmqcHMN4U/shipments/shp_3wmsgCJN4U',
+                  type: 'application/hal+json',
+                },
+                settlement: {
+                  href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN',
+                  type: 'application/hal+json',
+                },
+                documentation: {
+                  href: 'https://docs.mollie.com/reference/v2/captures-api/get-capture',
+                  type: 'text/html',
+                },
+              },
+            },
+          ],
+        },
+        count: 1,
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures',
+            type: 'text/html',
+          },
+          self: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/captures?limit=x',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: null,
+        },
+      })
+      .persist();
+    let capture = await getHead(mollieClient.settlementCaptures.page({ settlementId: 'stl_jDk30akdN', limit: 1 }));
+    expect(capture.id).toBe('cpt_4qqhO89gsT');
+
+    const settlement = await mollieClient.settlements.get('stl_jDk30akdN');
+    capture = await getHead(settlement.getCaptures());
+    expect(capture.id).toBe('cpt_4qqhO89gsT');
+  });
+
+  test('settlementRefunds', async () => {
+    networkMocker
+      .intercept(/settlements\/stl_jDk30akdN\/refunds\?limit=\d+$/, 'GET')
+      .reply(200, {
+        _embedded: {
+          refunds: [
+            {
+              resource: 'refund',
+              id: 're_3aKhkUNigy',
+              amount: {
+                value: '10.00',
+                currency: 'EUR',
+              },
+              status: 'refunded',
+              createdAt: '2018-08-30T07:59:02+00:00',
+              description: 'Order #33',
+              paymentId: 'tr_maJaG2j8OM',
+              settlementAmount: {
+                value: '-10.00',
+                currency: 'EUR',
+              },
+              settlementId: 'stl_jDk30akdN',
+              _links: {
+                self: {
+                  href: 'https://api.mollie.com/v2/payments/tr_maJaG2j8OM/refunds/re_3aKhkUNigy',
+                  type: 'application/hal+json',
+                },
+                payment: {
+                  href: 'https://api.mollie.com/v2/payments/tr_maJaG2j8OM',
+                  type: 'application/hal+json',
+                },
+                settlement: {
+                  href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN',
+                  type: 'application/hal+json',
+                },
+              },
+            },
+          ],
+        },
+        count: 1,
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds',
+            type: 'text/html',
+          },
+          self: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/refunds?limit=x',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: null,
+        },
+      })
+      .persist();
+    let refund = await getHead(mollieClient.settlementRefunds.page({ settlementId: 'stl_jDk30akdN', limit: 1 }));
+    expect(refund.id).toBe('re_3aKhkUNigy');
+
+    const settlement = await mollieClient.settlements.get('stl_jDk30akdN');
+    refund = await getHead(settlement.getRefunds());
+    expect(refund.id).toBe('re_3aKhkUNigy');
+  });
+
+  test('settlementChargebacks', async () => {
+    networkMocker
+      .intercept(/settlements\/stl_jDk30akdN\/chargebacks\?limit=\d+$/, 'GET')
+      .reply(200, {
+        count: 1,
+        _embedded: {
+          chargebacks: [
+            {
+              resource: 'chargeback',
+              id: 'chb_n9z0tp',
+              amount: {
+                value: '43.38',
+                currency: 'USD',
+              },
+              settlementAmount: {
+                value: '-37.14',
+                currency: 'EUR',
+              },
+              createdAt: '2018-03-14T17:00:52.0Z',
+              reversedAt: null,
+              paymentId: 'tr_WDqYK6vllg',
+              settlementId: 'stl_jDk30akdN',
+              _links: {
+                self: {
+                  href: 'https://api.mollie.com/v2/payments/tr_WDqYK6vllg/chargebacks/chb_n9z0tp',
+                  type: 'application/hal+json',
+                },
+                payment: {
+                  href: 'https://api.mollie.com/v2/payments/tr_WDqYK6vllg',
+                  type: 'application/hal+json',
+                },
+                settlement: {
+                  href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN',
+                  type: 'application/hal+json',
+                },
+              },
+            },
+          ],
+        },
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks',
+            type: 'text/html',
+          },
+          self: {
+            href: 'https://api.mollie.com/v2/settlements/stl_jDk30akdN/chargebacks?limit=x',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: null,
+        },
+      })
+      .persist();
+    let chargeback = await getHead(mollieClient.settlementChargebacks.page({ settlementId: 'stl_jDk30akdN', limit: 1 }));
+    expect(chargeback.id).toBe('chb_n9z0tp');
+
+    const settlement = await mollieClient.settlements.get('stl_jDk30akdN');
+    chargeback = await getHead(settlement.getChargebacks());
+    expect(chargeback.id).toBe('chb_n9z0tp');
+  });
+
+  afterAll(() => networkMocker.cleanup());
+});


### PR DESCRIPTION
This PR adds some binders:
 * `profileMethods` (closes #253)
 * `profileGiftcardIssuers`
 * `profileVoucherIssuers`
 * `settlements` (closes #270)
 * `settlementPayments`
 * `settlementCaptures`
 * `settlementRefunds`
 * `settlementChargebacks`

It also changes the `NetworkMocker` class to have a simpler interface.

The added tests are not executed on Node.js 6.14 (see `jest.config.js`). However, support for Node.js < 8 will be dropped in the next major release anyway.

Solves #253 and #270.