### PR TITLE
Cleanup helpers

### DIFF
--- a/src/data/customers/mandates/MandateHelper.ts
+++ b/src/data/customers/mandates/MandateHelper.ts
@@ -13,15 +13,6 @@ export default class MandateHelper extends Helper<MandateData, Mandate> {
   }
 
   /**
-   * Returns whether the mandate is valid.
-   *
-   * @deprecated Use `mandate.status == MandateStatus.valid` instead.
-   */
-  public isValid(this: MandateData): boolean {
-    return this.status === MandateStatus.valid;
-  }
-
-  /**
    * Returns the payments belonging to the customer.
    *
    * @since 3.6.0

--- a/src/data/onboarding/OnboardingHelper.ts
+++ b/src/data/onboarding/OnboardingHelper.ts
@@ -13,27 +13,6 @@ export default class OnboardingHelper extends Helper<OnboardingData, Onboarding>
   }
 
   /**
-   * @deprecated Use `onboarding.status == OnboardingStatus.needsData` instead.
-   */
-  public needsData(this: OnboardingData) {
-    return this.status == OnboardingStatus.needsData;
-  }
-
-  /**
-   * @deprecated Use `onboarding.status == OnboardingStatus.inReview` instead.
-   */
-  public isInReview(this: OnboardingData) {
-    return this.status == OnboardingStatus.inReview;
-  }
-
-  /**
-   * @deprecated Use `onboarding.status == OnboardingStatus.completed` instead.
-   */
-  public isCompleted(this: OnboardingData) {
-    return this.status == OnboardingStatus.completed;
-  }
-
-  /**
    * Returns the organization.
    *
    * @since 3.6.0

--- a/src/data/payments/PaymentHelper.ts
+++ b/src/data/payments/PaymentHelper.ts
@@ -28,85 +28,12 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
   }
 
   /**
-   * Returns whether the payment has been created, but nothing else has happened with it yet.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.open` instead.
-   */
-  public isOpen(this: PaymentData): boolean {
-    return this.status === PaymentStatus.open;
-  }
-
-  /**
-   * Returns whether new captures can be created for this payment.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.authorized` instead.
-   */
-  public isAuthorized(this: PaymentData): boolean {
-    return this.status === PaymentStatus.authorized;
-  }
-
-  /**
-   * Returns whether the payment is successfully paid.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.paid` instead.
-   */
-  public isPaid(this: PaymentData): boolean {
-    return this.paidAt != undefined;
-  }
-
-  /**
-   * Returns whether the payment has been canceled by the customer.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.canceled` instead.
-   */
-  public isCanceled(this: PaymentData): boolean {
-    return this.status == PaymentStatus.canceled;
-  }
-
-  /**
-   * Returns whether the payment has expired, e.g. the customer has abandoned the payment.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.expired` instead.
-   */
-  public isExpired(this: PaymentData): boolean {
-    return this.status == PaymentStatus.expired;
-  }
-
-  /**
    * Returns whether the payment is refundable.
    *
    * @since 2.0.0-rc.2
    */
   public isRefundable(this: PaymentData): boolean {
     return this.amountRemaining !== null;
-  }
-
-  /**
-   * Returns the URL the customer should visit to make the payment. This is to where you should redirect the consumer.
-   *
-   * @deprecated Use `payment.getCheckoutUrl()` instead.
-   */
-  public getPaymentUrl(): Nullable<string> {
-    return this.getCheckoutUrl();
-  }
-
-  /**
-   * Returns whether the payment has failed and cannot be completed with a different payment method.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.failed` instead.
-   */
-  public isFailed(this: PaymentData): boolean {
-    return this.status == PaymentStatus.failed;
-  }
-
-  /**
-   * Returns whether the payment is in this temporary status that can occur when the actual payment process has been
-   * started, but has not completed yet.
-   *
-   * @deprecated Use `payment.status == PaymentStatus.pending` instead.
-   */
-  public isPending(this: PaymentData): boolean {
-    return this.status == PaymentStatus.pending;
   }
 
   /**
@@ -124,26 +51,6 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
   }
 
   /**
-   * Returns whether `sequenceType` is set to `'first'`. If a `'first'` payment has been completed successfully, the
-   * consumer's account may be charged automatically using recurring payments.
-   *
-   * @deprecated Use `payment.sequenceType == SequenceType.first` instead.
-   */
-  public hasSequenceTypeFirst(this: PaymentData): boolean {
-    return this.sequenceType == SequenceType.first;
-  }
-
-  /**
-   * Returns whether `sequenceType` is set to `'recurring'`. This type of payment is processed without involving the
-   * consumer.
-   *
-   * @deprecated Use `payment.sequenceType == SequenceType.recurring` instead.
-   */
-  public hasSequenceTypeRecurring(this: PaymentData): boolean {
-    return this.sequenceType == SequenceType.recurring;
-  }
-
-  /**
    * The URL your customer should visit to make the payment. This is where you should redirect the consumer to.
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=_links/checkout#response
@@ -158,41 +65,6 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
 
   public canBePartiallyRefunded(this: PaymentData): boolean {
     return this.amountRemaining != undefined;
-  }
-
-  /**
-   * Returns the total amount that is already refunded. For some payment methods, this amount may be higher than the
-   * payment amount, for example to allow reimbursement of the costs for a return shipment to the customer.
-   *
-   * @deprecated Use `payment.amountRefunded` instead. To obtain the value, use `payment.amountRefunded?.value`.
-   */
-  public getAmountRefunded(this: PaymentData): Amount {
-    if (this.amountRefunded == undefined) {
-      return {
-        // Perhaps this zero-value should depend on the currency. If the currency is JPY (¥), for instance, the value
-        // should probably be "0"; not "0.00".
-        value: '0.00',
-        currency: this.amount.currency,
-      };
-    }
-    return this.amountRefunded;
-  }
-
-  /**
-   * Returns the remaining amount that can be refunded.
-   *
-   * @deprecated Use `payment.amountRemaining` instead. To obtain the value, use `payment.amountRemaining?.value`.
-   */
-  public getAmountRemaining(this: PaymentData): Amount {
-    if (this.amountRemaining == undefined) {
-      return {
-        // Perhaps this zero-value should depend on the currency. If the currency is JPY (¥), for instance, the value
-        // should probably be "0"; not "0.00".
-        value: '0.00',
-        currency: this.amount.currency,
-      };
-    }
-    return this.amountRemaining;
   }
 
   /**

--- a/src/data/profiles/ProfileHelper.ts
+++ b/src/data/profiles/ProfileHelper.ts
@@ -24,27 +24,6 @@ export default class ProfileHelper extends Helper<ProfileData, Profile> {
   }
 
   /**
-   * @deprecated Use `profile.status == ProfileStatus.unverified` instead.
-   */
-  public isUnverified(this: ProfileData) {
-    return this.status == ProfileStatus.unverified;
-  }
-
-  /**
-   * @deprecated Use `profile.status == ProfileStatus.verified` instead.
-   */
-  public isVerified(this: ProfileData) {
-    return this.status == ProfileStatus.verified;
-  }
-
-  /**
-   * @deprecated Use `profile.status == ProfileStatus.blocked` instead.
-   */
-  public isBlocked(this: ProfileData) {
-    return this.status == ProfileStatus.blocked;
-  }
-
-  /**
    * The Checkout preview URL. You need to be logged in to access this page.
    *
    * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/checkoutPreviewUrl#response

--- a/src/data/refunds/RefundHelper.ts
+++ b/src/data/refunds/RefundHelper.ts
@@ -19,51 +19,6 @@ export default class RefundHelper extends Helper<RefundData, Refund> {
   }
 
   /**
-   * Returns whether the refund is queued due to a lack of balance. A queued refund can be canceled.
-   *
-   * @deprecated Use `refund.status == RefundStatus.queued` instead.
-   */
-  public isQueued(this: RefundData): boolean {
-    return this.status === RefundStatus.queued;
-  }
-
-  /**
-   * Returns whether the refund is ready to be sent to the bank. You can still cancel the refund if you like.
-   *
-   * @deprecated Use `refund.status == RefundStatus.pending` instead.
-   */
-  public isPending(this: RefundData): boolean {
-    return this.status === RefundStatus.pending;
-  }
-
-  /**
-   * Returns whether the refund is being processed. Cancellation is no longer possible if so.
-   *
-   * @deprecated Use `refund.status == RefundStatus.processing` instead.
-   */
-  public isProcessing(this: RefundData): boolean {
-    return this.status === RefundStatus.processing;
-  }
-
-  /**
-   * Returns whether the refund has been settled to your customer.
-   *
-   * @deprecated Use `refund.status == RefundStatus.refunded` instead.
-   */
-  public isRefunded(this: RefundData): boolean {
-    return this.status === RefundStatus.refunded;
-  }
-
-  /**
-   * Returns whether the refund has failed after processing.
-   *
-   * @deprecated Use `refund.status == RefundStatus.failed` instead.
-   */
-  public isFailed(this: RefundData): boolean {
-    return this.status === RefundStatus.failed;
-  }
-
-  /**
    * Returns the payment this refund was created for.
    *
    * @since 3.6.0

--- a/src/data/subscriptions/SubscriptionHelper.ts
+++ b/src/data/subscriptions/SubscriptionHelper.ts
@@ -30,41 +30,6 @@ export default class SubscriptionHelper extends Helper<SubscriptionData, Subscri
   }
 
   /**
-   * @deprecated Use `subscription.status == SubscriptionStatus.active` instead.
-   */
-  public isActive(this: SubscriptionData): boolean {
-    return this.status === SubscriptionStatus.active;
-  }
-
-  /**
-   * @deprecated Use `subscription.status == SubscriptionStatus.pending` instead.
-   */
-  public isPending(this: SubscriptionData): boolean {
-    return this.status === SubscriptionStatus.pending;
-  }
-
-  /**
-   * @deprecated Use `subscription.status == SubscriptionStatus.completed` instead.
-   */
-  public isCompleted(this: SubscriptionData): boolean {
-    return this.status === SubscriptionStatus.completed;
-  }
-
-  /**
-   * @deprecated Use `subscription.status == SubscriptionStatus.suspended` instead.
-   */
-  public isSuspended(this: SubscriptionData): boolean {
-    return this.status === SubscriptionStatus.suspended;
-  }
-
-  /**
-   * @deprecated Use `subscription.status == SubscriptionStatus.canceled` instead.
-   */
-  public isCanceled(this: SubscriptionData): boolean {
-    return SubscriptionStatus.canceled == this.status;
-  }
-
-  /**
    * Returns the customer the subscription is for.
    *
    * @since 3.6.0

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { fail } from 'node:assert';
 
-import createMollieClient, { Locale, OrderEmbed, OrderLineType, Payment, PaymentMethod } from '../..';
+import createMollieClient, { Locale, OrderEmbed, OrderLineType, Payment, PaymentMethod, PaymentStatus } from '../..';
 
 /**
  * Load the API_KEY environment variable
@@ -94,7 +94,7 @@ describe('orders', () => {
     const order = await orderExists;
 
     const payment: Payment = order._embedded.payments[0];
-    if (!payment.isPaid()) {
+    if (payment.status != PaymentStatus.paid) {
       console.log('If you want to test the full flow, set the embedded order payment to paid:', order.redirectUrl);
       return;
     }

--- a/tests/integration/payments.test.ts
+++ b/tests/integration/payments.test.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { fail } from 'node:assert';
 
-import createMollieClient from '../..';
+import createMollieClient, { PaymentStatus } from '../..';
 
 /**
  * Load the API_KEY environment variable
@@ -16,7 +16,7 @@ describe('payments', () => {
 
     let paymentExists;
 
-    if (!payments.length || payments[0].isExpired()) {
+    if (!payments.length || payments[0].status == PaymentStatus.expired) {
       paymentExists = mollieClient.payments
         .create({
           amount: { value: '10.00', currency: 'EUR' },
@@ -35,8 +35,8 @@ describe('payments', () => {
 
     const payment = await paymentExists;
 
-    if (!payment.isPaid()) {
-      console.log('If you want to test the full flow, set the payment to paid:', payment.getPaymentUrl());
+    if (payment.status != PaymentStatus.paid) {
+      console.log('If you want to test the full flow, set the payment to paid:', payment.getCheckoutUrl());
       return;
     }
 

--- a/tests/unit/models/onboarding.test.ts
+++ b/tests/unit/models/onboarding.test.ts
@@ -36,22 +36,10 @@ function getOnboarding(status) {
 
 test('onboardingStatuses', () => {
   return Promise.all(
-    [
-      ['needs-data', 'needsData', true],
-      ['needs-data', 'isInReview', false],
-      ['needs-data', 'isCompleted', false],
-
-      ['in-review', 'needsData', false],
-      ['in-review', 'isInReview', true],
-      ['in-review', 'isCompleted', false],
-
-      ['completed', 'needsData', false],
-      ['completed', 'isInReview', false],
-      ['completed', 'isCompleted', true],
-    ].map(async ([status, method, expectedResult]) => {
+    ['needs-data', 'in-review', 'completed'].map(async status => {
       const onboarding = await getOnboarding(status);
 
-      expect(onboarding[method as keyof Onboarding]()).toBe(expectedResult);
+      expect(onboarding.status).toBe(status);
     }),
   );
 });

--- a/tests/unit/models/profile.test.ts
+++ b/tests/unit/models/profile.test.ts
@@ -51,22 +51,10 @@ function getProfile(status) {
 
 test('profileStatuses', () => {
   return Promise.all(
-    [
-      ['blocked', 'isBlocked', true],
-      ['blocked', 'isVerified', false],
-      ['blocked', 'isUnverified', false],
-
-      ['verified', 'isBlocked', false],
-      ['verified', 'isVerified', true],
-      ['verified', 'isUnverified', false],
-
-      ['unverified', 'isBlocked', false],
-      ['unverified', 'isVerified', false],
-      ['unverified', 'isUnverified', true],
-    ].map(async ([status, method, expectedResult]) => {
+    ['blocked', 'verified', 'unverified'].map(async status => {
       const profile = await getProfile(status);
 
-      expect(profile[method as keyof Profile]()).toBe(expectedResult);
+      expect(profile.status).toBe(status);
     }),
   );
 });

--- a/tests/unit/models/refund.test.ts
+++ b/tests/unit/models/refund.test.ts
@@ -55,26 +55,10 @@ function getRefund(status) {
 
 test('refundStatuses', () => {
   return Promise.all(
-    [
-      ['pending', 'isPending', true],
-      ['pending', 'isProcessing', false],
-      ['pending', 'isQueued', false],
-
-      ['processing', 'isPending', false],
-      ['processing', 'isProcessing', true],
-      ['processing', 'isQueued', false],
-
-      ['queued', 'isPending', false],
-      ['queued', 'isProcessing', false],
-      ['queued', 'isQueued', true],
-
-      ['refunded', 'isPending', false],
-      ['refunded', 'isProcessing', false],
-      ['refunded', 'isQueued', false],
-    ].map(async ([status, method, expectedResult]) => {
+    ['pending', 'processing', 'queued', 'refunded'].map(async status => {
       const refund = await getRefund(status);
 
-      expect(refund[method as keyof Refund]()).toBe(expectedResult);
+      expect(refund.status).toBe(status);
     }),
   );
 });

--- a/tests/unit/models/subscription.test.ts
+++ b/tests/unit/models/subscription.test.ts
@@ -41,41 +41,10 @@ function getSubscription(status) {
 
 test('subscriptionStatuses', () => {
   return Promise.all(
-    [
-      ['pending', 'isPending', true],
-      ['pending', 'isCanceled', false],
-      ['pending', 'isCompleted', false],
-      ['pending', 'isSuspended', false],
-      ['pending', 'isActive', false],
-
-      // (Note that canceled subscriptions usually have their canceledAt set.)
-      ['canceled', 'isPending', false],
-      ['canceled', 'isCanceled', true],
-      ['canceled', 'isCompleted', false],
-      ['canceled', 'isSuspended', false],
-      ['canceled', 'isActive', false],
-
-      ['completed', 'isPending', false],
-      ['completed', 'isCanceled', false],
-      ['completed', 'isCompleted', true],
-      ['completed', 'isSuspended', false],
-      ['completed', 'isActive', false],
-
-      ['suspended', 'isPending', false],
-      ['suspended', 'isCanceled', false],
-      ['suspended', 'isCompleted', false],
-      ['suspended', 'isSuspended', true],
-      ['suspended', 'isActive', false],
-
-      ['active', 'isPending', false],
-      ['active', 'isCanceled', false],
-      ['active', 'isCompleted', false],
-      ['active', 'isSuspended', false],
-      ['active', 'isActive', true],
-    ].map(async ([status, method, expectedResult]) => {
+    ['pending', 'canceled', 'completed', 'suspended', 'active'].map(async status => {
       const subscription = await getSubscription(status);
 
-      expect(subscription[method as keyof Subscription]()).toBe(expectedResult);
+      expect(subscription.status).toBe(status);
     }),
   );
 });


### PR DESCRIPTION
This PR removes deprecated helpers from `MandateHelper`, `OnboardingHelper`, `PaymentHelper`, `ProfileHelper`, `RefundHelper`, and `SubscriptionHelper`. These are functions with no or very little logic in them and can be easily avoided:
```diff
-if (payment.isOpen()) {
+if (payment.status == PaymentStatus.open) {
```
The functions were deprecated in eb0abd2c1e7c230e8f6e6634ce68a134e7bce6c5. I believe including them in the API produces more noise than convenience.