### PR TITLE
Cleanup ApiError

### DIFF
--- a/src/errors/ApiError.ts
+++ b/src/errors/ApiError.ts
@@ -28,36 +28,6 @@ export default class ApiError extends Error {
   }
 
   /**
-   * Get the error message
-   *
-   * @since 3.0.0
-   * @deprecated Use `error.message` instead.
-   */
-  public getMessage(): string {
-    return this.message;
-  }
-
-  /**
-   * Get the field name that contains an error
-   *
-   * @since 3.0.0
-   * @deprecated Use `error.field` instead.
-   */
-  public getField(): Maybe<string> {
-    return this.field;
-  }
-
-  /**
-   * Get the API status code
-   *
-   * @since 3.0.0
-   * @deprecated Use `error.statusCode` instead.
-   */
-  public getStatusCode(): Maybe<number> {
-    return this.statusCode;
-  }
-
-  /**
    * Get the documentation URL
    *
    * @since 3.0.0

--- a/tests/unit/resources/methods.test.ts
+++ b/tests/unit/resources/methods.test.ts
@@ -46,7 +46,7 @@ describe('methods', () => {
           })
           .catch(err => {
             expect(err).toBeInstanceOf(ApiError);
-            expect(err.getMessage()).toEqual(error.detail);
+            expect(err.message).toEqual(error.detail);
           });
       });
     });
@@ -57,7 +57,7 @@ describe('methods', () => {
         return new Promise<void>(resolve => {
           methods.get('foo', {}, (err: any, result) => {
             expect(err).toBeInstanceOf(ApiError);
-            expect(err.getMessage()).toEqual(error.detail);
+            expect(err.message).toEqual(error.detail);
             expect(result).toBeUndefined();
             resolve();
           });


### PR DESCRIPTION
This PR removes `ApiError::getMessage`, `ApiError::getField`, and `ApiError::getStatusCode`:
```diff
  try {
    const payment = await mollieClient.payments.get(…);
  } catch (error) {
-    console.warn(error.getMessage())
+    console.warn(error.message)
  }
```
The functions were deprecated in eb0abd2c1e7c230e8f6e6634ce68a134e7bce6c5. The values returned by these functions are available as (public) properties.