### PR TITLE
More helpful error in createMollieClient for missing credentials

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -31,4 +31,30 @@ type Options = Xor<
   apiEndpoint?: string;
 } & Pick<AxiosRequestConfig, 'adapter' | 'proxy' | 'socketPath' | 'timeout'>;
 
+const falsyDescriptions = new Map<any, string>([
+  [undefined, 'undefined'],
+  [null, 'null'],
+  ['', 'an empty string'],
+]);
+
+/**
+ * Returns an error message (string) similar to `"Parameter "×" is null."` if a property with the passed key exists in
+ * the passed options object, or `null` if said property does not exist.
+ */
+function describeFalsyOption(options: Options, key: keyof Options) {
+  if (key in options == false) {
+    return null;
+  }
+  return `Parameter "${key}" is ${falsyDescriptions.get(options[key]) ?? options[key]}.`;
+};
+
+/**
+ * Throws a `TypeError` if the passed options object does not contain an `apiKey` or an `accessToken`.
+ */
+export function checkCredentials(options: Options) {
+  if (!options.apiKey && !options.accessToken) {
+    throw new TypeError(describeFalsyOption(options, 'apiKey') ?? describeFalsyOption(options, 'accessToken') ?? 'Missing parameter "apiKey" or "accessToken".');
+  }
+}
+
 export default Options;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -4,6 +4,7 @@ import caCertificates from './cacert.pem';
 import NetworkClient from './communication/NetworkClient';
 import TransformingNetworkClient, { Transformers } from './communication/TransformingNetworkClient';
 import type Options from './Options';
+import { run } from 'ruply';
 
 // Transformers
 import { transform as transformPayment } from './data/payments/Payment';
@@ -59,6 +60,25 @@ import SubscriptionsBinder from './binders/subscriptions/SubscriptionsBinder';
 import SubscriptionPaymentsBinder from './binders/subscriptions/payments/SubscriptionPaymentsBinder';
 
 /**
+ * Returns an error message (string) similar to `"Parameter "×" is null."` if a property with the passed key exists in
+ * the passed object, or `null` if said property does not exist.
+ */
+const describeFalsyOption = run(
+  new Map([
+    [undefined, 'undefined'],
+    [null, 'null'],
+    ['', 'an empty string'],
+  ]) as Map<any, string>,
+  descriptions =>
+    function describeFalsyOption<O extends Record<string, unknown>>(object: O, key: keyof O & string) {
+      if (key in object == false) {
+        return null;
+      }
+      return `Parameter "${key}" is ${descriptions.get(object[key]) ?? object[key]}.`;
+    },
+);
+
+/**
  * Create Mollie client.
  * @since 2.0.0
  */
@@ -71,7 +91,7 @@ export default function createMollieClient(options: Options) {
   }
 
   if (!options.apiKey && !options.accessToken) {
-    throw new TypeError('Missing parameter "apiKey" or "accessToken".');
+    throw new TypeError(describeFalsyOption(options, 'apiKey') ?? describeFalsyOption(options, 'accessToken') ?? 'Missing parameter "apiKey" or "accessToken".');
   }
 
   const networkClient = new NetworkClient({ ...options, libraryVersion, nodeVersion: process.version, caCertificates });

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -3,8 +3,8 @@ import { version as libraryVersion } from '../package.json';
 import caCertificates from './cacert.pem';
 import NetworkClient from './communication/NetworkClient';
 import TransformingNetworkClient, { Transformers } from './communication/TransformingNetworkClient';
+import { checkCredentials } from './Options';
 import type Options from './Options';
-import { run } from 'ruply';
 
 // Transformers
 import { transform as transformPayment } from './data/payments/Payment';
@@ -60,25 +60,6 @@ import SubscriptionsBinder from './binders/subscriptions/SubscriptionsBinder';
 import SubscriptionPaymentsBinder from './binders/subscriptions/payments/SubscriptionPaymentsBinder';
 
 /**
- * Returns an error message (string) similar to `"Parameter "×" is null."` if a property with the passed key exists in
- * the passed object, or `null` if said property does not exist.
- */
-const describeFalsyOption = run(
-  new Map([
-    [undefined, 'undefined'],
-    [null, 'null'],
-    ['', 'an empty string'],
-  ]) as Map<any, string>,
-  descriptions =>
-    function describeFalsyOption<O extends Record<string, unknown>>(object: O, key: keyof O & string) {
-      if (key in object == false) {
-        return null;
-      }
-      return `Parameter "${key}" is ${descriptions.get(object[key]) ?? object[key]}.`;
-    },
-);
-
-/**
  * Create Mollie client.
  * @since 2.0.0
  */
@@ -90,9 +71,7 @@ export default function createMollieClient(options: Options) {
     );
   }
 
-  if (!options.apiKey && !options.accessToken) {
-    throw new TypeError(describeFalsyOption(options, 'apiKey') ?? describeFalsyOption(options, 'accessToken') ?? 'Missing parameter "apiKey" or "accessToken".');
-  }
+  checkCredentials(options);
 
   const networkClient = new NetworkClient({ ...options, libraryVersion, nodeVersion: process.version, caCertificates });
 

--- a/tests/unit/createMollieClient.test.ts
+++ b/tests/unit/createMollieClient.test.ts
@@ -1,9 +1,19 @@
 import createMollieClient from '../..';
 
-describe('mollie', () => {
-  it('should fail when no api key is provided', () => {
+describe('createMollieClient', () => {
+  it('should fail when no credentials are provided', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
     // @ts-ignore
-    expect(() => createMollieClient(undefined)).toThrowError(TypeError);
+    expect(() => createMollieClient({})).toThrow('Missing parameter "apiKey" or "accessToken".');
+  });
+
+  it('should throw a descriptive error when a apiKey is set to null', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    expect(() => createMollieClient({ apiKey: null })).toThrow('Parameter "apiKey" is null.');
+  });
+
+  it('should throw a descriptive error when a apiKey is set to an empty string', () => {
+    expect(() => createMollieClient({ apiKey: '' })).toThrow('Parameter "apiKey" is an empty string.');
   });
 });


### PR DESCRIPTION
Previously, not setting `apiKey` or `accessToken` to an appropriate value would result in a generic error. After this PR, an accidental empty string (`createMollieClient({ apiKey: '' })`) gives a distinct error from no value at all (`createmollieClient({})`).

I suspect this is what happened in #349, and I hope this will prevent some headaches in the future.