### PR TITLE
Methods: fix types for pricing and issuer

### DIFF
--- a/src/data/methods/data.ts
+++ b/src/data/methods/data.ts
@@ -32,7 +32,7 @@ export interface MethodData extends Model<'method', PaymentMethodEnum> {
    *
    * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=pricing#response
    */
-  pricing: MethodPricing;
+  pricing: MethodPricing[];
   /**
    * An object with several URL objects relevant to the payment method. Every URL object will contain an `href` and a `type` field.
    *

--- a/src/data/methods/data.ts
+++ b/src/data/methods/data.ts
@@ -32,7 +32,13 @@ export interface MethodData extends Model<'method', PaymentMethodEnum> {
    *
    * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=pricing#response
    */
-  pricing: MethodPricing[];
+  pricing?: MethodPricing[];
+  /**
+   * Pricing set of the payment method what will be include if you add the parameter.
+   *
+   * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=pricing#response
+   */
+  issuers?: MethodIssuers[];
   /**
    * An object with several URL objects relevant to the payment method. Every URL object will contain an `href` and a `type` field.
    *
@@ -92,4 +98,11 @@ export interface MethodPricing {
   fixed: Amount;
   variable: string;
   feeRegion: FeeRegion;
+}
+
+export interface MethodIssuers {
+  resource: string;
+  id: string;
+  name: string;
+  image: Image;
 }

--- a/src/data/methods/data.ts
+++ b/src/data/methods/data.ts
@@ -28,13 +28,14 @@ export interface MethodData extends Model<'method', PaymentMethodEnum> {
    */
   image: Image;
   /**
-   * Pricing set of the payment method what will be include if you add the parameter.
+   * Array of objects describing the pricing configuration applicable for this payment method on your account.
    *
    * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=pricing#response
    */
   pricing?: MethodPricing[];
   /**
-   * Pricing set of the payment method what will be include if you add the parameter.
+   * Array of objects for each 'issuer' that is available for this payment method. Only relevant for iDEAL, KBC/CBC,
+   * gift cards, and vouchers.
    *
    * @see https://docs.mollie.com/reference/v2/methods-api/get-method?path=pricing#response
    */


### PR DESCRIPTION
When using the method's `include` option, we expect the result to include a `pricing` or `issuers` property, which is an array of objects.

see https://docs.mollie.com/reference/get-method


This replaces https://github.com/mollie/mollie-api-node/pull/355 and resolves https://github.com/mollie/mollie-api-node/issues/316