### PR TITLE
Export ApiError

### DIFF
--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -166,3 +166,4 @@ export { RefundEmbed, RefundStatus } from './data/refunds/data';
 export { SubscriptionStatus } from './data/subscriptions/data';
 export { ProfileStatus } from './data/profiles/data';
 export { OnboardingStatus } from './data/onboarding/data';
+export { default as ApiError } from './errors/ApiError';

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,3 +107,5 @@ export { SubscriptionCreateParams, SubscriptionGetParams, SubscriptionsListParam
 export { CardAudience, CardFailureReason, CardLabel, FeeRegion } from './data/global';
 export { Issuer } from './data/Issuer';
 export { PaymentInclude } from './data/payments/data';
+
+export { default as ApiError } from './errors/ApiError';


### PR DESCRIPTION
Exports ApiError so errors thrown by Mollie can be detected with `instanceof`
