### PR TITLE
update required node version [breaking]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   # Run on every 1st and 15th of the month.
   schedule:
     - cron: 0 12 1,15 * *
@@ -17,12 +17,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        config-file: ./.github/codeql-configuration.yml
-        languages: javascript
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          config-file: ./.github/codeql-configuration.yml
+          languages: javascript
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,32 +2,25 @@ name: Node.js test
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [[6.14, 14.x], [18.x]]
+        node-version: [14.x, 18.x, 20.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      # Some modules used for building and testing this library require a greater Node.js version than this library
-      # itself. Switch to the second Node.js version in the tuple before installing to game the system (and switch back
-      # later before running the tests).
-      - name: Use Node.js ${{ matrix.node-version[1] || matrix.node-version[0] }}
-        uses: actions/setup-node@v2
+        uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version[1] || matrix.node-version[0] }}
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: yarn --frozen-lockfile
-      - name: Use Node.js ${{ matrix.node-version[0] }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version[0] }}
       - name: Run test suite
         run: yarn test
         env:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you include this library in a website or app, however, your API key will be s
 
 ## Requirements
 
-- Node.js 6.14.× or greater.
+- Node.js 14.× or greater.
 - A free [Mollie account](https://www.mollie.com/dashboard/signup).
 - Your API keys, which you can find on your [dashboard](https://www.mollie.com/dashboard/developers/api-keys).
 
@@ -101,7 +101,9 @@ const payments = mollieClient.payments.page({ limit: 15 });
 
 // payments.nextPageCursor is the cursor: the ID of the first payment on the next page.
 ```
+
 Later:
+
 ```javascript
 // Retrieve the second 15 payments (using the cursor from the previous page).
 const payments = mollieClient.payments.page({ limit: 15, from: 'tr_8WhJKGmgBy' });
@@ -144,7 +146,6 @@ Want to help us make our API client even better? We take [pull requests](https:/
 ## License
 
 [New BSD (Berkeley Software Distribution) License](https://opensource.org/licenses/BSD-3-Clause). Copyright 2013-2021, Mollie B.V.
-
 
 [credit-card]: https://www.mollie.com/payments/credit-card
 [apple-pay]: https://www.mollie.com/payments/apple-pay

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "jsnext:main": "dist/mollie.esm.js",
   "types": "dist/types/src/types.d.ts",
   "engines": {
-    "node": ">=6.14"
+    "node": ">=14"
   },
   "scripts": {
     "prepublish": "yarn build",


### PR DESCRIPTION
In accordance with the discussion [here](https://github.com/mollie/mollie-api-node/pull/338), this raises the minimum node version for the package to node 14.

It also updates some github actions versions (which should have no effect).

The CI is now also configured to run on node 20.

This update will require the repo settings to be updated to expect the correct checks.