### PR TITLE
Mandates: export missing mandate types from package

### DIFF
--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -188,7 +188,7 @@ export { createMollieClient };
 
 export { ApiMode, Locale, PaymentMethod, HistoricPaymentMethod, SequenceType } from './data/global';
 export { CaptureEmbed } from './data/payments/captures/data';
-export { MandateMethod, MandateStatus } from './data/customers/mandates/data';
+export { type MandateDetails, type MandateDetailsCreditCard, type MandateDetailsDirectDebit, MandateMethod, MandateStatus } from './data/customers/mandates/data';
 export { MethodImageSize, MethodInclude } from './data/methods/data';
 export { OrderEmbed, OrderStatus } from './data/orders/data';
 export { OrderLineType } from './data/orders/orderlines/OrderLine';


### PR DESCRIPTION
This fixes https://github.com/mollie/mollie-api-node/issues/356