### PR TITLE
Unconditionally run all tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,25 +1,7 @@
-const nockfulTests = ['communication', 'iteration', 'paymentLinks', 'profiles', 'settlements'];
-
-function createProject(displayName, testRegex, rest) {
-  return Object.assign({}, rest, {
-    testEnvironment: 'node',
-    setupFilesAfterEnv: ['jest-bluster'],
-    displayName,
-    testRegex
-  });
-}
-
-const projects = [
-  createProject('nockless tests', `/tests/(?!${nockfulTests.join('|')}).*/.+\\.test\\.[jt]s$`)
-];
-
-// Only execute the Nockful tests on Node.js 8+.
-if (parseInt(process.version.substring(1)) >= 8) {
-  projects.push(createProject('nockful tests', `/tests/(?:${nockfulTests.join('|')}).*/.+\\.test\\.[jt]s$`));
-}
-
 module.exports = {
-  projects,
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['jest-bluster'],
+  testRegex: '/tests/.*/.+\\.test\\.[jt]s$',
   transform: {
     '\\.[jt]s$': 'babel-jest'
   }


### PR DESCRIPTION
Previously, some tests were skipped on older Node.js versions because they rely on Nock, which is unsupported by Node.js < 8.0.0.

We are currently figuring out which Node.js versions 4.0.0 of the client will support, but we plan on raising it to at least 8.0.0. We can thus safely run all tests unconditionally.