### PR TITLE
Re-introduce runtime aliases

### DIFF
--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -2,6 +2,7 @@ import type TransformingNetworkClient from '../../communication/TransformingNetw
 import type Chargeback from '../../data/chargebacks/Chargeback';
 import { type ChargebackData } from '../../data/chargebacks/Chargeback';
 import type Page from '../../data/page/Page';
+import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
@@ -12,6 +13,7 @@ const pathSegment = 'chargebacks';
 export default class ChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
   }
 
   /**

--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -13,7 +13,7 @@ const pathSegment = 'chargebacks';
 export default class ChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
+    alias(this, { page: ['all', 'list'] });
   }
 
   /**

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -15,8 +15,7 @@ const pathSegment = 'customers';
 export default class CustomersBinder extends Binder<CustomerData, Customer> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
-    alias(this, 'delete', 'cancel')
+    alias(this, { page: ['all', 'list'], delete: 'cancel' });
   }
 
   /**

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -3,6 +3,7 @@ import type Customer from '../../data/customers/Customer';
 import { type CustomerData } from '../../data/customers/Customer';
 import type Page from '../../data/page/Page';
 import ApiError from '../../errors/ApiError';
+import alias from '../../plumbing/alias';
 import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
@@ -14,6 +15,8 @@ const pathSegment = 'customers';
 export default class CustomersBinder extends Binder<CustomerData, Customer> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
+    alias(this, 'delete', 'cancel')
   }
 
   /**

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -3,6 +3,7 @@ import { type MandateData } from '../../../data/customers/mandates/data';
 import type Mandate from '../../../data/customers/mandates/Mandate';
 import type Page from '../../../data/page/Page';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,8 @@ function getPathSegments(customerId: string) {
 export default class CustomerMandatesBinder extends Binder<MandateData, Mandate> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
+    alias(this, 'revoke', 'cancel', 'delete');
   }
 
   /**

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -17,8 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerMandatesBinder extends Binder<MandateData, Mandate> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
-    alias(this, 'revoke', 'cancel', 'delete');
+    alias(this, { page: ['all', 'list'], revoke: ['cancel', 'delete'] });
   }
 
   /**

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type PaymentData } from '../../../data/payments/data';
 import type Payment from '../../../data/payments/Payment';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
   }
 
   /**

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -17,7 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
+    alias(this, { page: ['all', 'list'] });
   }
 
   /**

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type SubscriptionData } from '../../../data/subscriptions/data';
 import type Subscription from '../../../data/subscriptions/Subscription';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,8 @@ function getPathSegments(customerId: string) {
 export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData, Subscription> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
+    alias(this, 'cancel', 'delete');
   }
 
   /**

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -17,8 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData, Subscription> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
-    alias(this, 'cancel', 'delete');
+    alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 
   /**

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -12,7 +12,7 @@ const pathSegment = 'methods';
 export default class MethodsBinder extends Binder<MethodData, Method> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'list', 'all', 'page');
+    alias(this, { list: ['all', 'page'] });
   }
 
   /**

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -1,6 +1,7 @@
 import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import type Method from '../../data/methods/Method';
 import { type MethodData } from '../../data/methods/data';
+import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
@@ -11,6 +12,7 @@ const pathSegment = 'methods';
 export default class MethodsBinder extends Binder<MethodData, Method> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'list', 'all', 'page');
   }
 
   /**

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -37,8 +37,7 @@ export const pathSegment = 'orders';
 export default class OrdersBinder extends Binder<OrderData, Order> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
-    alias(this, 'cancel', 'delete');
+    alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 
   /**

--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -8,6 +8,7 @@ import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type CancelParameters, type CreateParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
+import alias from '../../plumbing/alias';
 
 export const pathSegment = 'orders';
 
@@ -36,6 +37,8 @@ export const pathSegment = 'orders';
 export default class OrdersBinder extends Binder<OrderData, Order> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
+    alias(this, 'cancel', 'delete');
   }
 
   /**

--- a/src/binders/orders/orderlines/OrderLinesBinder.ts
+++ b/src/binders/orders/orderlines/OrderLinesBinder.ts
@@ -2,6 +2,7 @@ import type TransformingNetworkClient from '../../../communication/TransformingN
 import { type OrderData } from '../../../data/orders/data';
 import type Order from '../../../data/orders/Order';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -15,6 +16,7 @@ function getPathSegments(orderId: string) {
 export default class OrderLinesBinder extends Binder<OrderData, Order> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'cancel', 'delete');
   }
 
   /**

--- a/src/binders/orders/orderlines/OrderLinesBinder.ts
+++ b/src/binders/orders/orderlines/OrderLinesBinder.ts
@@ -16,7 +16,7 @@ function getPathSegments(orderId: string) {
 export default class OrderLinesBinder extends Binder<OrderData, Order> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'cancel', 'delete');
+    alias(this, { cancel: 'delete' });
   }
 
   /**

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -16,7 +16,7 @@ export function getPathSegments(orderId: string) {
 export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'list', 'all', 'page');
+    alias(this, { list: ['all', 'page'] });
   }
 
   /**

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -2,6 +2,7 @@ import type TransformingNetworkClient from '../../../communication/TransformingN
 import type Shipment from '../../../data/orders/shipments/Shipment';
 import { type ShipmentData } from '../../../data/orders/shipments/Shipment';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -15,6 +16,7 @@ export function getPathSegments(orderId: string) {
 export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'list', 'all', 'page');
   }
 
   /**

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../data/page/Page';
 import { type PaymentData } from '../../data/payments/data';
 import type Payment from '../../data/payments/Payment';
 import ApiError from '../../errors/ApiError';
+import alias from '../../plumbing/alias';
 import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
@@ -14,6 +15,8 @@ const pathSegment = 'payments';
 export default class PaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
+    alias(this, 'cancel', 'delete');
   }
 
   /**

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -15,8 +15,7 @@ const pathSegment = 'payments';
 export default class PaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
-    alias(this, 'cancel', 'delete');
+    alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 
   /**

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import type Capture from '../../../data/payments/captures/Capture';
 import { type CaptureData } from '../../../data/payments/captures/data';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentCapturesBinder extends Binder<CaptureData, Capture> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
   }
 
   /**

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -17,7 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentCapturesBinder extends Binder<CaptureData, Capture> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
+    alias(this, { page: ['all', 'list'] });
   }
 
   /**

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -17,7 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
+    alias(this, { page: ['all', 'list'] });
   }
 
   /**

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -3,6 +3,7 @@ import type Chargeback from '../../../data/chargebacks/Chargeback';
 import { type ChargebackData } from '../../../data/chargebacks/Chargeback';
 import type Page from '../../../data/page/Page';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
   }
 
   /**

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -17,8 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
-    alias(this, 'cancel', 'delete');
+    alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 
   /**

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type RefundData } from '../../../data/refunds/data';
 import type Refund from '../../../data/refunds/Refund';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,8 @@ function getPathSegments(paymentId: string) {
 export default class PaymentRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
+    alias(this, 'cancel', 'delete');
   }
 
   /**

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -1,6 +1,7 @@
 import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import type Permission from '../../data/permissions/Permission';
 import { type PermissionData } from '../../data/permissions/Permission';
+import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
@@ -10,6 +11,7 @@ const pathSegment = 'permissions';
 export default class PermissionsBinder extends Binder<PermissionData, Permission> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'list', 'page');
   }
 
   /**

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -11,7 +11,7 @@ const pathSegment = 'permissions';
 export default class PermissionsBinder extends Binder<PermissionData, Permission> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'list', 'page');
+    alias(this, { list: 'page' });
   }
 
   /**

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -15,7 +15,7 @@ const pathSegment = 'profiles';
 export default class ProfilesBinder extends Binder<ProfileData, Profile> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'list');
+    alias(this, { page: 'list' });
   }
 
   /**

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../data/page/Page';
 import { type ProfileData } from '../../data/profiles/data';
 import type Profile from '../../data/profiles/Profile';
 import ApiError from '../../errors/ApiError';
+import alias from '../../plumbing/alias';
 import checkId from '../../plumbing/checkId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
@@ -14,6 +15,7 @@ const pathSegment = 'profiles';
 export default class ProfilesBinder extends Binder<ProfileData, Profile> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'list');
   }
 
   /**

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -2,6 +2,7 @@ import type TransformingNetworkClient from '../../communication/TransformingNetw
 import type Page from '../../data/page/Page';
 import { type RefundData } from '../../data/refunds/data';
 import type Refund from '../../data/refunds/Refund';
+import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
@@ -12,6 +13,7 @@ const pathSegment = 'refunds';
 export default class RefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
   }
 
   /**

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -13,7 +13,7 @@ const pathSegment = 'refunds';
 export default class RefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
+    alias(this, { page: ['all', 'list'] });
   }
 
   /**

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -17,7 +17,7 @@ export function getPathSegments(orderId: string) {
 export default class OrderRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'all', 'list');
+    alias(this, { page: ['all', 'list'] });
   }
 
   /**

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type RefundData } from '../../../data/refunds/data';
 import type Refund from '../../../data/refunds/Refund';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,7 @@ export function getPathSegments(orderId: string) {
 export default class OrderRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'all', 'list');
   }
 
   /**

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -13,7 +13,7 @@ const pathSegment = 'subscriptions';
 export default class SubscriptionsBinder extends Binder<SubscriptionData, Subscription> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'list');
+    alias(this, { page: 'list' });
   }
 
   /**

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -2,6 +2,7 @@ import type TransformingNetworkClient from '../../communication/TransformingNetw
 import type Page from '../../data/page/Page';
 import { type SubscriptionData } from '../../data/subscriptions/data';
 import type Subscription from '../../data/subscriptions/Subscription';
+import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
@@ -12,6 +13,7 @@ const pathSegment = 'subscriptions';
 export default class SubscriptionsBinder extends Binder<SubscriptionData, Subscription> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'list');
   }
 
   /**

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type PaymentData } from '../../../data/payments/data';
 import type Payment from '../../../data/payments/Payment';
 import ApiError from '../../../errors/ApiError';
+import alias from '../../../plumbing/alias';
 import checkId from '../../../plumbing/checkId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
@@ -16,6 +17,7 @@ function getPathSegments(customerId: string, subscriptionId: string): string {
 export default class SubscriptionPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    alias(this, 'page', 'list');
   }
 
   /**

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -17,7 +17,7 @@ function getPathSegments(customerId: string, subscriptionId: string): string {
 export default class SubscriptionPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    alias(this, 'page', 'list');
+    alias(this, { page: 'list' });
   }
 
   /**

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -1,10 +1,12 @@
 // Lib
+import { apply } from 'ruply';
 import { version as libraryVersion } from '../package.json';
 import caCertificates from './cacert.pem';
 import NetworkClient from './communication/NetworkClient';
 import TransformingNetworkClient, { Transformers } from './communication/TransformingNetworkClient';
 import { checkCredentials } from './Options';
 import type Options from './Options';
+import alias from './plumbing/alias';
 
 // Transformers
 import { transform as transformPayment } from './data/payments/Payment';
@@ -97,73 +99,88 @@ export default function createMollieClient(options: Options) {
       .add('settlement', transformSettlement),
   );
 
-  return {
-    // Payments.
-    payments: new PaymentsBinder(transformingNetworkClient),
+  return apply(
+    {
+      // Payments.
+      payments: new PaymentsBinder(transformingNetworkClient),
 
-    // Methods.
-    methods: new MethodsBinder(transformingNetworkClient),
+      // Methods.
+      methods: new MethodsBinder(transformingNetworkClient),
 
-    // Refunds.
-    refunds: new RefundsBinder(transformingNetworkClient),
-    paymentRefunds: new PaymentRefundsBinder(transformingNetworkClient),
+      // Refunds.
+      refunds: new RefundsBinder(transformingNetworkClient),
+      paymentRefunds: new PaymentRefundsBinder(transformingNetworkClient),
 
-    // Chargebacks.
-    chargebacks: new ChargebacksBinder(transformingNetworkClient),
-    paymentChargebacks: new PaymentChargebacksBinder(transformingNetworkClient),
+      // Chargebacks.
+      chargebacks: new ChargebacksBinder(transformingNetworkClient),
+      paymentChargebacks: new PaymentChargebacksBinder(transformingNetworkClient),
 
-    // Captures.
-    paymentCaptures: new PaymentCapturesBinder(transformingNetworkClient),
+      // Captures.
+      paymentCaptures: new PaymentCapturesBinder(transformingNetworkClient),
 
-    // Customers.
-    customers: new CustomersBinder(transformingNetworkClient),
-    customerPayments: new CustomerPaymentsBinder(transformingNetworkClient),
+      // Customers.
+      customers: new CustomersBinder(transformingNetworkClient),
+      customerPayments: new CustomerPaymentsBinder(transformingNetworkClient),
 
-    // Mandates.
-    customerMandates: new CustomerMandatesBinder(transformingNetworkClient),
+      // Mandates.
+      customerMandates: new CustomerMandatesBinder(transformingNetworkClient),
 
-    // Subscriptions.
-    subscription: new SubscriptionsBinder(transformingNetworkClient),
-    subscriptionPayments: new SubscriptionPaymentsBinder(transformingNetworkClient),
-    customerSubscriptions: new CustomerSubscriptionsBinder(transformingNetworkClient),
+      // Subscriptions.
+      subscription: new SubscriptionsBinder(transformingNetworkClient),
+      subscriptionPayments: new SubscriptionPaymentsBinder(transformingNetworkClient),
+      customerSubscriptions: new CustomerSubscriptionsBinder(transformingNetworkClient),
 
-    // Orders.
-    orders: new OrdersBinder(transformingNetworkClient),
-    orderRefunds: new OrderRefundsBinder(transformingNetworkClient),
-    orderLines: new OrderLinesBinder(transformingNetworkClient),
-    orderPayments: new OrderPaymentsBinder(transformingNetworkClient),
+      // Orders.
+      orders: new OrdersBinder(transformingNetworkClient),
+      orderRefunds: new OrderRefundsBinder(transformingNetworkClient),
+      orderLines: new OrderLinesBinder(transformingNetworkClient),
+      orderPayments: new OrderPaymentsBinder(transformingNetworkClient),
 
-    // Shipments.
-    orderShipments: new OrderShipmentsBinder(transformingNetworkClient),
+      // Shipments.
+      orderShipments: new OrderShipmentsBinder(transformingNetworkClient),
 
-    // Permissions.
-    permissions: new PermissionsBinder(transformingNetworkClient),
+      // Permissions.
+      permissions: new PermissionsBinder(transformingNetworkClient),
 
-    // Organizations.
-    organizations: new OrganizationsBinder(transformingNetworkClient),
+      // Organizations.
+      organizations: new OrganizationsBinder(transformingNetworkClient),
 
-    // Profiles.
-    profiles: new ProfilesBinder(transformingNetworkClient),
-    profileMethods: new ProfileMethodsBinder(transformingNetworkClient),
-    profileGiftcardIssuers: new ProfileGiftcardIssuersBinder(transformingNetworkClient),
-    profileVoucherIssuers: new ProfileVoucherIssuersBinder(transformingNetworkClient),
+      // Profiles.
+      profiles: new ProfilesBinder(transformingNetworkClient),
+      profileMethods: new ProfileMethodsBinder(transformingNetworkClient),
+      profileGiftcardIssuers: new ProfileGiftcardIssuersBinder(transformingNetworkClient),
+      profileVoucherIssuers: new ProfileVoucherIssuersBinder(transformingNetworkClient),
 
-    // Onboarding.
-    onboarding: new OnboardingBinder(transformingNetworkClient),
+      // Onboarding.
+      onboarding: new OnboardingBinder(transformingNetworkClient),
 
-    // Apple Pay.
-    applePay: new ApplePayBinder(networkClient),
+      // Apple Pay.
+      applePay: new ApplePayBinder(networkClient),
 
-    // Payment links.
-    paymentLinks: new PaymentLinksBinder(transformingNetworkClient),
+      // Payment links.
+      paymentLinks: new PaymentLinksBinder(transformingNetworkClient),
 
-    // Settlements
-    settlements: new SettlementsBinder(transformingNetworkClient),
-    settlementPayments: new SettlementPaymentsBinder(transformingNetworkClient),
-    settlementCaptures: new SettlementCapturesBinder(transformingNetworkClient),
-    settlementRefunds: new SettlementRefundsBinder(transformingNetworkClient),
-    settlementChargebacks: new SettlementChargebacksBinder(transformingNetworkClient),
-  };
+      // Settlements
+      settlements: new SettlementsBinder(transformingNetworkClient),
+      settlementPayments: new SettlementPaymentsBinder(transformingNetworkClient),
+      settlementCaptures: new SettlementCapturesBinder(transformingNetworkClient),
+      settlementRefunds: new SettlementRefundsBinder(transformingNetworkClient),
+      settlementChargebacks: new SettlementChargebacksBinder(transformingNetworkClient),
+    },
+    client => {
+      alias(client, 'paymentRefunds', 'payments_refunds');
+      alias(client, 'paymentChargebacks', 'payments_chargebacks');
+      alias(client, 'paymentCaptures', 'payments_captures');
+      alias(client, 'customerPayments', 'customers_payments');
+      alias(client, 'customerMandates', 'customers_mandates');
+      alias(client, 'subscriptionPayments', 'subscriptions_payments');
+      alias(client, 'customerSubscriptions', 'customers_subscriptions');
+      alias(client, 'orderRefunds', 'orders_refunds');
+      alias(client, 'orderLines', 'orders_lines');
+      alias(client, 'orderPayments', 'orders_payments');
+      alias(client, 'orderShipments', 'orders_shipments');
+    },
+  );
 }
 
 export { createMollieClient };

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -167,19 +167,20 @@ export default function createMollieClient(options: Options) {
       settlementRefunds: new SettlementRefundsBinder(transformingNetworkClient),
       settlementChargebacks: new SettlementChargebacksBinder(transformingNetworkClient),
     },
-    client => {
-      alias(client, 'paymentRefunds', 'payments_refunds');
-      alias(client, 'paymentChargebacks', 'payments_chargebacks');
-      alias(client, 'paymentCaptures', 'payments_captures');
-      alias(client, 'customerPayments', 'customers_payments');
-      alias(client, 'customerMandates', 'customers_mandates');
-      alias(client, 'subscriptionPayments', 'subscriptions_payments');
-      alias(client, 'customerSubscriptions', 'customers_subscriptions');
-      alias(client, 'orderRefunds', 'orders_refunds');
-      alias(client, 'orderLines', 'orders_lines');
-      alias(client, 'orderPayments', 'orders_payments');
-      alias(client, 'orderShipments', 'orders_shipments');
-    },
+    client =>
+      alias(client, {
+        paymentRefunds: 'payments_refunds',
+        paymentChargebacks: 'payments_chargebacks',
+        paymentCaptures: 'payments_captures',
+        customerPayments: 'customers_payments',
+        customerMandates: 'customers_mandates',
+        subscriptionPayments: 'subscriptions_payments',
+        customerSubscriptions: 'customers_subscriptions',
+        orderRefunds: 'orders_refunds',
+        orderLines: 'orders_lines',
+        orderPayments: 'orders_payments',
+        orderShipments: 'orders_shipments',
+      }),
   );
 }
 

--- a/src/plumbing/alias.ts
+++ b/src/plumbing/alias.ts
@@ -1,0 +1,17 @@
+import { run } from 'ruply';
+
+/**
+ * Defines new properties on the passed target object which take the value of the original property. The newly defined
+ * properties are not enumerable and purposely do not exist in the TypeScript type of the target object.
+ */
+export default function alias<T>(target: T, property: keyof T & string, ...aliases: Array<string>) {
+  run(
+    {
+      configurable: true,
+      /* enumerable: false, */
+      writable: true,
+      value: target[property],
+    },
+    descriptor => aliases.forEach(alias => Object.defineProperty(target, alias, descriptor)),
+  );
+}

--- a/src/plumbing/alias.ts
+++ b/src/plumbing/alias.ts
@@ -1,17 +1,31 @@
-import { run } from 'ruply';
+import { apply, run } from 'ruply';
+
+function createDescriptor<T>(value: T) {
+  return {
+    configurable: true,
+    /* enumerable: false, */
+    writable: true,
+    value,
+  } satisfies PropertyDescriptor;
+}
 
 /**
  * Defines new properties on the passed target object which take the value of the original property. The newly defined
  * properties are not enumerable and purposely do not exist in the TypeScript type of the target object.
  */
-export default function alias<T>(target: T, property: keyof T & string, ...aliases: Array<string>) {
-  run(
-    {
-      configurable: true,
-      /* enumerable: false, */
-      writable: true,
-      value: target[property],
-    },
-    descriptor => aliases.forEach(alias => Object.defineProperty(target, alias, descriptor)),
+export default function alias<T, P extends keyof T>(target: T, aliases: Record<P, Array<string> | string>) {
+  Object.defineProperties(
+    target,
+    (Object.entries(aliases) as Array<[P, Array<string> | string]>).reduce(
+      (descriptors, [property, aliases]) =>
+        apply(descriptors, descriptors => {
+          if (Array.isArray(aliases)) {
+            aliases.forEach(alias => (descriptors[alias] = createDescriptor(target[property])));
+          } /* if ('string' == typeof aliases) */ else {
+            descriptors[aliases as string] = createDescriptor(target[property]);
+          }
+        }),
+      {} as PropertyDescriptorMap,
+    ),
   );
 }

--- a/tests/unit/backwards-compatibitily.test.ts
+++ b/tests/unit/backwards-compatibitily.test.ts
@@ -1,0 +1,11 @@
+import createMollieClient from '../..';
+
+test('client object should have aliases for backwards-compatibility', () => {
+  const client = createMollieClient({ apiKey: 'mock-api-key' });
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  expect(client.payments_refunds).toBe(client.paymentRefunds);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  expect(client.customers_subscriptions).toBe(client.customerSubscriptions);
+});

--- a/tests/unit/backwards-compatibitily.test.ts
+++ b/tests/unit/backwards-compatibitily.test.ts
@@ -9,3 +9,13 @@ test('client object should have aliases for backwards-compatibility', () => {
   // @ts-ignore
   expect(client.customers_subscriptions).toBe(client.customerSubscriptions);
 });
+
+test('binder should have aliases for backwards-compatibility', () => {
+  const client = createMollieClient({ apiKey: 'mock-api-key' });
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  expect(client.paymentRefunds.all).toBe(client.paymentRefunds.page);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  expect(client.paymentRefunds.list).toBe(client.paymentRefunds.page);
+});


### PR DESCRIPTION
We [removed snake_case aliases for client properties](//github.com/mollie/mollie-api-node/pull/314) and [aliases for endpoints](//github.com/mollie/mollie-api-node/pull/315). This PR re-introduces them, this time unenumerable and non-existent in the TypeScript types.

This will not do much for TypeScript users, they will still get a compile-time error. This merely affects JavaScript users who are still using deprecated aliases. See #319 for more discussion on this.