### PR TITLE
Remove Page::count

### DIFF
--- a/src/binders/Binder.ts
+++ b/src/binders/Binder.ts
@@ -10,7 +10,7 @@ export default class Binder<R, T extends Omit<R, '_links' | '_embedded'>> {
   /**
    * Injects `nextPage`, `nextPageCursor`, `previousPage`, and `previousPageCursor` into the passed list.
    */
-  protected injectPaginationHelpers<P>(input: Array<T> & Pick<Page<T>, 'count' | 'links'>, list: (parameters: P) => Promise<Page<T>>, selfParameters: P = {} as P): Page<T> {
+  protected injectPaginationHelpers<P>(input: Array<T> & Pick<Page<T>, 'links'>, list: (parameters: P) => Promise<Page<T>>, selfParameters: P = {} as P): Page<T> {
     const { links } = input;
     let nextPage: Maybe<() => Promise<Page<T>>>;
     let nextPageCursor: Maybe<string>;

--- a/src/communication/NetworkClient.ts
+++ b/src/communication/NetworkClient.ts
@@ -175,18 +175,15 @@ export default class NetworkClient {
     return embedded[binderName] as R[];
   }
 
-  async page<R>(pathname: string, binderName: string, query?: SearchParameters): Promise<R[] & Pick<Page<R>, 'links' | 'count'>> {
+  async page<R>(pathname: string, binderName: string, query?: SearchParameters): Promise<R[] & Pick<Page<R>, 'links'>> {
     const data = await this.request(buildUrl(pathname, query));
     try {
       /* eslint-disable-next-line no-var */
-      var { _embedded: embedded, _links: links, count } = data;
+      var { _embedded: embedded, _links: links } = data;
     } catch (error) {
       throw new ApiError('Received unexpected response from the server');
     }
-    return Object.assign(embedded[binderName] as R[], {
-      links,
-      count,
-    });
+    return Object.assign(embedded[binderName] as R[], { links });
   }
 
   iterate<R>(pathname: string, binderName: string, query: Maybe<SearchParameters>, valuesPerMinute = 5000): HelpfulIterator<R> {

--- a/src/communication/TransformingNetworkClient.ts
+++ b/src/communication/TransformingNetworkClient.ts
@@ -50,8 +50,8 @@ export default class TransformingNetworkClient {
 
   async page<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['page']>) {
     const response = await this.networkClient.page<R>(...passingArguments);
-    const { count, links } = response;
-    return Object.assign(response.map(this.transform) as U[], { count, links });
+    const { links } = response;
+    return Object.assign(response.map(this.transform) as U[], { links });
   }
 
   iterate<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['iterate']>) {

--- a/src/data/page/Page.ts
+++ b/src/data/page/Page.ts
@@ -4,10 +4,6 @@ import { type Links, type Url } from '../global';
 
 export default interface Page<T> extends Array<T> {
   links: PageLinks;
-  /**
-   * @deprecated Use `list.length` instead.
-   */
-  count: number;
   nextPageCursor: Maybe<string>;
   previousPageCursor: Maybe<string>;
   nextPage: Maybe<() => Promise<Page<T>>>;


### PR DESCRIPTION
ECMAScript has [a length property](https://tc39.es/ecma262/#sec-properties-of-array-instances-length) which makes `count` unnecessary. `count` was deprecated in eb0abd2c1e7c230e8f6e6634ce68a134e7bce6c5.
```diff
-payments.page({ limit: 10 }).count
+payments.page({ limit: 10 }).length
```