### PR TITLE
Readme images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-![Mollie](https://www.mollie.com/files/Mollie-Logo-Style-Small.png)
+![Mollie](https://github.com/user-attachments/assets/2236d7d8-d5b6-4d1c-bb76-390d5e96db00)
+
 
 ### Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-  <img src="https://info.mollie.com/hubfs/github/nodejs/logo-1.png" width="128" height="128"/>
+  <img src="https://github.com/user-attachments/assets/a98b62f7-f0f1-44ac-8ade-3a83cfecf264" width="128" height="128"/>
 </p>
 <h1 align="center">Mollie API client for Node.js</h1>
 
-<img src="https://info.mollie.com/hubfs/github/nodejs/editor-3.png" />
+![Mollie Node.js API Example](https://github.com/user-attachments/assets/0c1c454f-c944-4042-863c-f0a556bdb87f)
 
 # About
 


### PR DESCRIPTION
This PR changes the URLs of the images in `README.md` and `CHANGELOG.md` from mollie.com ones to github.com (user attachment) ones. The images in `README.md` are currently broken. The `CHANGELOG.md` one isn't, but this PR hopefully ensures it won't.