### PR TITLE
4.0.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mollie/api-client",
-  "version": "3.7.0",
+  "version": "4.0.0-beta.0",
   "license": "BSD-3-Clause",
   "description": "Official Mollie API client for Node",
   "repository": {


### PR DESCRIPTION
Beta release

Most notably for the security warning addressed in #338.

Breaking change is updating the Node dependency to >=14.

We are planning some more breaking changes - like removing deprecated code. These changes are planned to land in the v4 stable, which means that subsequent v4beta versions will contain breaking changes. However, this release will allow any consumers to upgrade to a version without CVE warnings.