### PR TITLE
Remove endpoint aliases

### DIFF
--- a/examples/chargebacks/list.ts
+++ b/examples/chargebacks/list.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const chargebacks: List<Chargeback> = await mollieClient.chargebacks.all();
+    const chargebacks: List<Chargeback> = await mollieClient.chargebacks.page();
 
     console.log(chargebacks);
   } catch (error) {

--- a/examples/customers/list-payments.ts
+++ b/examples/customers/list-payments.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const payments: List<Payment> = await mollieClient.customerPayments.all({ customerId: 'cst_pzhEvnttJ2' });
+    const payments: List<Payment> = await mollieClient.customerPayments.page({ customerId: 'cst_pzhEvnttJ2' });
 
     console.log(payments);
   } catch (error) {

--- a/examples/customers/list.ts
+++ b/examples/customers/list.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const customers: List<Customer> = await mollieClient.customers.all();
+    const customers: List<Customer> = await mollieClient.customers.page();
 
     console.log(customers);
   } catch (error) {

--- a/examples/mandates/list.ts
+++ b/examples/mandates/list.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const mandates: List<Mandate> = await mollieClient.customerMandates.all({
+    const mandates: List<Mandate> = await mollieClient.customerMandates.page({
       customerId: 'cst_pzhEvnttJ2',
     });
 

--- a/examples/methods/list-for-amount-and-currency.ts
+++ b/examples/methods/list-for-amount-and-currency.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const filteredMethods: List<Method> = await mollieClient.methods.all({
+    const filteredMethods: List<Method> = await mollieClient.methods.list({
       include: MethodInclude.issuers,
       amount: {
         value: '10.00',

--- a/examples/methods/list-with-issuers.ts
+++ b/examples/methods/list-with-issuers.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const methods: List<Method> = await mollieClient.methods.all({
+    const methods: List<Method> = await mollieClient.methods.list({
       include: MethodInclude.issuers,
     });
 

--- a/examples/methods/list.ts
+++ b/examples/methods/list.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const methods: List<Method> = await mollieClient.methods.all();
+    const methods: List<Method> = await mollieClient.methods.list();
 
     console.log(methods);
   } catch (error) {

--- a/examples/orders/list.ts
+++ b/examples/orders/list.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const mostRecentOrders: List<Order> = await mollieClient.orders.all();
+    const mostRecentOrders: List<Order> = await mollieClient.orders.page();
     const previousOrders: List<Order> = await mostRecentOrders.nextPage();
 
     console.log(mostRecentOrders);

--- a/examples/refunds/list.ts
+++ b/examples/refunds/list.ts
@@ -9,12 +9,12 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 (async () => {
   try {
     // Payment refunds
-    const paymentRefunds: List<Refund> = await mollieClient.paymentRefunds.all({ paymentId: 'tr_WDqYK6vllg' });
+    const paymentRefunds: List<Refund> = await mollieClient.paymentRefunds.page({ paymentId: 'tr_WDqYK6vllg' });
 
     console.log(paymentRefunds);
 
     // Order refunds
-    const orderRefunds: List<Refund> = await mollieClient.orderRefunds.all({ orderId: 'ord_stTC2WHAuS' });
+    const orderRefunds: List<Refund> = await mollieClient.orderRefunds.page({ orderId: 'ord_stTC2WHAuS' });
 
     console.log(orderRefunds);
   } catch (error) {

--- a/examples/subscriptions/list-payments.ts
+++ b/examples/subscriptions/list-payments.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const payments: List<Payment> = await mollieClient.subscriptionPayments.list({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
+    const payments: List<Payment> = await mollieClient.subscriptionPayments.page({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
 
     console.log(payments);
   } catch (error) {

--- a/examples/subscriptions/list.ts
+++ b/examples/subscriptions/list.ts
@@ -7,7 +7,7 @@ const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWX
 
 (async () => {
   try {
-    const subscriptions: List<Subscription> = await mollieClient.customerSubscriptions.all({
+    const subscriptions: List<Subscription> = await mollieClient.customerSubscriptions.page({
       customerId: 'cst_pzhEvnttJ2',
     });
 

--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -18,27 +18,6 @@ export default class ChargebacksBinder extends InnerBinder<ChargebackData, Charg
    *
    * The results are paginated. See pagination for more information.
    *
-   * @since 2.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
-   */
-  public all: ChargebacksBinder['page'] = this.page;
-  /**
-   * Retrieve all chargebacks filed for your payments.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
-   */
-  public list: ChargebacksBinder['page'] = this.page;
-
-  /**
-   * Retrieve all chargebacks filed for your payments.
-   *
-   * The results are paginated. See pagination for more information.
-   *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -16,35 +16,6 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
   }
 
   /**
-   * Retrieve all customers created.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 2.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
-   */
-  public all: CustomersBinder['page'] = this.page;
-  /**
-   * Retrieve all customers created.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
-   */
-  public list: CustomersBinder['page'] = this.page;
-  /**
-   * Delete a customer. All mandates and subscriptions created for this customer will be canceled as well.
-   *
-   * @since 2.0.0
-   * @deprecated Use `delete` instead.
-   * @see https://docs.mollie.com/reference/v2/customers-api/delete-customer
-   */
-  public cancel: CustomersBinder['delete'] = this.delete;
-
-  /**
    * Creates a simple minimal representation of a customer in the Mollie API to use for the [Mollie Checkout](https://www.mollie.com/products/checkout) and Recurring features. These customers will
    * appear in your [Mollie Dashboard](https://www.mollie.com/dashboard) where you can manage their details, and also see their payments and subscriptions.
    *

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -19,43 +19,6 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
   }
 
   /**
-   * Retrieve all mandates for the given `customerId`, ordered from newest to oldest.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 1.2.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
-   */
-  public all: CustomerMandatesBinder['page'] = this.page;
-  /**
-   * Retrieve all mandates for the given `customerId`, ordered from newest to oldest.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
-   */
-  public list: CustomerMandatesBinder['page'] = this.page;
-  /**
-   * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
-   *
-   * @since 1.3.2
-   * @deprecated Use `revoke` instead.
-   * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
-   */
-  public cancel: CustomerMandatesBinder['revoke'] = this.revoke;
-  /**
-   * Revoke a customer's mandate. You will no longer be able to charge the consumer's bank account or credit card with this mandate and all connected subscriptions will be canceled.
-   *
-   * @since 2.0.0
-   * @deprecated Use `revoke` instead.
-   * @see https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
-   */
-  public delete: CustomerMandatesBinder['revoke'] = this.revoke;
-
-  /**
    * Create a mandate for a specific customer. Mandates allow you to charge a customer's credit card, PayPal account or bank account recurrently.
    *
    * It is only possible to create mandates for IBANs and PayPal billing agreements with this endpoint. To create mandates for credit cards, have your customers perform a 'first payment' with their

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -19,23 +19,6 @@ export default class CustomerPaymentsBinder extends InnerBinder<PaymentData, Pay
   }
 
   /**
-   * Retrieve all Payments linked to the Customer.
-   *
-   * @since 1.1.1
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
-   */
-  public all: CustomerPaymentsBinder['page'] = this.page;
-  /**
-   * Retrieve all Payments linked to the Customer.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
-   */
-  public list: CustomerPaymentsBinder['page'] = this.page;
-
-  /**
    * Creates a payment for the customer.
    *
    * Linking customers to payments enables a number of [Mollie Checkout](https://www.mollie.com/products/checkout) features, including:

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -19,31 +19,6 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
   }
 
   /**
-   * A subscription can be canceled any time by calling `DELETE` on the resource endpoint.
-   *
-   * @since 1.3.2
-   * @deprecated Use `cancel` instead.
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
-   */
-  public delete: CustomerSubscriptionsBinder['cancel'] = this.cancel;
-  /**
-   * Retrieve all subscriptions of a customer.
-   *
-   * @since 1.3.2
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
-   */
-  public all: CustomerSubscriptionsBinder['page'] = this.page;
-  /**
-   * Retrieve all subscriptions of a customer.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
-   */
-  public list: CustomerSubscriptionsBinder['page'] = this.page;
-
-  /**
    * With subscriptions, you can schedule recurring payments to take place at regular intervals.
    *
    * For example, by simply specifying an `amount` and an `interval`, you can create an endless subscription to charge a monthly fee, until you cancel the subscription.

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -15,43 +15,6 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
   }
 
   /**
-   * Retrieve all enabled payment methods. The results are not paginated.
-   *
-   * -   For test mode, payment methods are returned that are enabled in the Dashboard (or the activation is pending).
-   * -   For live mode, payment methods are returned that have been activated on your account and have been enabled in the Dashboard.
-   *
-   * New payment methods can be activated via the Enable payment method endpoint in the Profiles API.
-   *
-   * When using the `first` sequence type, methods will be returned if they can be used as a first payment in a recurring sequence and if they are enabled in the Dashboard.
-   *
-   * When using the `recurring` sequence type, payment methods that can be used for recurring payments or subscriptions will be returned. Enabling / disabling methods in the dashboard does not affect
-   * how they can be used for recurring payments.
-   *
-   * @since 2.0.0
-   * @deprecated Use `list` instead.
-   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
-   */
-  public all: MethodsBinder['list'] = this.list;
-  /**
-   * Retrieve all enabled payment methods. The results are not paginated.
-   *
-   * -   For test mode, payment methods are returned that are enabled in the Dashboard (or the activation is pending).
-   * -   For live mode, payment methods are returned that have been activated on your account and have been enabled in the Dashboard.
-   *
-   * New payment methods can be activated via the Enable payment method endpoint in the Profiles API.
-   *
-   * When using the `first` sequence type, methods will be returned if they can be used as a first payment in a recurring sequence and if they are enabled in the Dashboard.
-   *
-   * When using the `recurring` sequence type, payment methods that can be used for recurring payments or subscriptions will be returned. Enabling / disabling methods in the dashboard does not affect
-   * how they can be used for recurring payments.
-   *
-   * @since 3.0.0
-   * @deprecated Use `list` instead.
-   * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
-   */
-  public page: MethodsBinder['list'] = this.list;
-
-  /**
    * Retrieve a single method by its ID. Note that if a method is not available on the website profile a status `404 Not found` is returned. When the method is not enabled, a status `403 Forbidden` is
    * returned. You can enable payments methods via the Enable payment method endpoint in the Profiles API, or via your [Mollie Dashboard](https://www.mollie.com/dashboard).
    *

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -39,47 +39,6 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
   }
 
   /**
-   * The order can only be canceled while:
-   *
-   * -   the order doesn't have any open payments except for the methods `banktransfer`, `directdebit`, `klarnapaylater`, `klarnapaynow`, and `klarnasliceit`.
-   * -   the order's `status` field is either `created`, `authorized` or `shipping`[1].
-   *
-   * 1.  In case of `created`, all order lines will be canceled and the new order status will be `canceled`.
-   * 2.  In case of `authorized`, the authorization will be released, all order lines will be canceled and the new order status will be `canceled`.
-   * 3.  In case of `shipping`, any order lines that are still `authorized` will be canceled and order lines that are `shipping` will be completed. The new order status will be `completed`.
-   *
-   * For more information about the status transitions, check our order status changes guide.
-   *
-   * [1] If the order status is `shipping`, some order lines can have the status `paid` if the order was paid using a payment method that does not support authorizations (such as iDEAL) and the order
-   * lines are not shipped yet. In this case, the order cannot be canceled. You should create refunds for these order lines instead.
-   *
-   * @since 3.0.0
-   * @deprecated Use `cancel` instead.
-   * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
-   */
-  public delete: OrdersBinder['cancel'] = this.cancel;
-  /**
-   * Retrieve all orders.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
-   */
-  public all: OrdersBinder['page'] = this.page;
-  /**
-   * Retrieve all orders.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
-   */
-  public list: OrdersBinder['page'] = this.page;
-
-  /**
    * Using the Orders API is the preferred approach when integrating the Mollie API into e-commerce applications such as webshops. If you want to use *Klarna Pay now*, *Klarna Pay later*, *Klarna
    * Slice it*, *in3* or *Vouchers*, using the Orders API is mandatory.
    *

--- a/src/binders/orders/orderlines/OrderLinesBinder.ts
+++ b/src/binders/orders/orderlines/OrderLinesBinder.ts
@@ -18,28 +18,6 @@ export default class OrderLinesBinder extends InnerBinder<OrderData, Order> {
   }
 
   /**
-   * This endpoint can be used to cancel one or more order lines that were previously authorized using a Klarna payment method. Use the Cancel order endpoint if you want to cancel the entire order or
-   * the remainder of the order.
-   *
-   * Canceling or partially canceling an order line will immediately release the authorization held for that amount. Your customer will be able to see the updated order in his portal / app. Any
-   * canceled lines will be removed from the customer's point of view, but will remain visible in the Mollie Dashboard.
-   *
-   * You should cancel an order line if you do not intend to (fully) ship it.
-   *
-   * An order line can only be canceled while its `status` field is either `authorized` or `shipping`. If you cancel an `authorized` order line, the new order line status will be `canceled`. Canceling
-   * a `shipping` order line will result in a `completed` order line status.
-   *
-   * If the order line is `paid` or already `completed`, you should create a refund using the Create order refund endpoint instead.
-   *
-   * For more information about the status transitions, check our order status changes guide.
-   *
-   * @since 3.0.0
-   * @deprecated Use `cancel` instead.
-   * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
-   */
-  public delete: OrderLinesBinder['cancel'] = this.cancel;
-
-  /**
    * This endpoint can be used to update an order line. Only the lines that belong to an order with status `created`, `pending` or `authorized` can be updated.
    *
    * Use cases for this endpoint could be updating the `name`, `productUrl`, `imageUrl`, and `metadata` for a certain order line because your customer wants to swap the item for a different variant,

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -18,23 +18,6 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
   }
 
   /**
-   * Retrieve all shipments for an order.
-   *
-   * @since 3.0.0
-   * @deprecated Use `list` instead.
-   * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
-   */
-  public all: OrderShipmentsBinder['list'] = this.list;
-  /**
-   * Retrieve all shipments for an order.
-   *
-   * @since 3.0.0
-   * @deprecated Use `list` instead.
-   * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
-   */
-  public page: OrderShipmentsBinder['list'] = this.list;
-
-  /**
    * Create a shipment for specific order lines of an order.
    *
    * When using *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice it*, using this endpoint is mandatory for the order amount to be captured. A capture will automatically be created for the

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -17,38 +17,6 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
   }
 
   /**
-   * Retrieve all payments created with the current website profile, ordered from newest to oldest.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 2.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
-   */
-  public all: PaymentsBinder['page'] = this.page;
-  /**
-   * Retrieve all payments created with the current website profile, ordered from newest to oldest.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
-   */
-  public list: PaymentsBinder['page'] = this.page;
-  /**
-   * Some payment methods can be canceled by the merchant for a certain amount of time, usually until the next business day. Or as long as the payment status is `open`. Payments may be canceled
-   * manually from the Mollie Dashboard, or programmatically by using this endpoint.
-   *
-   * The `isCancelable` property on the Payment object will indicate if the payment can be canceled.
-   *
-   * @since 2.0.0
-   * @deprecated Use `cancel` instead.
-   * @see https://docs.mollie.com/reference/v2/payments-api/cancel-payment
-   */
-  public delete: PaymentsBinder['cancel'] = this.cancel;
-
-  /**
    * Payment creation is elemental to the Mollie API: this is where most payment implementations start off.
    *
    * Once you have created a payment, you should redirect your customer to the URL in the `_links.checkout` property from the response.

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -19,29 +19,6 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
   }
 
   /**
-   * Retrieve all captures for a certain payment.
-   *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
-   * it*.
-   *
-   * @since 1.1.1
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
-   */
-  public all: PaymentCapturesBinder['page'] = this.page;
-  /**
-   * Retrieve all captures for a certain payment.
-   *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
-   * it*.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
-   */
-  public list: PaymentCapturesBinder['page'] = this.page;
-
-  /**
    * Retrieve a single capture by its ID. Note the original payment's ID is needed as well.
    *
    * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are **Klarna Pay now**, **Klarna Pay later** and **Klarna

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -18,27 +18,6 @@ export default class PaymentChargebacksBinder extends InnerBinder<ChargebackData
   }
 
   /**
-   * Retrieve all chargebacks filed for your payments.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 1.1.1
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
-   */
-  public all: PaymentChargebacksBinder['page'] = this.page;
-  /**
-   * Retrieve all chargebacks filed for your payments.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
-   */
-  public list: PaymentChargebacksBinder['page'] = this.page;
-
-  /**
    * Retrieve a single chargeback by its ID. Note the original payment's ID is needed as well.
    *
    * If you do not know the original payment's ID, you can use the chargebacks list endpoint.

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -19,37 +19,6 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
   }
 
   /**
-   * Retrieve a list of all of your refunds.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 1.1.1
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
-   */
-  public all: PaymentRefundsBinder['page'] = this.page;
-  /**
-   * Retrieve a list of all of your refunds.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
-   */
-  public list: PaymentRefundsBinder['page'] = this.page;
-  /**
-   * For certain payment methods, like iDEAL, the underlying banking system will delay refunds until the next day. Until that time, refunds may be canceled manually in the [Mollie
-   * Dashboard](https://www.mollie.com/dashboard), or programmatically by using this endpoint.
-   *
-   * A refund can only be canceled while its `status` field is either `queued` or `pending`. See the Get refund endpoint for more information.
-   *
-   * @deprecated Use `cancel` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/cancel-payment-refund
-   */
-  public delete: PaymentRefundsBinder['cancel'] = this.cancel;
-
-  /**
    * Creates a refund for a specific payment. The refunded amount is credited to your customer usually either via a bank transfer or by refunding the amount to your customer's credit card.
    *
    * @since 1.1.1

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -13,15 +13,6 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
   }
 
   /**
-   * List all permissions available with the current app access token. The list is not paginated.
-   *
-   * @since 3.2.0
-   * @deprecated Use `list` instead.
-   * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
-   */
-  public page: PermissionsBinder['list'] = this.list;
-
-  /**
    * Retrieve the details on a specific permission, and see if the permission is granted to the current app access token.
    *
    * @since 3.2.0

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -17,17 +17,6 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
   }
 
   /**
-   * Retrieve all profiles available on the account.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.2.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
-   */
-  public list: ProfilesBinder['page'] = this.page;
-
-  /**
    * In order to process payments, you need to create a website profile. A website profile can easily be created via the Dashboard manually. However, the Mollie API also allows automatic profile
    * creation via the Profiles API.
    *

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -19,27 +19,6 @@ export default class RefundsBinder extends Binder<RefundData, Refund> {
    *
    * The results are paginated. See pagination for more information.
    *
-   * @since 2.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
-   */
-  public all: RefundsBinder['page'] = this.page;
-  /**
-   * Retrieve a list of all of your refunds.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
-   */
-  public list: RefundsBinder['page'] = this.page;
-
-  /**
-   * Retrieve a list of all of your refunds.
-   *
-   * The results are paginated. See pagination for more information.
-   *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -19,27 +19,6 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
   }
 
   /**
-   * Retrieve a list of all refunds made for a specific order.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
-   */
-  public all: OrderRefundsBinder['page'] = this.page;
-  /**
-   * Retrieve a list of all refunds made for a specific order.
-   *
-   * The results are paginated. See pagination for more information.
-   *
-   * @since 3.0.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
-   */
-  public list: OrderRefundsBinder['page'] = this.page;
-
-  /**
    * When using the Orders API, refunds should be made for a specific order.
    *
    * If you want to refund arbitrary amounts, however, you can also use the Create payment refund endpoint for Pay later and Slice it by creating a refund on the payment itself.

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -18,16 +18,6 @@ export default class SubscriptionsBinder extends InnerBinder<SubscriptionData, S
    * Retrieve all subscriptions, ordered from newest to oldest. By using an API key all the subscriptions created with the current website profile will be returned. In the case of an OAuth Access
    * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
    *
-   * @since 3.2.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
-   */
-  public list: SubscriptionsBinder['page'] = this.page;
-
-  /**
-   * Retrieve all subscriptions, ordered from newest to oldest. By using an API key all the subscriptions created with the current website profile will be returned. In the case of an OAuth Access
-   * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
-   *
    * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
    */

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -21,15 +21,6 @@ export default class SubscriptionPaymentsBinder extends InnerBinder<PaymentData,
   /**
    * Retrieve all payments of a specific subscriptions of a customer.
    *
-   * @since 3.3.0
-   * @deprecated Use `page` instead.
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscription-payments
-   */
-  public list: SubscriptionPaymentsBinder['page'] = this.page;
-
-  /**
-   * Retrieve all payments of a specific subscriptions of a customer.
-   *
    * @since 3.3.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscription-payments
    */

--- a/tests/integration/chargebacks.test.ts
+++ b/tests/integration/chargebacks.test.ts
@@ -17,7 +17,7 @@ const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
 
 describe('chargebacks', () => {
   it('should integrate', async () => {
-    const chargebacks = await mollieClient.chargebacks.all();
+    const chargebacks = await mollieClient.chargebacks.page();
 
     expect(chargebacks).toBeDefined();
   });

--- a/tests/integration/customers.test.ts
+++ b/tests/integration/customers.test.ts
@@ -17,18 +17,18 @@ const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
 
 describe('customers', () => {
   it('should integrate', async () => {
-    const customers = await mollieClient.customers.all();
+    const customers = await mollieClient.customers.page();
 
     expect(customers).toBeDefined();
 
     const [mandates, payments, subscriptions] = await Promise.all([
-      mollieClient.customerMandates.list({
+      mollieClient.customerMandates.page({
         customerId: customers[0].id,
       }),
-      mollieClient.customerPayments.list({
+      mollieClient.customerPayments.page({
         customerId: customers[0].id,
       }),
-      mollieClient.customerSubscriptions.list({
+      mollieClient.customerSubscriptions.page({
         customerId: customers[0].id,
       }),
     ]);

--- a/tests/integration/methods.test.ts
+++ b/tests/integration/methods.test.ts
@@ -17,7 +17,7 @@ const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
 
 describe('methods', () => {
   it('should integrate', async () => {
-    const methods = await mollieClient.methods.all();
+    const methods = await mollieClient.methods.list();
 
     expect(methods).toBeDefined();
 

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -17,7 +17,7 @@ const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
 
 describe('orders', () => {
   it('should integrate', async () => {
-    const orders = await mollieClient.orders.all();
+    const orders = await mollieClient.orders.page();
 
     let orderExists;
 
@@ -109,7 +109,7 @@ describe('orders', () => {
       return;
     }
 
-    const paymentRefunds = await mollieClient.paymentRefunds.all({ paymentId: payment.id });
+    const paymentRefunds = await mollieClient.paymentRefunds.page({ paymentId: payment.id });
 
     let refundExists;
 
@@ -144,7 +144,7 @@ describe('orders', () => {
   it('should paginate', async () => {
     let nextPageCursor;
 
-    let orders = await mollieClient.orders.all({ limit: 2 });
+    let orders = await mollieClient.orders.page({ limit: 2 });
 
     expect(orders.length).toEqual(2);
     expect(orders.nextPageCursor).toBeDefined();

--- a/tests/integration/payments.test.ts
+++ b/tests/integration/payments.test.ts
@@ -17,7 +17,7 @@ const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
 
 describe('payments', () => {
   it('should integrate', async () => {
-    const payments = await mollieClient.payments.all();
+    const payments = await mollieClient.payments.page();
 
     let paymentExists;
 
@@ -50,7 +50,7 @@ describe('payments', () => {
       return;
     }
 
-    const paymentRefunds = await mollieClient.paymentRefunds.all({ paymentId: payment.id });
+    const paymentRefunds = await mollieClient.paymentRefunds.page({ paymentId: payment.id });
 
     let refundExists;
 
@@ -100,7 +100,7 @@ describe('payments', () => {
   it('should paginate', async () => {
     let nextPageCursor;
 
-    let payments = await mollieClient.payments.all({
+    let payments = await mollieClient.payments.page({
       limit: 2,
     });
 

--- a/tests/integration/refunds.test.ts
+++ b/tests/integration/refunds.test.ts
@@ -17,7 +17,7 @@ const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
 
 describe('refunds', () => {
   it('should integrate', async () => {
-    const refunds = await mollieClient.refunds.list();
+    const refunds = await mollieClient.refunds.page();
 
     expect(refunds).toBeDefined();
   });

--- a/tests/unit/models/refund.test.ts
+++ b/tests/unit/models/refund.test.ts
@@ -50,7 +50,7 @@ async function getRefund(status) {
     count: 1,
   });
 
-  return await bluster(client.refunds.list.bind(client.refunds))().then(refunds => refunds[0]);
+  return await bluster(client.refunds.page.bind(client.refunds))().then(refunds => refunds[0]);
 }
 
 test('refundStatuses', () => {

--- a/tests/unit/networking.test.ts
+++ b/tests/unit/networking.test.ts
@@ -21,7 +21,7 @@ test('queryString', async () => {
     },
   });
 
-  const methods = await bluster(client.methods.all.bind(client.methods))({
+  const methods = await bluster(client.methods.list.bind(client.methods))({
     include: [MethodInclude.issuers, MethodInclude.pricing],
     amount: {
       value: '10.00',
@@ -54,7 +54,7 @@ test('defaults', async () => {
     },
   });
 
-  await bluster(client.customers.all.bind(client.customers))();
+  await bluster(client.customers.page.bind(client.customers))();
 
   const { baseURL, headers, httpsAgent } = adapter.history.get[0];
 
@@ -93,7 +93,7 @@ async function requestWithVersionStrings(versionStrings: string | string[] | und
     },
   });
 
-  await bluster(client.customers.all.bind(client.customers))();
+  await bluster(client.customers.page.bind(client.customers))();
 
   return adapter.history.get[0];
 }
@@ -146,7 +146,7 @@ test('customApiEndpoint', async () => {
     },
   });
 
-  await bluster(client.customers.all.bind(client.customers))();
+  await bluster(client.customers.page.bind(client.customers))();
 
   expect(adapter.history.get[0].baseURL).toBe('https://null.house/');
 });

--- a/tests/unit/resources/__snapshots__/methods.test.ts.snap
+++ b/tests/unit/resources/__snapshots__/methods.test.ts.snap
@@ -1,135 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`methods .all() should return a list of all methods 1`] = `
-Array [
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/ideal",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "iDEAL",
-    "id": "ideal",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png",
-    },
-    "resource": "method",
-  },
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/creditcard",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "Credit card",
-    "id": "creditcard",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png",
-    },
-    "resource": "method",
-  },
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/banktransfer",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "Bank transfer",
-    "id": "banktransfer",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/banktransfer.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/banktransfer%402x.png",
-    },
-    "resource": "method",
-  },
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/inghomepay",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "ING Home'Pay",
-    "id": "inghomepay",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/inghomepay.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/inghomepay%402x.png",
-    },
-    "resource": "method",
-  },
-]
-`;
-
-exports[`methods .all() should work with a callback 1`] = `
-Array [
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/ideal",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "iDEAL",
-    "id": "ideal",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png",
-    },
-    "resource": "method",
-  },
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/creditcard",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "Credit card",
-    "id": "creditcard",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png",
-    },
-    "resource": "method",
-  },
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/banktransfer",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "Bank transfer",
-    "id": "banktransfer",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/banktransfer.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/banktransfer%402x.png",
-    },
-    "resource": "method",
-  },
-  Object {
-    "_links": Object {
-      "self": Object {
-        "href": "https://api.mollie.com/v2/methods/inghomepay",
-        "type": "application/hal+json",
-      },
-    },
-    "description": "ING Home'Pay",
-    "id": "inghomepay",
-    "image": Object {
-      "size1x": "https://www.mollie.com/images/payscreen/methods/inghomepay.png",
-      "size2x": "https://www.mollie.com/images/payscreen/methods/inghomepay%402x.png",
-    },
-    "resource": "method",
-  },
-]
-`;
-
 exports[`methods .get() should return a method instance 1`] = `
 Object {
   "_links": Object {
@@ -164,4 +34,134 @@ Object {
   },
   "resource": "method",
 }
+`;
+
+exports[`methods .list() should return a list of all methods 1`] = `
+Array [
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/ideal",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "iDEAL",
+    "id": "ideal",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png",
+    },
+    "resource": "method",
+  },
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/creditcard",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "Credit card",
+    "id": "creditcard",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png",
+    },
+    "resource": "method",
+  },
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/banktransfer",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "Bank transfer",
+    "id": "banktransfer",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/banktransfer.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/banktransfer%402x.png",
+    },
+    "resource": "method",
+  },
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/inghomepay",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "ING Home'Pay",
+    "id": "inghomepay",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/inghomepay.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/inghomepay%402x.png",
+    },
+    "resource": "method",
+  },
+]
+`;
+
+exports[`methods .list() should work with a callback 1`] = `
+Array [
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/ideal",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "iDEAL",
+    "id": "ideal",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/ideal.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/ideal%402x.png",
+    },
+    "resource": "method",
+  },
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/creditcard",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "Credit card",
+    "id": "creditcard",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/creditcard.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/creditcard%402x.png",
+    },
+    "resource": "method",
+  },
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/banktransfer",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "Bank transfer",
+    "id": "banktransfer",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/banktransfer.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/banktransfer%402x.png",
+    },
+    "resource": "method",
+  },
+  Object {
+    "_links": Object {
+      "self": Object {
+        "href": "https://api.mollie.com/v2/methods/inghomepay",
+        "type": "application/hal+json",
+      },
+    },
+    "description": "ING Home'Pay",
+    "id": "inghomepay",
+    "image": Object {
+      "size1x": "https://www.mollie.com/images/payscreen/methods/inghomepay.png",
+      "size2x": "https://www.mollie.com/images/payscreen/methods/inghomepay%402x.png",
+    },
+    "resource": "method",
+  },
+]
 `;

--- a/tests/unit/resources/customers/mandates.test.ts
+++ b/tests/unit/resources/customers/mandates.test.ts
@@ -150,7 +150,7 @@ test('getCustomerMandates', async () => {
     },
   });
 
-  const mandates = await bluster(client.customerMandates.all.bind(client.customerMandates))({ customerId: 'cst_FhQJRw4s2n' });
+  const mandates = await bluster(client.customerMandates.page.bind(client.customerMandates))({ customerId: 'cst_FhQJRw4s2n' });
 
   mandates.forEach(mandate => {
     expect(mandate.resource).toBe('mandate');

--- a/tests/unit/resources/customers/payments.test.ts
+++ b/tests/unit/resources/customers/payments.test.ts
@@ -214,7 +214,7 @@ test('listCustomerPayouts', async () => {
     count: 3,
   });
 
-  const payments = await bluster(client.customerPayments.all.bind(client.customerPayments))({ customerId: 'cst_FhQJRw4s2n' });
+  const payments = await bluster(client.customerPayments.page.bind(client.customerPayments))({ customerId: 'cst_FhQJRw4s2n' });
 
   expect(payments.length).toBe(3);
 

--- a/tests/unit/resources/customers/subscriptions.test.ts
+++ b/tests/unit/resources/customers/subscriptions.test.ts
@@ -170,7 +170,7 @@ test('getCustomerSubscriptions', async () => {
     },
   });
 
-  const subscriptions = await bluster(client.customerSubscriptions.all.bind(client.customerSubscriptions))({ customerId: 'cst_FhQJRw4s2n' });
+  const subscriptions = await bluster(client.customerSubscriptions.page.bind(client.customerSubscriptions))({ customerId: 'cst_FhQJRw4s2n' });
 
   expect(subscriptions.length).toBe(1);
 

--- a/tests/unit/resources/lists.test.ts
+++ b/tests/unit/resources/lists.test.ts
@@ -25,7 +25,7 @@ describe('lists', () => {
 
     it('should retrieve a limited list', done => {
       customers
-        .list({ limit: 3 })
+        .page({ limit: 3 })
         .then(result => {
           expect(result[2].resource).toEqual('customer');
           expect(result[3]).toBeUndefined();
@@ -39,7 +39,7 @@ describe('lists', () => {
 
     it('should retrieve the next page', done => {
       customers
-        .list({ limit: 3 })
+        .page({ limit: 3 })
         .then(result => {
           result.nextPage().then(list => {
             expect(list[0].id).toEqual('cst_l4J9zsdzO');
@@ -55,7 +55,7 @@ describe('lists', () => {
 
     it('should retrieve the next page', done => {
       customers
-        .list({ limit: 3 })
+        .page({ limit: 3 })
         .then(result => {
           result
             .nextPage()
@@ -89,7 +89,7 @@ describe('lists', () => {
         }
       };
 
-      customers.list({ limit: 3 }, handleNextPage).then();
+      customers.page({ limit: 3 }, handleNextPage).then();
     });
   });
 });

--- a/tests/unit/resources/methods.test.ts
+++ b/tests/unit/resources/methods.test.ts
@@ -56,17 +56,17 @@ describe('methods', () => {
     });
   });
 
-  describe('.all()', () => {
+  describe('.list()', () => {
     mock.onGet('/methods').reply(200, response);
 
     it('should return a list of all methods', () =>
-      methods.all().then(result => {
+      methods.list().then(result => {
         expect(result).toHaveProperty('links');
         expect(result).toMatchSnapshot();
       }));
 
     it('should work with a callback', done => {
-      methods.all({}, (err, result) => {
+      methods.list({}, (err, result) => {
         expect(err).toBeNull();
         expect(result).toHaveProperty('links');
         expect(result).toMatchSnapshot();

--- a/tests/unit/resources/orders/refunds.test.ts
+++ b/tests/unit/resources/orders/refunds.test.ts
@@ -196,7 +196,7 @@ test('listOrderRefunds', async () => {
     },
   });
 
-  const refunds = await bluster(client.orderRefunds.all.bind(client.orderRefunds))({ orderId: 'ord_stTC2WHAuS' });
+  const refunds = await bluster(client.orderRefunds.page.bind(client.orderRefunds))({ orderId: 'ord_stTC2WHAuS' });
 
   expect(refunds.length).toBe(1);
 

--- a/tests/unit/resources/payments/captures.test.ts
+++ b/tests/unit/resources/payments/captures.test.ts
@@ -113,7 +113,7 @@ test('listCaptures', async () => {
     },
   });
 
-  const captures = await bluster(client.paymentCaptures.all.bind(client.paymentCaptures))({ paymentId: 'tr_WDqYK6vllg' });
+  const captures = await bluster(client.paymentCaptures.page.bind(client.paymentCaptures))({ paymentId: 'tr_WDqYK6vllg' });
 
   expect(captures.length).toBe(1);
 

--- a/tests/unit/resources/profiles.test.ts
+++ b/tests/unit/resources/profiles.test.ts
@@ -184,7 +184,7 @@ test('listProfiles', async () => {
     },
   });
 
-  const profiles = await bluster(client.profiles.list.bind(client.profiles))();
+  const profiles = await bluster(client.profiles.page.bind(client.profiles))();
 
   expect(profiles.length).toBe(2);
 

--- a/tests/unit/resources/subscriptions.test.ts
+++ b/tests/unit/resources/subscriptions.test.ts
@@ -50,7 +50,7 @@ test('listPageOfRootSubscriptions', async () => {
     },
   });
 
-  const subscriptions = await bluster(client.subscription.list.bind(client.subscription))();
+  const subscriptions = await bluster(client.subscription.page.bind(client.subscription))();
 
   expect(subscriptions.length).toBe(1);
 

--- a/tests/unit/resources/subscriptions/payments.test.ts
+++ b/tests/unit/resources/subscriptions/payments.test.ts
@@ -135,7 +135,7 @@ test('listSubscriptionPayments', async () => {
     count: 2,
   });
 
-  const payments = await bluster(client.subscriptionPayments.list.bind(client.subscriptionPayments))({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
+  const payments = await bluster(client.subscriptionPayments.page.bind(client.subscriptionPayments))({ customerId: 'cst_8wmqcHMN4U', subscriptionId: 'sub_8JfGzs6v3K' });
 
   expect(payments.length).toBe(2);
 


### PR DESCRIPTION
These endpoint aliases (such as `client.payments.delete` for `client.payments.cancel`) were deprecated in #234. The first version to include this deprecation is 3.6.0, released on 10 February 2022.

This PR removes the aliases.

Rationale:
* I suspect the aliases were introduced with the idea that "someone might misremember and accidentally type `delete` instead of `cancel`". We now live in the era of TypeScript, we no longer rely on memory; we rely on code completion. When one relies on code completion, aliases _introduce_ confusion: "`delete` sounds like what I need, but so does `cancel`… what's the difference between the two? When should I use which? Why am I using `delete` while this snippet on StackOverflow uses `cancel`?"
* The `all` aliases have always been deceptive. Instead of returning _all_ objects in an array, they were aliases for `page` and thus returned _the first page_ in an array.
* Because a binder now has either `page` or `list`, you can see whether the result will be paginated or not. 

The change is breaking. The next release will be 4.0.0.