### PR TITLE
update metadata type from `any` to `unknown`

### DIFF
--- a/src/binders/orders/parameters.ts
+++ b/src/binders/orders/parameters.ts
@@ -5,8 +5,8 @@ import { type IdempotencyParameter, type PaginationParameters, type ThrottlingPa
 import { type CreateParameters as PaymentCreateParameters } from '../payments/parameters';
 import type PickOptional from '../../types/PickOptional';
 
-export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'consumerDateOfBirth' | 'webhookUrl' | 'locale' | 'metadata' | 'expiresAt'> &
-  PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'cancelUrl'> & {
+export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'consumerDateOfBirth' | 'webhookUrl' | 'locale' | 'expiresAt'> &
+  PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'cancelUrl' | 'metadata'> & {
     /**
      * All order lines must have the same currency as the order. You cannot mix currencies within a single order.
      *

--- a/src/binders/payments/refunds/parameters.ts
+++ b/src/binders/payments/refunds/parameters.ts
@@ -7,7 +7,7 @@ interface ContextParameters {
   testmode?: boolean;
 }
 
-export type CreateParameters = ContextParameters & Pick<RefundData, 'amount' | 'metadata'> & PickOptional<RefundData, 'description'> & IdempotencyParameter;
+export type CreateParameters = ContextParameters & Pick<RefundData, 'amount'> & PickOptional<RefundData, 'description' | 'metadata'> & IdempotencyParameter;
 
 export type GetParameters = ContextParameters & {
   embed?: RefundEmbed[];

--- a/src/data/customers/Customer.ts
+++ b/src/data/customers/Customer.ts
@@ -40,7 +40,7 @@ export interface CustomerData extends Model<'customer'> {
    *
    * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=metadata#response
    */
-  metadata: Record<string, string>;
+  metadata: unknown;
   /**
    * The customer's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *

--- a/src/data/orders/data.ts
+++ b/src/data/orders/data.ts
@@ -105,7 +105,7 @@ export interface OrderData extends Model<'order'> {
    *
    * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=metadata#response
    */
-  metadata?: any;
+  metadata: unknown;
   /**
    * The URL your customer will be redirected to after completing or canceling the payment process.
    *

--- a/src/data/orders/orderlines/OrderLine.ts
+++ b/src/data/orders/orderlines/OrderLine.ts
@@ -146,7 +146,7 @@ export interface OrderLineData extends Model<'orderline'> {
    * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=lines/_links#response
    */
   _links: OrderLineLinks;
-  metadata: any;
+  metadata: unknown;
 }
 
 type OrderLine = Seal<OrderLineData, {}>;

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -161,7 +161,7 @@ export interface PaymentData extends Model<'payment'> {
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=metadata#response
    */
-  metadata: any;
+  metadata: unknown;
   /**
    * The customer's locale, either forced on creation by specifying the `locale` parameter, or detected by us during checkout. Will be a full locale, for example `nl_NL`.
    *

--- a/src/data/refunds/data.ts
+++ b/src/data/refunds/data.ts
@@ -40,7 +40,7 @@ export interface RefundData extends Model<'refund'> {
    *
    * @see https://docs.mollie.com/reference/v2/refunds-api/get-payment-refund?path=metadata#response
    */
-  metadata?: any;
+  metadata: unknown;
   /**
    * Since refunds may not be instant for certain payment methods, the refund carries a status field.
    *

--- a/src/data/subscriptions/data.ts
+++ b/src/data/subscriptions/data.ts
@@ -99,7 +99,7 @@ export interface SubscriptionData extends Model<'subscription'> {
    *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=metadata#response
    */
-  metadata: any;
+  metadata: unknown;
   /**
    * The application fee, if the subscription was created with one. This will be applied on each payment created for the subscription.
    *


### PR DESCRIPTION
The general direction for ts is to use unknown over any here to force better type validation.

Also see:
https://github.com/microsoft/TypeScript/issues/41016