### PR TITLE
List API changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "lint": "yarn lint:eslint:fix && yarn lint:prettier"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^0.27.2",
+    "ruply": "^1.0.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.18.6",
@@ -65,7 +66,6 @@
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "ruply": "^1.0.1",
     "typescript": "^4.9.5"
   },
   "resolutions": {

--- a/src/binders/Binder.ts
+++ b/src/binders/Binder.ts
@@ -1,5 +1,5 @@
 import breakUrl from '../communication/breakUrl';
-import List from '../data/list/List';
+import Page from '../data/page/Page';
 import Maybe from '../types/Maybe';
 
 /**
@@ -10,9 +10,9 @@ export default class Binder<R, T extends Omit<R, '_links' | '_embedded'>> {
   /**
    * Injects `nextPage`, `nextPageCursor`, `previousPage`, and `previousPageCursor` into the passed list.
    */
-  protected injectPaginationHelpers<P>(input: Array<T> & Pick<List<T>, 'count' | 'links'>, list: (parameters: P) => Promise<List<T>>, selfParameters: P = {} as P): List<T> {
+  protected injectPaginationHelpers<P>(input: Array<T> & Pick<Page<T>, 'count' | 'links'>, list: (parameters: P) => Promise<Page<T>>, selfParameters: P = {} as P): Page<T> {
     const { links } = input;
-    let nextPage: Maybe<() => Promise<List<T>>>;
+    let nextPage: Maybe<() => Promise<Page<T>>>;
     let nextPageCursor: Maybe<string>;
     if (links.next != null) {
       const [, query] = breakUrl(links.next.href);
@@ -22,7 +22,7 @@ export default class Binder<R, T extends Omit<R, '_links' | '_embedded'>> {
       });
       nextPageCursor = query.from;
     }
-    let previousPage: Maybe<() => Promise<List<T>>>;
+    let previousPage: Maybe<() => Promise<Page<T>>>;
     let previousPageCursor: Maybe<string>;
     if (links.previous != null) {
       const [, query] = breakUrl(links.previous.href);
@@ -37,6 +37,6 @@ export default class Binder<R, T extends Omit<R, '_links' | '_embedded'>> {
       nextPageCursor,
       previousPage,
       previousPageCursor,
-    }) as List<T>;
+    }) as Page<T>;
   }
 }

--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -4,7 +4,7 @@ import Page from '../../data/page/Page';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import InnerBinder from '../InnerBinder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 const pathSegment = 'chargebacks';
 
@@ -21,9 +21,9 @@ export default class ChargebacksBinder extends InnerBinder<ChargebackData, Charg
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public page(parameters?: ListParameters): Promise<Page<Chargeback>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Chargeback>>): void;
-  public page(parameters: ListParameters = {}) {
+  public page(parameters?: PageParameters): Promise<Page<Chargeback>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Chargeback>>): void;
+  public page(parameters: PageParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<ChargebackData, Chargeback>(pathSegment, 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -1,6 +1,6 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import Chargeback, { ChargebackData } from '../../data/chargebacks/Chargeback';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import InnerBinder from '../InnerBinder';
@@ -21,11 +21,11 @@ export default class ChargebacksBinder extends InnerBinder<ChargebackData, Charg
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public page(parameters?: ListParameters): Promise<List<Chargeback>>;
-  public page(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Chargeback>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Chargeback>>): void;
   public page(parameters: ListParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<ChargebackData, Chargeback>(pathSegment, 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<ChargebackData, Chargeback>(pathSegment, 'chargebacks', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/chargebacks/parameters.ts
+++ b/src/binders/chargebacks/parameters.ts
@@ -1,9 +1,9 @@
 import { ChargebackEmbed } from '../../data/chargebacks/Chargeback';
 import { PaginationParameters, ThrottlingParameter } from '../../types/parameters';
 
-export type ListParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & {
   profileId?: string;
   embed?: ChargebackEmbed[];
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -6,7 +6,7 @@ import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { CreateParameters, DeleteParameters, GetParameters, IterateParameters, ListParameters, UpdateParameters } from './parameters';
+import { CreateParameters, DeleteParameters, GetParameters, IterateParameters, PageParameters, UpdateParameters } from './parameters';
 
 const pathSegment = 'customers';
 
@@ -53,9 +53,9 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
-  public page(parameters?: ListParameters): Promise<Page<Customer>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Customer>>): void;
-  public page(parameters?: ListParameters) {
+  public page(parameters?: PageParameters): Promise<Page<Customer>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Customer>>): void;
+  public page(parameters?: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<CustomerData, Customer>(pathSegment, 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -1,6 +1,6 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import Customer, { CustomerData } from '../../data/customers/Customer';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import ApiError from '../../errors/ApiError';
 import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
@@ -53,11 +53,11 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
    */
-  public page(parameters?: ListParameters): Promise<List<Customer>>;
-  public page(parameters: ListParameters, callback: Callback<List<Customer>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Customer>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Customer>>): void;
   public page(parameters?: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<CustomerData, Customer>(pathSegment, 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<CustomerData, Customer>(pathSegment, 'customers', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -1,7 +1,7 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
 import { MandateData } from '../../../data/customers/mandates/data';
 import Mandate from '../../../data/customers/mandates/Mandate';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import ApiError from '../../../errors/ApiError';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
@@ -69,8 +69,8 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
-  public page(parameters: ListParameters): Promise<List<Mandate>>;
-  public page(parameters: ListParameters, callback: Callback<List<Mandate>>): void;
+  public page(parameters: ListParameters): Promise<Page<Mandate>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Mandate>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -79,7 +79,7 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
       throw new ApiError('The customer id is invalid');
     }
     const { customerId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<MandateData, Mandate>(getPathSegments(customerId), 'mandates', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
+    return this.networkClient.page<MandateData, Mandate>(getPathSegments(customerId), 'mandates', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 
   /**

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { CreateParameters, GetParameters, IterateParameters, ListParameters, RevokeParameters } from './parameters';
+import { CreateParameters, GetParameters, IterateParameters, PageParameters, RevokeParameters } from './parameters';
 
 function getPathSegments(customerId: string) {
   return `customers/${customerId}/mandates`;
@@ -69,9 +69,9 @@ export default class CustomerMandatesBinder extends InnerBinder<MandateData, Man
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/mandates-api/list-mandates
    */
-  public page(parameters: ListParameters): Promise<Page<Mandate>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Mandate>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Mandate>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Mandate>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const customerId = this.getParentId((parameters ?? {}).customerId);

--- a/src/binders/customers/mandates/parameters.ts
+++ b/src/binders/customers/mandates/parameters.ts
@@ -54,8 +54,8 @@ export type CreateParameters = ContextParameters &
 
 export type GetParameters = ContextParameters;
 
-export type ListParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export type RevokeParameters = ContextParameters & IdempotencyParameter;

--- a/src/binders/customers/parameters.ts
+++ b/src/binders/customers/parameters.ts
@@ -10,9 +10,9 @@ export type CreateParameters = ContextParameter & PickOptional<CustomerData, 'na
 
 export type GetParameters = ContextParameter;
 
-export type ListParameters = ContextParameter & PaginationParameters;
+export type PageParameters = ContextParameter & PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export type UpdateParameters = ContextParameter & PickOptional<CustomerData, 'name' | 'email' | 'locale' | 'metadata'>;
 

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { CreateParameters, IterateParameters, ListParameters } from './parameters';
+import { CreateParameters, IterateParameters, PageParameters } from './parameters';
 
 function getPathSegments(customerId: string) {
   return `customers/${customerId}/payments`;
@@ -49,9 +49,9 @@ export default class CustomerPaymentsBinder extends InnerBinder<PaymentData, Pay
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
-  public page(parameters: ListParameters): Promise<Page<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Payment>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const customerId = this.getParentId((parameters ?? {}).customerId);

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { PaymentData } from '../../../data/payments/data';
 import Payment from '../../../data/payments/Payment';
 import ApiError from '../../../errors/ApiError';
@@ -49,8 +49,8 @@ export default class CustomerPaymentsBinder extends InnerBinder<PaymentData, Pay
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
    */
-  public page(parameters: ListParameters): Promise<List<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters): Promise<Page<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -59,7 +59,7 @@ export default class CustomerPaymentsBinder extends InnerBinder<PaymentData, Pay
       throw new ApiError('The customer id is invalid');
     }
     const { customerId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<PaymentData, Payment>(getPathSegments(customerId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
+    return this.networkClient.page<PaymentData, Payment>(getPathSegments(customerId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 
   /**

--- a/src/binders/customers/payments/parameters.ts
+++ b/src/binders/customers/payments/parameters.ts
@@ -24,6 +24,6 @@ export type CreateParameters = ContextParameters &
     method?: PaymentMethod | PaymentMethod[];
   } & IdempotencyParameter;
 
-export type ListParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { SubscriptionData } from '../../../data/subscriptions/data';
 import Subscription from '../../../data/subscriptions/Subscription';
 import ApiError from '../../../errors/ApiError';
@@ -74,8 +74,8 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
-  public page(parameters: ListParameters): Promise<List<Subscription>>;
-  public page(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
+  public page(parameters: ListParameters): Promise<Page<Subscription>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Subscription>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -85,7 +85,7 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
     }
     const { customerId: _, ...query } = parameters ?? {};
     return this.networkClient
-      .list<SubscriptionData, Subscription>(getPathSegments(customerId), 'subscriptions', query)
+      .page<SubscriptionData, Subscription>(getPathSegments(customerId), 'subscriptions', query)
       .then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { CancelParameters, CreateParameters, GetParameters, IterateParameters, ListParameters, UpdateParameters } from './parameters';
+import { CancelParameters, CreateParameters, GetParameters, IterateParameters, PageParameters, UpdateParameters } from './parameters';
 
 function getPathSegments(customerId: string) {
   return `customers/${customerId}/subscriptions`;
@@ -74,9 +74,9 @@ export default class CustomerSubscriptionsBinder extends InnerBinder<Subscriptio
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
    */
-  public page(parameters: ListParameters): Promise<Page<Subscription>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Subscription>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Subscription>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Subscription>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const customerId = this.getParentId((parameters ?? {}).customerId);

--- a/src/binders/customers/subscriptions/parameters.ts
+++ b/src/binders/customers/subscriptions/parameters.ts
@@ -14,9 +14,9 @@ export type CreateParameters = ContextParameters &
 
 export type GetParameters = ContextParameters;
 
-export type ListParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export type UpdateParameters = ContextParameters &
   Pick<SubscriptionData, 'mandateId'> &

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -1,7 +1,6 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
-import { MethodData } from '../../data/methods/data';
 import Method from '../../data/methods/Method';
+import { MethodData } from '../../data/methods/data';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
@@ -48,10 +47,10 @@ export default class MethodsBinder extends Binder<MethodData, Method> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
    */
-  public list(parameters?: ListParameters): Promise<List<Method>>;
-  public list(parameters: ListParameters, callback: Callback<List<Method>>): void;
+  public list(parameters?: ListParameters): Promise<Method[]>;
+  public list(parameters: ListParameters, callback: Callback<Method[]>): void;
   public list(parameters: ListParameters = {}) {
     if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<MethodData, Method>(pathSegment, 'methods', parameters).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list<MethodData, Method>(pathSegment, 'methods', parameters);
   }
 }

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { OrderData } from '../../data/orders/data';
 import Order from '../../data/orders/Order';
 import ApiError from '../../errors/ApiError';
@@ -85,11 +85,11 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
-  public page(parameters?: ListParameters): Promise<List<Order>>;
-  public page(parameters: ListParameters, callback: Callback<List<Order>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Order>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Order>>): void;
   public page(parameters?: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<OrderData, Order>(pathSegment, 'orders', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<OrderData, Order>(pathSegment, 'orders', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { CancelParameters, CreateParameters, GetParameters, IterateParameters, ListParameters, UpdateParameters } from './parameters';
+import { CancelParameters, CreateParameters, GetParameters, IterateParameters, PageParameters, UpdateParameters } from './parameters';
 
 export const pathSegment = 'orders';
 
@@ -85,9 +85,9 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
    */
-  public page(parameters?: ListParameters): Promise<Page<Order>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Order>>): void;
-  public page(parameters?: ListParameters) {
+  public page(parameters?: PageParameters): Promise<Page<Order>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Order>>): void;
+  public page(parameters?: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<OrderData, Order>(pathSegment, 'orders', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/orders/parameters.ts
+++ b/src/binders/orders/parameters.ts
@@ -94,12 +94,12 @@ export type UpdateParameters = PickOptional<OrderData, 'billingAddress' | 'shipp
   testmode?: boolean;
 };
 
-export type ListParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & {
   profileId?: string;
   testmode?: boolean;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export interface CancelParameters extends IdempotencyParameter {
   testmode?: boolean;

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -1,5 +1,4 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
 import Shipment, { ShipmentData } from '../../../data/orders/shipments/Shipment';
 import ApiError from '../../../errors/ApiError';
 import checkId from '../../../plumbing/checkId';
@@ -68,8 +67,8 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
    */
-  public list(parameters: ListParameters): Promise<List<Shipment>>;
-  public list(parameters: ListParameters, callback: Callback<List<Shipment>>): void;
+  public list(parameters: ListParameters): Promise<Shipment[]>;
+  public list(parameters: ListParameters, callback: Callback<Shipment[]>): void;
   public list(parameters: ListParameters) {
     if (renege(this, this.list, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -78,7 +77,7 @@ export default class OrderShipmentsBinder extends InnerBinder<ShipmentData, Ship
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', query).then(result => this.injectPaginationHelpers(result, this.list, parameters));
+    return this.networkClient.list<ShipmentData, Shipment>(getPathSegments(orderId), 'shipments', query);
   }
 
   /**

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { CreateParameters, GetParameters, IterateParameters, ListParameters } from './parameters';
+import { CreateParameters, GetParameters, IterateParameters, PageParameters } from './parameters';
 
 const pathSegment = 'payment-links';
 
@@ -54,9 +54,9 @@ export default class PaymentsLinksBinder extends Binder<PaymentLinkData, Payment
    * @since 3.6.0
    * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
    */
-  public page(parameters?: ListParameters): Promise<Page<PaymentLink>>;
-  public page(parameters: ListParameters, callback: Callback<Page<PaymentLink>>): void;
-  public page(parameters: ListParameters = {}) {
+  public page(parameters?: PageParameters): Promise<Page<PaymentLink>>;
+  public page(parameters: PageParameters, callback: Callback<Page<PaymentLink>>): void;
+  public page(parameters: PageParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<PaymentLinkData, PaymentLink>(pathSegment, 'payment_links', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { PaymentLinkData } from '../../data/paymentLinks/data';
 import PaymentLink from '../../data/paymentLinks/PaymentLink';
 import ApiError from '../../errors/ApiError';
@@ -54,11 +54,11 @@ export default class PaymentsLinksBinder extends Binder<PaymentLinkData, Payment
    * @since 3.6.0
    * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
    */
-  public page(parameters?: ListParameters): Promise<List<PaymentLink>>;
-  public page(parameters: ListParameters, callback: Callback<List<PaymentLink>>): void;
+  public page(parameters?: ListParameters): Promise<Page<PaymentLink>>;
+  public page(parameters: ListParameters, callback: Callback<Page<PaymentLink>>): void;
   public page(parameters: ListParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<PaymentLinkData, PaymentLink>(pathSegment, 'payment_links', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<PaymentLinkData, PaymentLink>(pathSegment, 'payment_links', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/paymentLinks/parameters.ts
+++ b/src/binders/paymentLinks/parameters.ts
@@ -10,9 +10,9 @@ export interface GetParameters {
   testmode?: boolean;
 }
 
-export type ListParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & {
   profileId?: string;
   testmode?: boolean;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { CancelParameters, CreateParameters, GetParameters, IterateParameters, ListParameters, UpdateParameters } from './parameters';
+import { CancelParameters, CreateParameters, GetParameters, IterateParameters, PageParameters, UpdateParameters } from './parameters';
 
 const pathSegment = 'payments';
 
@@ -59,9 +59,9 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
-  public page(parameters?: ListParameters): Promise<Page<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
-  public page(parameters: ListParameters = {}) {
+  public page(parameters?: PageParameters): Promise<Page<Payment>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
+  public page(parameters: PageParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<PaymentData, Payment>(pathSegment, 'payments', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { PaymentData } from '../../data/payments/data';
 import Payment from '../../data/payments/Payment';
 import ApiError from '../../errors/ApiError';
@@ -59,11 +59,11 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/payments-api/list-payments
    */
-  public page(parameters?: ListParameters): Promise<List<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
   public page(parameters: ListParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<PaymentData, Payment>(pathSegment, 'payments', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<PaymentData, Payment>(pathSegment, 'payments', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**
@@ -105,7 +105,7 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
    * @see https://docs.mollie.com/reference/v2/payments-api/cancel-payment
    */
   public cancel(id: string, parameters?: CancelParameters): Promise<Payment>;
-  public cancel(id: string, parameters: CancelParameters, callback: Callback<List<Payment>>): void;
+  public cancel(id: string, parameters: CancelParameters, callback: Callback<Page<Payment>>): void;
   public cancel(id: string, parameters?: CancelParameters) {
     if (renege(this, this.cancel, ...arguments)) return;
     if (!checkId(id, 'payment')) {

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import Capture from '../../../data/payments/captures/Capture';
 import { CaptureData } from '../../../data/payments/captures/data';
 import ApiError from '../../../errors/ApiError';
@@ -52,8 +52,8 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
-  public page(parameters: ListParameters): Promise<List<Capture>>;
-  public page(parameters: ListParameters, callback: Callback<List<Capture>>): void;
+  public page(parameters: ListParameters): Promise<Page<Capture>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Capture>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -62,7 +62,7 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.networkClient.list<CaptureData, Capture>(getPathSegments(paymentId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<CaptureData, Capture>(getPathSegments(paymentId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { GetParameters, IterateParameters, ListParameters } from './parameters';
+import { GetParameters, IterateParameters, PageParameters } from './parameters';
 
 function getPathSegments(paymentId: string) {
   return `payments/${paymentId}/captures`;
@@ -52,9 +52,9 @@ export default class PaymentCapturesBinder extends InnerBinder<CaptureData, Capt
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
    */
-  public page(parameters: ListParameters): Promise<Page<Capture>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Capture>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Capture>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Capture>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const paymentId = this.getParentId((parameters ?? {}).paymentId);

--- a/src/binders/payments/captures/parameters.ts
+++ b/src/binders/payments/captures/parameters.ts
@@ -10,9 +10,9 @@ export type GetParameters = ContextParameters & {
   embed?: CaptureEmbed[];
 };
 
-export type ListParameters = ContextParameters &
+export type PageParameters = ContextParameters &
   PaginationParameters & {
     embed?: CaptureEmbed[];
   };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -1,6 +1,6 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
 import Chargeback, { ChargebackData } from '../../../data/chargebacks/Chargeback';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import ApiError from '../../../errors/ApiError';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
@@ -49,8 +49,8 @@ export default class PaymentChargebacksBinder extends InnerBinder<ChargebackData
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public page(parameters: ListParameters): Promise<List<Chargeback>>;
-  public page(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
+  public page(parameters: ListParameters): Promise<Page<Chargeback>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Chargeback>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -59,7 +59,7 @@ export default class PaymentChargebacksBinder extends InnerBinder<ChargebackData
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.networkClient.list<ChargebackData, Chargeback>(getPathSegments(paymentId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<ChargebackData, Chargeback>(getPathSegments(paymentId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -6,7 +6,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { GetParameters, IterateParameters, ListParameters } from './parameters';
+import { GetParameters, IterateParameters, PageParameters } from './parameters';
 
 function getPathSegments(paymentId: string) {
   return `payments/${paymentId}/chargebacks`;
@@ -49,9 +49,9 @@ export default class PaymentChargebacksBinder extends InnerBinder<ChargebackData
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
    */
-  public page(parameters: ListParameters): Promise<Page<Chargeback>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Chargeback>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Chargeback>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Chargeback>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const paymentId = this.getParentId((parameters ?? {}).paymentId);

--- a/src/binders/payments/chargebacks/parameters.ts
+++ b/src/binders/payments/chargebacks/parameters.ts
@@ -9,9 +9,9 @@ export type GetParameters = ContextParameters & {
   embed?: ChargebackEmbed[];
 };
 
-export type ListParameters = ContextParameters &
+export type PageParameters = ContextParameters &
   PaginationParameters & {
     embed?: ChargebackEmbed[];
   };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -167,12 +167,12 @@ export interface GetParameters {
   testmode?: boolean;
 }
 
-export type ListParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & {
   profileId?: string;
   testmode?: boolean;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export type UpdateParameters = Pick<PaymentData, 'redirectUrl' | 'webhookUrl'> &
   PickOptional<PaymentData, 'description' | 'metadata'> & {

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { CancelParameters, CreateParameters, GetParameters, IterateParameters, ListParameters } from './parameters';
+import { CancelParameters, CreateParameters, GetParameters, IterateParameters, PageParameters } from './parameters';
 
 function getPathSegments(paymentId: string) {
   return `payments/${paymentId}/refunds`;
@@ -68,9 +68,9 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public page(parameters: ListParameters): Promise<Page<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Refund>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Refund>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const paymentId = this.getParentId((parameters ?? {}).paymentId);

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { RefundData } from '../../../data/refunds/data';
 import Refund from '../../../data/refunds/Refund';
 import ApiError from '../../../errors/ApiError';
@@ -68,8 +68,8 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public page(parameters: ListParameters): Promise<List<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters): Promise<Page<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -78,7 +78,7 @@ export default class PaymentRefundsBinder extends InnerBinder<RefundData, Refund
       throw new ApiError('The payment id is invalid');
     }
     const { paymentId: _, ...query } = parameters;
-    return this.networkClient.list<RefundData, Refund>(getPathSegments(paymentId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<RefundData, Refund>(getPathSegments(paymentId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/payments/refunds/parameters.ts
+++ b/src/binders/payments/refunds/parameters.ts
@@ -13,11 +13,11 @@ export type GetParameters = ContextParameters & {
   embed?: RefundEmbed[];
 };
 
-export type ListParameters = ContextParameters &
+export type PageParameters = ContextParameters &
   PaginationParameters & {
     embed?: RefundEmbed[];
   };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export type CancelParameters = ContextParameters & IdempotencyParameter;

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -1,5 +1,4 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
 import Permission, { PermissionData } from '../../data/permissions/Permission';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
@@ -31,10 +30,10 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
    * @since 3.2.0
    * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
    */
-  public list(): Promise<List<Permission>>;
-  public list(callback: Callback<List<Permission>>): void;
+  public list(): Promise<Permission[]>;
+  public list(callback: Callback<Permission[]>): void;
   public list() {
     if (renege(this, this.list, ...arguments)) return;
-    return this.networkClient.list<PermissionData, Permission>(pathSegment, 'permissions', {}).then(result => this.injectPaginationHelpers<undefined>(result, this.list, undefined));
+    return this.networkClient.list<PermissionData, Permission>(pathSegment, 'permissions', {});
   }
 }

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { ProfileData } from '../../data/profiles/data';
 import Profile from '../../data/profiles/Profile';
 import ApiError from '../../errors/ApiError';
@@ -70,11 +70,11 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
    */
-  public page(parameters?: ListParameters): Promise<List<Profile>>;
-  public page(parameters: ListParameters, callback: Callback<List<Profile>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Profile>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Profile>>): void;
   public page(parameters?: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<ProfileData, Profile>(pathSegment, 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<ProfileData, Profile>(pathSegment, 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { CreateParameters, DeleteParameters, IterateParameters, ListParameters, UpdateParameters } from './parameters';
+import { CreateParameters, DeleteParameters, IterateParameters, PageParameters, UpdateParameters } from './parameters';
 
 const pathSegment = 'profiles';
 
@@ -70,9 +70,9 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
    */
-  public page(parameters?: ListParameters): Promise<Page<Profile>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Profile>>): void;
-  public page(parameters?: ListParameters) {
+  public page(parameters?: PageParameters): Promise<Page<Profile>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Profile>>): void;
+  public page(parameters?: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<ProfileData, Profile>(pathSegment, 'profiles', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/profiles/parameters.ts
+++ b/src/binders/profiles/parameters.ts
@@ -4,9 +4,9 @@ import PickOptional from '../../types/PickOptional';
 
 export type CreateParameters = Pick<ProfileData, 'name' | 'website' | 'email' | 'phone'> & PickOptional<ProfileData, 'businessCategory' | 'categoryCode' | 'mode'> & IdempotencyParameter;
 
-export type ListParameters = PaginationParameters;
+export type PageParameters = PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
 export type UpdateParameters = PickOptional<ProfileData, 'name' | 'website' | 'email' | 'phone' | 'businessCategory' | 'categoryCode' | 'mode'>;
 

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { RefundData } from '../../data/refunds/data';
 import Refund from '../../data/refunds/Refund';
 import renege from '../../plumbing/renege';
@@ -22,11 +22,11 @@ export default class RefundsBinder extends Binder<RefundData, Refund> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public page(parameters?: ListParameters): Promise<List<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
   public page(parameters: ListParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<RefundData, Refund>(pathSegment, 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<RefundData, Refund>(pathSegment, 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -5,7 +5,7 @@ import Refund from '../../data/refunds/Refund';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 const pathSegment = 'refunds';
 
@@ -22,9 +22,9 @@ export default class RefundsBinder extends Binder<RefundData, Refund> {
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-refunds
    */
-  public page(parameters?: ListParameters): Promise<Page<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
-  public page(parameters: ListParameters = {}) {
+  public page(parameters?: PageParameters): Promise<Page<Refund>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Refund>>): void;
+  public page(parameters: PageParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<RefundData, Refund>(pathSegment, 'refunds', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { CreateParameters, ListParameters } from './parameters';
+import { CreateParameters, IterateParameters, ListParameters } from './parameters';
 
 export function getPathSegments(orderId: string) {
   return `orders/${orderId}/refunds`;
@@ -71,13 +71,13 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
    * @since 3.6.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
    */
-  public iterate(parameters: Omit<ListParameters, 'limit'>) {
+  public iterate(parameters: IterateParameters) {
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const orderId = this.getParentId((parameters ?? {}).orderId);
     if (!checkId(orderId, 'order')) {
       throw new ApiError('The order id is invalid');
     }
-    const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.iterate<RefundData, Refund>(getPathSegments(orderId), 'refunds', query);
+    const { valuesPerMinute, orderId: _, ...query } = parameters ?? {};
+    return this.networkClient.iterate<RefundData, Refund>(getPathSegments(orderId), 'refunds', query, valuesPerMinute);
   }
 }

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { CreateParameters, IterateParameters, ListParameters } from './parameters';
+import { CreateParameters, IterateParameters, PageParameters } from './parameters';
 
 export function getPathSegments(orderId: string) {
   return `orders/${orderId}/refunds`;
@@ -50,9 +50,9 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
    */
-  public page(parameters: ListParameters): Promise<Page<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Refund>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Refund>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
     const orderId = this.getParentId((parameters ?? {}).orderId);

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { RefundData } from '../../../data/refunds/data';
 import Refund from '../../../data/refunds/Refund';
 import ApiError from '../../../errors/ApiError';
@@ -50,8 +50,8 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
    */
-  public page(parameters: ListParameters): Promise<List<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters): Promise<Page<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     // parameters ?? {} is used here, because in case withParent is used, parameters could be omitted.
@@ -60,7 +60,7 @@ export default class OrderRefundsBinder extends InnerBinder<RefundData, Refund> 
       throw new ApiError('The order id is invalid');
     }
     const { orderId: _, ...query } = parameters ?? {};
-    return this.networkClient.list<RefundData, Refund>(getPathSegments(orderId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
+    return this.networkClient.page<RefundData, Refund>(getPathSegments(orderId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters ?? {}));
   }
 
   /**

--- a/src/binders/refunds/orders/parameters.ts
+++ b/src/binders/refunds/orders/parameters.ts
@@ -47,6 +47,6 @@ export type CreateParameters = ContextParameters &
     }[];
   } & IdempotencyParameter;
 
-export type ListParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/refunds/parameters.ts
+++ b/src/binders/refunds/parameters.ts
@@ -1,8 +1,8 @@
 import { PaginationParameters, ThrottlingParameter } from '../../types/parameters';
 
-export type ListParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & {
   profileId?: string;
   testmode?: boolean;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/settlements/SettlementsBinder.ts
+++ b/src/binders/settlements/SettlementsBinder.ts
@@ -5,7 +5,7 @@ import SettlementModel from '../../data/settlements/SettlementModel';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 const pathSegment = 'settlements';
 
@@ -65,9 +65,9 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
    */
-  public page(parameters?: ListParameters): Promise<Page<SettlementModel>>;
-  public page(parameters: ListParameters, callback: Callback<Page<SettlementModel>>): void;
-  public page(parameters: ListParameters = {}) {
+  public page(parameters?: PageParameters): Promise<Page<SettlementModel>>;
+  public page(parameters: PageParameters, callback: Callback<Page<SettlementModel>>): void;
+  public page(parameters: PageParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<SettlementData, SettlementModel>(pathSegment, 'settlements', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/settlements/SettlementsBinder.ts
+++ b/src/binders/settlements/SettlementsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { SettlementData } from '../../data/settlements/data';
 import SettlementModel from '../../data/settlements/SettlementModel';
 import renege from '../../plumbing/renege';
@@ -65,11 +65,11 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
    */
-  public page(parameters?: ListParameters): Promise<List<SettlementModel>>;
-  public page(parameters: ListParameters, callback: Callback<List<SettlementModel>>): void;
+  public page(parameters?: ListParameters): Promise<Page<SettlementModel>>;
+  public page(parameters: ListParameters, callback: Callback<Page<SettlementModel>>): void;
   public page(parameters: ListParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<SettlementData, SettlementModel>(pathSegment, 'settlements', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<SettlementData, SettlementModel>(pathSegment, 'settlements', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/settlements/captures/SettlementCapturesBinder.ts
+++ b/src/binders/settlements/captures/SettlementCapturesBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import Capture from '../../../data/payments/captures/Capture';
 import { CaptureData } from '../../../data/payments/captures/data';
 import renege from '../../../plumbing/renege';
@@ -25,12 +25,12 @@ export default class SettlementCapturesBinder extends Binder<CaptureData, Captur
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
    */
-  public page(parameters: ListParameters): Promise<List<Capture>>;
-  public page(parameters: ListParameters, callback: Callback<List<Capture>>): void;
+  public page(parameters: ListParameters): Promise<Page<Capture>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Capture>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
-    return this.networkClient.list<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/settlements/captures/SettlementCapturesBinder.ts
+++ b/src/binders/settlements/captures/SettlementCapturesBinder.ts
@@ -5,7 +5,7 @@ import { CaptureData } from '../../../data/payments/captures/data';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import Binder from '../../Binder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 export function getPathSegments(settlementId: string) {
   return `settlements/${settlementId}/captures`;
@@ -25,9 +25,9 @@ export default class SettlementCapturesBinder extends Binder<CaptureData, Captur
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
    */
-  public page(parameters: ListParameters): Promise<Page<Capture>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Capture>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Capture>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Capture>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
     return this.networkClient.page<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));

--- a/src/binders/settlements/captures/parameters.ts
+++ b/src/binders/settlements/captures/parameters.ts
@@ -1,8 +1,8 @@
 import { ThrottlingParameter } from '../../../types/parameters';
-import { ListParameters as CaptureListParameters } from '../../payments/captures/parameters';
+import { PageParameters as CapturePageParameters } from '../../payments/captures/parameters';
 
-export type ListParameters = Omit<CaptureListParameters, 'paymentId'> & {
+export type PageParameters = Omit<CapturePageParameters, 'paymentId'> & {
   settlementId: string;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
+++ b/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
@@ -1,6 +1,6 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
 import Chargeback, { ChargebackData } from '../../../data/chargebacks/Chargeback';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import Binder from '../../Binder';
@@ -21,12 +21,12 @@ export default class SettlementChargebacksBinder extends Binder<ChargebackData, 
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
    */
-  public page(parameters: ListParameters): Promise<List<Chargeback>>;
-  public page(parameters: ListParameters, callback: Callback<List<Chargeback>>): void;
+  public page(parameters: ListParameters): Promise<Page<Chargeback>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Chargeback>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
-    return this.networkClient.list<ChargebackData, Chargeback>(getPathSegments(settlementId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<ChargebackData, Chargeback>(getPathSegments(settlementId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
+++ b/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
@@ -4,7 +4,7 @@ import Page from '../../../data/page/Page';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import Binder from '../../Binder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 export function getPathSegments(settlementId: string) {
   return `settlements/${settlementId}/chargebacks`;
@@ -21,9 +21,9 @@ export default class SettlementChargebacksBinder extends Binder<ChargebackData, 
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
    */
-  public page(parameters: ListParameters): Promise<Page<Chargeback>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Chargeback>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Chargeback>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Chargeback>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
     return this.networkClient.page<ChargebackData, Chargeback>(getPathSegments(settlementId), 'chargebacks', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));

--- a/src/binders/settlements/chargebacks/parameters.ts
+++ b/src/binders/settlements/chargebacks/parameters.ts
@@ -1,8 +1,8 @@
 import { ThrottlingParameter } from '../../../types/parameters';
-import { ListParameters as ChargebacksListParameters } from '../../chargebacks/parameters';
+import { PageParameters as ChargebacksPageParameters } from '../../chargebacks/parameters';
 
-export type ListParameters = ChargebacksListParameters & {
+export type PageParameters = ChargebacksPageParameters & {
   settlementId: string;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/settlements/parameters.ts
+++ b/src/binders/settlements/parameters.ts
@@ -1,5 +1,5 @@
 import { PaginationParameters, ThrottlingParameter } from '../../types/parameters';
 
-export type ListParameters = PaginationParameters;
+export type PageParameters = PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/settlements/payments/SettlementPaymentsBinder.ts
+++ b/src/binders/settlements/payments/SettlementPaymentsBinder.ts
@@ -5,7 +5,7 @@ import Payment from '../../../data/payments/Payment';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import Binder from '../../Binder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 export function getPathSegments(settlementId: string) {
   return `settlements/${settlementId}/payments`;
@@ -24,9 +24,9 @@ export default class SettlementPaymentsBinder extends Binder<PaymentData, Paymen
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
    */
-  public page(parameters: ListParameters): Promise<Page<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Payment>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
     return this.networkClient.page<PaymentData, Payment>(getPathSegments(settlementId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));

--- a/src/binders/settlements/payments/SettlementPaymentsBinder.ts
+++ b/src/binders/settlements/payments/SettlementPaymentsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { PaymentData } from '../../../data/payments/data';
 import Payment from '../../../data/payments/Payment';
 import renege from '../../../plumbing/renege';
@@ -24,12 +24,12 @@ export default class SettlementPaymentsBinder extends Binder<PaymentData, Paymen
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
    */
-  public page(parameters: ListParameters): Promise<List<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters): Promise<Page<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
-    return this.networkClient.list<PaymentData, Payment>(getPathSegments(settlementId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<PaymentData, Payment>(getPathSegments(settlementId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/settlements/payments/parameters.ts
+++ b/src/binders/settlements/payments/parameters.ts
@@ -1,8 +1,8 @@
 import { ThrottlingParameter } from '../../../types/parameters';
-import { ListParameters as PaymentListParameters } from '../../payments/parameters';
+import { PageParameters as PaymentPageParameters } from '../../payments/parameters';
 
-export type ListParameters = PaymentListParameters & {
+export type PageParameters = PaymentPageParameters & {
   settlementId: string;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/settlements/refunds/SettlementRefundsBinder.ts
+++ b/src/binders/settlements/refunds/SettlementRefundsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { RefundData } from '../../../data/refunds/data';
 import Refund from '../../../data/refunds/Refund';
 import renege from '../../../plumbing/renege';
@@ -22,12 +22,12 @@ export default class SettlementRefundsBinder extends Binder<RefundData, Refund> 
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
    */
-  public page(parameters: ListParameters): Promise<List<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<List<Refund>>): void;
+  public page(parameters: ListParameters): Promise<Page<Refund>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
-    return this.networkClient.list<RefundData, Refund>(getPathSegments(settlementId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<RefundData, Refund>(getPathSegments(settlementId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/settlements/refunds/SettlementRefundsBinder.ts
+++ b/src/binders/settlements/refunds/SettlementRefundsBinder.ts
@@ -5,7 +5,7 @@ import Refund from '../../../data/refunds/Refund';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import Binder from '../../Binder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 export function getPathSegments(settlementId: string) {
   return `settlements/${settlementId}/refunds`;
@@ -22,9 +22,9 @@ export default class SettlementRefundsBinder extends Binder<RefundData, Refund> 
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
    */
-  public page(parameters: ListParameters): Promise<Page<Refund>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Refund>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Refund>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Refund>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const { settlementId, ...query } = parameters;
     return this.networkClient.page<RefundData, Refund>(getPathSegments(settlementId), 'refunds', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));

--- a/src/binders/settlements/refunds/parameters.ts
+++ b/src/binders/settlements/refunds/parameters.ts
@@ -1,8 +1,8 @@
 import { ThrottlingParameter } from '../../../types/parameters';
-import { ListParameters as RefundsListParameters } from '../../refunds/parameters';
+import { PageParameters as RefundsPageParameters } from '../../refunds/parameters';
 
-export type ListParameters = RefundsListParameters & {
+export type PageParameters = RefundsPageParameters & {
   settlementId: string;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import List from '../../data/list/List';
+import Page from '../../data/page/Page';
 import { SubscriptionData } from '../../data/subscriptions/data';
 import Subscription from '../../data/subscriptions/Subscription';
 import renege from '../../plumbing/renege';
@@ -21,11 +21,11 @@ export default class SubscriptionsBinder extends InnerBinder<SubscriptionData, S
    * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
    */
-  public page(parameters?: ListParameters): Promise<List<Subscription>>;
-  public page(parameters: ListParameters, callback: Callback<List<Subscription>>): void;
+  public page(parameters?: ListParameters): Promise<Page<Subscription>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Subscription>>): void;
   public page(parameters?: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.list<SubscriptionData, Subscription>(pathSegment, 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<SubscriptionData, Subscription>(pathSegment, 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -5,7 +5,7 @@ import Subscription from '../../data/subscriptions/Subscription';
 import renege from '../../plumbing/renege';
 import Callback from '../../types/Callback';
 import InnerBinder from '../InnerBinder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 const pathSegment = 'subscriptions';
 
@@ -21,9 +21,9 @@ export default class SubscriptionsBinder extends InnerBinder<SubscriptionData, S
    * @since 3.2.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
    */
-  public page(parameters?: ListParameters): Promise<Page<Subscription>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Subscription>>): void;
-  public page(parameters?: ListParameters) {
+  public page(parameters?: PageParameters): Promise<Page<Subscription>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Subscription>>): void;
+  public page(parameters?: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     return this.networkClient.page<SubscriptionData, Subscription>(pathSegment, 'subscriptions', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }

--- a/src/binders/subscriptions/parameters.ts
+++ b/src/binders/subscriptions/parameters.ts
@@ -1,8 +1,8 @@
 import { PaginationParameters, ThrottlingParameter } from '../../types/parameters';
 
-export type ListParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & {
   profileId?: string;
   testmode?: boolean;
 };
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -7,7 +7,7 @@ import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import Callback from '../../../types/Callback';
 import InnerBinder from '../../InnerBinder';
-import { IterateParameters, ListParameters } from './parameters';
+import { IterateParameters, PageParameters } from './parameters';
 
 function getPathSegments(customerId: string, subscriptionId: string): string {
   return `customers/${customerId}/subscriptions/${subscriptionId}/payments`;
@@ -24,9 +24,9 @@ export default class SubscriptionPaymentsBinder extends InnerBinder<PaymentData,
    * @since 3.3.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscription-payments
    */
-  public page(parameters: ListParameters): Promise<Page<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
-  public page(parameters: ListParameters) {
+  public page(parameters: PageParameters): Promise<Page<Payment>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
+  public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const customerId = this.getParentId(parameters.customerId);
     if (!checkId(customerId, 'customer')) {

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -1,5 +1,5 @@
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
-import List from '../../../data/list/List';
+import Page from '../../../data/page/Page';
 import { PaymentData } from '../../../data/payments/data';
 import Payment from '../../../data/payments/Payment';
 import ApiError from '../../../errors/ApiError';
@@ -24,8 +24,8 @@ export default class SubscriptionPaymentsBinder extends InnerBinder<PaymentData,
    * @since 3.3.0 (as `list`)
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscription-payments
    */
-  public page(parameters: ListParameters): Promise<List<Payment>>;
-  public page(parameters: ListParameters, callback: Callback<List<Payment>>): void;
+  public page(parameters: ListParameters): Promise<Page<Payment>>;
+  public page(parameters: ListParameters, callback: Callback<Page<Payment>>): void;
   public page(parameters: ListParameters) {
     if (renege(this, this.page, ...arguments)) return;
     const customerId = this.getParentId(parameters.customerId);
@@ -37,7 +37,7 @@ export default class SubscriptionPaymentsBinder extends InnerBinder<PaymentData,
       throw new ApiError('The subscription id is invalid');
     }
     const { customerId: _, subscriptionId: __, ...query } = parameters;
-    return this.networkClient.list<PaymentData, Payment>(getPathSegments(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient.page<PaymentData, Payment>(getPathSegments(customerId, subscriptionId), 'payments', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/subscriptions/payments/parameters.ts
+++ b/src/binders/subscriptions/payments/parameters.ts
@@ -6,6 +6,6 @@ interface ContextParameters {
   subscriptionId: string;
 }
 
-export type ListParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters;
 
-export type IterateParameters = Omit<ListParameters, 'limit'> & ThrottlingParameter;
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/communication/TransformingNetworkClient.ts
+++ b/src/communication/TransformingNetworkClient.ts
@@ -44,14 +44,14 @@ export default class TransformingNetworkClient {
     return this.networkClient.get<R>(...passingArguments).then(this.transform) as Promise<U>;
   }
 
-  async list<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['list']>) {
-    const response = await this.networkClient.list<R>(...passingArguments);
-    const { count, links } = response;
-    return Object.assign(response.map(this.transform) as U[], { count, links });
+  list<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['list']>) {
+    return this.networkClient.list<R>(...passingArguments).then(response => response.map(this.transform) as U[]);
   }
 
-  listPlain<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['listPlain']>) {
-    return this.networkClient.listPlain<R>(...passingArguments).then(response => response.map(this.transform) as U[]);
+  async page<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['page']>) {
+    const response = await this.networkClient.page<R>(...passingArguments);
+    const { count, links } = response;
+    return Object.assign(response.map(this.transform) as U[], { count, links });
   }
 
   iterate<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['iterate']>) {

--- a/src/data/chargebacks/ChargebackHelper.ts
+++ b/src/data/chargebacks/ChargebackHelper.ts
@@ -3,8 +3,8 @@ import renege from '../../plumbing/renege';
 import resolveIf from '../../plumbing/resolveIf';
 import Callback from '../../types/Callback';
 import Helper from '../Helper';
-import { PaymentData } from '../payments/data';
 import Payment from '../payments/Payment';
+import { PaymentData } from '../payments/data';
 import Chargeback, { ChargebackData } from './Chargeback';
 
 export default class ChargebackHelper extends Helper<ChargebackData, Chargeback> {

--- a/src/data/customers/CustomerHelper.ts
+++ b/src/data/customers/CustomerHelper.ts
@@ -1,14 +1,16 @@
+import { runIf } from 'ruply';
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
-import renege from '../../plumbing/renege';
-import Callback from '../../types/Callback';
+import HelpfulIterator from '../../plumbing/iteration/HelpfulIterator';
+import emptyHelpfulIterator from '../../plumbing/iteration/emptyHelpfulIterator';
+import { ThrottlingParameter } from '../../types/parameters';
 import Helper from '../Helper';
-import { PaymentData } from '../payments/data';
 import Payment from '../payments/Payment';
-import { SubscriptionData } from '../subscriptions/data';
+import { PaymentData } from '../payments/data';
 import Subscription from '../subscriptions/Subscription';
+import { SubscriptionData } from '../subscriptions/data';
 import Customer, { CustomerData } from './Customer';
-import { MandateData } from './mandates/data';
 import Mandate from './mandates/Mandate';
+import { MandateData } from './mandates/data';
 
 export default class CustomerHelper extends Helper<CustomerData, Customer> {
   constructor(networkClient: TransformingNetworkClient, protected readonly links: CustomerData['_links']) {
@@ -20,14 +22,8 @@ export default class CustomerHelper extends Helper<CustomerData, Customer> {
    *
    * @since 3.6.0
    */
-  public getMandates(): Promise<Array<Mandate>>;
-  public getMandates(callback: Callback<Array<Mandate>>): void;
-  public getMandates() {
-    if (renege(this, this.getMandates, ...arguments)) return;
-    if (this.links.mandates == undefined) {
-      return Promise.resolve([]);
-    }
-    return this.networkClient.listPlain<MandateData, Mandate>(this.links.mandates.href, 'mandates');
+  public getMandates(parameters?: ThrottlingParameter): HelpfulIterator<Mandate> {
+    return runIf(this.links.mandates, ({ href }) => this.networkClient.iterate<MandateData, Mandate>(href, 'mandates', undefined, parameters?.valuesPerMinute)) ?? emptyHelpfulIterator;
   }
 
   /**
@@ -35,14 +31,10 @@ export default class CustomerHelper extends Helper<CustomerData, Customer> {
    *
    * @since 3.6.0
    */
-  public getSubscriptions(): Promise<Array<Subscription>>;
-  public getSubscriptions(callback: Callback<Array<Subscription>>): void;
-  public getSubscriptions() {
-    if (renege(this, this.getSubscriptions, ...arguments)) return;
-    if (this.links.subscriptions == undefined) {
-      return Promise.resolve([]);
-    }
-    return this.networkClient.listPlain<SubscriptionData, Subscription>(this.links.subscriptions.href, 'subscriptions');
+  public getSubscriptions(parameters?: ThrottlingParameter): HelpfulIterator<Subscription> {
+    return (
+      runIf(this.links.subscriptions, ({ href }) => this.networkClient.iterate<SubscriptionData, Subscription>(href, 'subscriptions', undefined, parameters?.valuesPerMinute)) ?? emptyHelpfulIterator
+    );
   }
 
   /**
@@ -50,13 +42,7 @@ export default class CustomerHelper extends Helper<CustomerData, Customer> {
    *
    * @since 3.6.0
    */
-  public getPayments(): Promise<Array<Payment>>;
-  public getPayments(callback: Callback<Array<Payment>>): void;
-  public getPayments() {
-    if (renege(this, this.getPayments, ...arguments)) return;
-    if (this.links.payments == undefined) {
-      return Promise.resolve([]);
-    }
-    return this.networkClient.listPlain<PaymentData, Payment>(this.links.payments.href, 'payments');
+  public getPayments(parameters?: ThrottlingParameter): HelpfulIterator<Payment> {
+    return runIf(this.links.payments, ({ href }) => this.networkClient.iterate<PaymentData, Payment>(href, 'payments', undefined, parameters?.valuesPerMinute)) ?? emptyHelpfulIterator;
   }
 }

--- a/src/data/orders/shipments/ShipmentHelper.ts
+++ b/src/data/orders/shipments/ShipmentHelper.ts
@@ -17,7 +17,7 @@ export default class ShipmentHelper extends Helper<ShipmentData, Shipment> {
    * @since 3.6.0
    */
   public getOrder(): Promise<Order>;
-  public getOrder(callback: Callback<Array<Order>>): void;
+  public getOrder(callback: Callback<Order>): void;
   public getOrder() {
     if (renege(this, this.getOrder, ...arguments)) return;
     return this.networkClient.get<OrderData, Order>(this.links.order.href);

--- a/src/data/page/Page.ts
+++ b/src/data/page/Page.ts
@@ -2,19 +2,19 @@ import Maybe from '../../types/Maybe';
 import Nullable from '../../types/Nullable';
 import { Links, Url } from '../global';
 
-export default interface List<T> extends Array<T> {
-  links: ListLinks;
+export default interface Page<T> extends Array<T> {
+  links: PageLinks;
   /**
    * @deprecated Use `list.length` instead.
    */
   count: number;
   nextPageCursor: Maybe<string>;
   previousPageCursor: Maybe<string>;
-  nextPage: Maybe<() => Promise<List<T>>>;
-  previousPage: Maybe<() => Promise<List<T>>>;
+  nextPage: Maybe<() => Promise<Page<T>>>;
+  previousPage: Maybe<() => Promise<Page<T>>>;
 }
 
-export interface ListLinks extends Links {
+export interface PageLinks extends Links {
   next: Nullable<Url>;
   previous: Nullable<Url>;
 }

--- a/src/data/payments/captures/CaptureHelper.ts
+++ b/src/data/payments/captures/CaptureHelper.ts
@@ -1,3 +1,4 @@
+import { runIf } from 'ruply';
 import TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
 import renege from '../../../plumbing/renege';
 import resolveIf from '../../../plumbing/resolveIf';
@@ -6,8 +7,8 @@ import Callback from '../../../types/Callback';
 import Maybe from '../../../types/Maybe';
 import Helper from '../../Helper';
 import Shipment, { ShipmentData } from '../../orders/shipments/Shipment';
-import { PaymentData } from '../data';
 import Payment from '../Payment';
+import { PaymentData } from '../data';
 import Capture from './Capture';
 import { CaptureData } from './data';
 
@@ -37,9 +38,6 @@ export default class CaptureHelper extends Helper<CaptureData, Capture> {
   public getShipment(callback: Callback<Maybe<Shipment>>): void;
   public getShipment() {
     if (renege(this, this.getShipment, ...arguments)) return;
-    if (this.links.shipment == undefined) {
-      return undefinedPromise;
-    }
-    return this.networkClient.get<ShipmentData, Shipment>(this.links.shipment.href);
+    return runIf(this.links.shipment, ({ href }) => this.networkClient.get<ShipmentData, Shipment>(href)) ?? undefinedPromise;
   }
 }

--- a/src/data/refunds/RefundHelper.ts
+++ b/src/data/refunds/RefundHelper.ts
@@ -1,16 +1,17 @@
+import { runIf } from 'ruply';
 import TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import renege from '../../plumbing/renege';
-import resolveIf from '../../plumbing/resolveIf';
 import undefinedPromise from '../../plumbing/undefinedPromise';
 import Callback from '../../types/Callback';
 import Maybe from '../../types/Maybe';
 import Helper from '../Helper';
-import { OrderData } from '../orders/data';
 import Order from '../orders/Order';
-import { PaymentData } from '../payments/data';
+import { OrderData } from '../orders/data';
 import Payment from '../payments/Payment';
-import { RefundData, RefundStatus } from './data';
+import { PaymentData } from '../payments/data';
 import Refund from './Refund';
+import { RefundData, RefundStatus } from './data';
+import resolveIf from '../../plumbing/resolveIf';
 
 export default class RefundHelper extends Helper<RefundData, Refund> {
   constructor(networkClient: TransformingNetworkClient, protected readonly links: RefundData['_links'], protected readonly embedded: RefundData['_embedded']) {
@@ -83,9 +84,6 @@ export default class RefundHelper extends Helper<RefundData, Refund> {
   public getOrder(callback: Callback<Maybe<Order>>): void;
   public getOrder() {
     if (renege(this, this.getOrder, ...arguments)) return;
-    if (this.links.order == undefined) {
-      return undefinedPromise;
-    }
-    return this.networkClient.get<OrderData, Order>(this.links.order.href);
+    return runIf(this.links.order, ({ href }) => this.networkClient.get<OrderData, Order>(href)) ?? undefinedPromise;
   }
 }

--- a/src/plumbing/iteration/emptyHelpfulIterator.ts
+++ b/src/plumbing/iteration/emptyHelpfulIterator.ts
@@ -1,0 +1,7 @@
+import HelpfulIterator from './HelpfulIterator';
+import makeAsync from './makeAsync';
+
+/**
+ * A `HelpfulIterator` instance with an empty underlying sequence.
+ */
+export default new HelpfulIterator(makeAsync([][Symbol.iterator]()));

--- a/src/plumbing/iteration/makeAsync.ts
+++ b/src/plumbing/iteration/makeAsync.ts
@@ -1,0 +1,18 @@
+/**
+ * Converts a (synchronous) iterator to an asynchronous iterator.
+ */
+export default function makeAsync<T, R, N>(original: Iterator<T, R, N>) {
+  return {
+    next() {
+      return Promise.resolve(original.next());
+    },
+
+    return(value?: R) {
+      return Promise.resolve(original.return?.(value) ?? { done: true, value: value as R });
+    },
+
+    throw(error: any) {
+      return Promise.resolve(original.throw?.(error) ?? ({ done: true } as IteratorReturnResult<R>));
+    },
+  };
+}

--- a/src/plumbing/resolveIf.ts
+++ b/src/plumbing/resolveIf.ts
@@ -1,12 +1,11 @@
+import { runIf } from 'ruply';
+
 type Nullish = null | undefined;
 
 /**
  * Returns a promise which resolves to the passed value; unless the passed value is
  * [nullish](https://developer.mozilla.org/docs/Glossary/Nullish), in which case it returns that value directly.
  */
-export default function resolveIf<T>(value: T): Extract<T, Nullish> | Promise<Exclude<T, Nullish>> {
-  if (value == null) {
-    return value as Extract<T, Nullish>;
-  }
-  return Promise.resolve(value as Exclude<T, Nullish>);
+export default function resolveIf<T>(value: T extends Promise<unknown> ? never : T) {
+  return runIf(value, Promise.resolve) ?? (value as Extract<T, Nullish> | Promise<Exclude<T, Nullish>>);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export * from './createMollieClient';
 export type MollieClient = ReturnType<typeof createMollieClient>;
 export { default as MollieOptions } from './Options';
 
-export { default as List } from './data/list/List';
+export { default as Page } from './data/page/Page';
 
 export { default as Capture } from './data/payments/captures/Capture';
 import { GetParameters as CapturesGetParameters, ListParameters as CapturesListParameters } from './binders/payments/captures/parameters';

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,12 +8,12 @@ export { default as MollieOptions } from './Options';
 export { default as Page } from './data/page/Page';
 
 export { default as Capture } from './data/payments/captures/Capture';
-import { GetParameters as CapturesGetParameters, ListParameters as CapturesListParameters } from './binders/payments/captures/parameters';
-export { CapturesGetParameters, CapturesListParameters };
+import { GetParameters as CapturesGetParameters, PageParameters as CapturesPageParameters } from './binders/payments/captures/parameters';
+export { CapturesGetParameters, CapturesPageParameters };
 
 export { default as Chargeback } from './data/chargebacks/Chargeback';
-import { ListParameters as ChargebacksListParameters } from './binders/chargebacks/parameters';
-export { ChargebacksListParameters };
+import { PageParameters as ChargebacksPageParameters } from './binders/chargebacks/parameters';
+export { ChargebacksPageParameters };
 
 export { default as Customer } from './data/customers/Customer';
 import {
@@ -21,7 +21,7 @@ import {
   DeleteParameters as CustomerDeleteParams,
   GetParameters as CustomerGetParams,
   UpdateParameters as CustomerUpdateParams,
-  ListParameters as CustomersListParams,
+  PageParameters as CustomersListParams,
 } from './binders/customers/parameters';
 export { CustomerCreateParams, CustomerGetParams, CustomersListParams, CustomerUpdateParams, CustomerDeleteParams };
 
@@ -30,7 +30,7 @@ import {
   CreateParameters as MandateCreateParams,
   GetParameters as MandateGetParams,
   RevokeParameters as MandateRevokeParams,
-  ListParameters as MandatesListParams,
+  PageParameters as MandatesListParams,
 } from './binders/customers/mandates/parameters';
 export { MandateCreateParams, MandateGetParams, MandatesListParams, MandateRevokeParams };
 
@@ -48,7 +48,7 @@ import {
   CreateParameters as OrderCreateParams,
   GetParameters as OrderGetParams,
   UpdateParameters as OrderUpdateParams,
-  ListParameters as OrdersListParams,
+  PageParameters as OrdersListParams,
 } from './binders/orders/parameters';
 export { OrderCreateParams, OrderGetParams, OrdersListParams, OrderUpdateParams, OrderCancelParams };
 
@@ -59,30 +59,30 @@ export { OrderLineUpdateParams, OrderLineCancelParams };
 export { default as Organization } from './data/organizations/Organizations';
 
 export { default as Payment } from './data/payments/Payment';
-import { CreateParameters as CustomerPaymentCreateParams, ListParameters as CustomerPaymentsListParams } from './binders/customers/payments/parameters';
+import { CreateParameters as CustomerPaymentCreateParams, PageParameters as CustomerPaymentsListParams } from './binders/customers/payments/parameters';
 import { CreateParameters as OrderPaymentCreateParams } from './binders/payments/orders/parameters';
 import {
   CancelParameters as PaymentCancelParams,
   CreateParameters as PaymentCreateParams,
   GetParameters as PaymentGetParams,
-  ListParameters as PaymentsListParams,
+  PageParameters as PaymentsListParams,
 } from './binders/payments/parameters';
 export { PaymentCreateParams, PaymentGetParams, PaymentsListParams, PaymentCancelParams, CustomerPaymentCreateParams, CustomerPaymentsListParams, OrderPaymentCreateParams };
 
 export { default as Permission } from './data/permissions/Permission';
 
 export { default as Profile } from './data/profiles/Profile';
-import { CreateParameters as ProfileCreateParameters, ListParameters as ProfileListParameters, UpdateParameters as ProfileUpdateParameters } from './binders/profiles/parameters';
-export { ProfileCreateParameters, ProfileListParameters, ProfileUpdateParameters };
+import { CreateParameters as ProfileCreateParameters, PageParameters as ProfilePageParameters, UpdateParameters as ProfileUpdateParameters } from './binders/profiles/parameters';
+export { ProfileCreateParameters, ProfilePageParameters, ProfileUpdateParameters };
 
 export { default as Refund } from './data/refunds/Refund';
 import {
   CancelParameters as PaymentRefundCancelParams,
   CreateParameters as PaymentRefundCreateParams,
   GetParameters as PaymentRefundGetParams,
-  ListParameters as PaymentRefundsListParams,
+  PageParameters as PaymentRefundsListParams,
 } from './binders/payments/refunds/parameters';
-import { ListParameters as RefundsListParams } from './binders/refunds/parameters';
+import { PageParameters as RefundsListParams } from './binders/refunds/parameters';
 export { RefundsListParams, PaymentRefundCreateParams, PaymentRefundGetParams, PaymentRefundsListParams, PaymentRefundCancelParams };
 
 export { default as Shipment } from './data/orders/shipments/Shipment';
@@ -100,7 +100,7 @@ import {
   CreateParameters as SubscriptionCreateParams,
   GetParameters as SubscriptionGetParams,
   UpdateParameters as SubscriptionUpdateParams,
-  ListParameters as SubscriptionsListParams,
+  PageParameters as SubscriptionsListParams,
 } from './binders/customers/subscriptions/parameters';
 export { SubscriptionCreateParams, SubscriptionGetParams, SubscriptionsListParams, SubscriptionUpdateParams, SubscriptionCancelParams };
 

--- a/tests/unit/networking.test.ts
+++ b/tests/unit/networking.test.ts
@@ -29,7 +29,7 @@ test('queryString', async () => {
     },
   });
 
-  expect(methods.links.self.href).toBe('https://api.mollie.com/v2/methods?include=issuers%2Cpricing&amount%5Bvalue%5D=10.00&amount%5Bcurrency%5D=SEK');
+  expect(methods.length).toBe(0);
 });
 
 test('defaults', async () => {

--- a/tests/unit/resources/lists.test.ts
+++ b/tests/unit/resources/lists.test.ts
@@ -7,7 +7,7 @@ import NetworkClient from '../../../src/communication/NetworkClient';
 import page1 from '../__stubs__/list/customers_page_1.json';
 import page2 from '../__stubs__/list/customers_page_2.json';
 import page3 from '../__stubs__/list/customers_page_3.json';
-import List from '../../../src/data/list/List';
+import Page from '../../../src/data/page/Page';
 
 const mock = new MockAdapter(axios);
 
@@ -59,7 +59,7 @@ describe('lists', () => {
         .then(result => {
           result
             .nextPage()
-            .then((list: List<any>) => {
+            .then((list: Page<any>) => {
               expect(list[0].id).toEqual('cst_l4J9zsdzO');
               expect(list.nextPageCursor).toEqual('cst_1DVwgVBLS');
               expect(list).toMatchSnapshot();
@@ -78,7 +78,7 @@ describe('lists', () => {
       let i = 0;
       const expected = ['cst_kEn1PlbGa', 'cst_l4J9zsdzO', 'cst_1DVwgVBLS', undefined];
 
-      const handleNextPage = (err, result: List<any>): void => {
+      const handleNextPage = (err, result: Page<any>): void => {
         expect(err).toBeNull();
         expect(result[0].id).toEqual(expected[i]);
         expect(result.nextPageCursor).toEqual(expected[++i]);

--- a/tests/unit/resources/methods.test.ts
+++ b/tests/unit/resources/methods.test.ts
@@ -61,14 +61,12 @@ describe('methods', () => {
 
     it('should return a list of all methods', () =>
       methods.list().then(result => {
-        expect(result).toHaveProperty('links');
         expect(result).toMatchSnapshot();
       }));
 
     it('should work with a callback', done => {
       methods.list({}, (err, result) => {
         expect(err).toBeNull();
-        expect(result).toHaveProperty('links');
         expect(result).toMatchSnapshot();
         done();
       });


### PR DESCRIPTION
### Plain array return types

Changed the return type of `methods.list`, `orderShipments.list`, and `permissions.list` to (plain) arrays.

Previously, the object returned by those methods had optional properties, including `nextPage`:
```typescript
const methods = await methods.list();
await methods.nextPage?.();
```
As the underlying endpoints are not paginated, `nextPage` was always `undefined` anyway. Removing the `nextPage` property communicates this better.

### Iterator return types

Changed the return type of several helper functions to iterators, including `customer.getPayments`.

This forces users to handle the scenario in which the items do not fit on a single page, e.g. one customer has more than 250 payments. See #291.

### Renames

Renamed types and methods to solidify the distinction between (exhaustive) lists and pages. This does not affect the public-facing API (unless you count the exported TypeScript types).

---

Some changes are breaking. The next release will be 4.0.0.