### PR TITLE
Update payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 
 Please see [the migration guide](MIGRATION.md) for guidance about updating to a newer major version.
 
-### v4.0.0 - 2024-09-16
+### v4.0.0 - 2024-09-19
   - Replace Axios dependency in favour of [fetch](https://developer.mozilla.org/docs/Web/API/fetch) ([#358](https://github.com/mollie/mollie-api-node/pull/358))
   - Add `cancelUrl` and `getDashboardUrl` to payments and orders ([#327](https://github.com/mollie/mollie-api-node/pull/327)/[#373](https://github.com/mollie/mollie-api-node/pull/373))
   - Add `status` and `issuers` to methods and update `pricing` ([#335](https://github.com/mollie/mollie-api-node/pull/335)/[#374](https://github.com/mollie/mollie-api-node/pull/374))
   - Update and export `PaymentInclude` ([#370](https://github.com/mollie/mollie-api-node/pull/370))
+  - Update payment methods ([#376](https://github.com/mollie/mollie-api-node/pull/376))
   - Change type of `metadata` (from `any`) to `unknown` ([#367](https://github.com/mollie/mollie-api-node/pull/367))
   - Change return type of functions to plain arrays or iterators, depending on whether the represented list is paginated ([#322](https://github.com/mollie/mollie-api-node/pull/322))
   - Bump Node.js requirement to 14

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -55,6 +55,10 @@ Helper functions which do not provide a significantly simpler API have been remo
   }
 ```
 
+## Removed Giropay and SOFORT
+
+[Giropay](https://help.mollie.com/hc/en-us/articles/19745480480786-Giropay-Depreciation-FAQ) and [SOFORT](https://help.mollie.com/hc/en-us/articles/20904206772626-SOFORT-Deprecation-30-September-2024) have been deprecated, and removed from the client. Please update your code accordingly.
+
 ## Changed type of `metadata` (from `any`) to `unknown`
 
 The `metadata` property is now typed as `unknown`. Please check its type at runtime, or use `as any` to opt in to type issues.

--- a/README.md
+++ b/README.md
@@ -147,24 +147,26 @@ Want to help us make our API client even better? We take [pull requests](https:/
 
 [New BSD (Berkeley Software Distribution) License](https://opensource.org/licenses/BSD-3-Clause). Copyright 2013-2021, Mollie B.V.
 
-[credit-card]: https://www.mollie.com/payments/credit-card
 [apple-pay]: https://www.mollie.com/payments/apple-pay
-[paypal]: https://www.mollie.com/payments/paypal
-[klarna-pay-now]: https://www.mollie.com/payments/klarna-pay-now
-[klarna-pay-later]: https://www.mollie.com/payments/klarna-pay-later
-[klarna-slice-it]: https://www.mollie.com/payments/klarna-slice-it
-[ideal]: https://www.mollie.com/payments/ideal
-[meal-eco-gift-vouchers]: https://www.mollie.com/payments/meal-eco-gift-vouchers
-[bank-transfer]: https://www.mollie.com/payments/bank-transfer
-[direct-debit]: https://www.mollie.com/payments/direct-debit
-[sofort]: https://www.mollie.com/payments/sofort
 [bancontact]: https://www.mollie.com/payments/bancontact
-[cartes-bancaires]: https://www.mollie.com/payments/cartes-bancaires
-[eps]: https://www.mollie.com/payments/eps
-[postepay]: https://www.mollie.com/payments/postepay
-[giropay]: https://www.mollie.com/payments/giropay
-[kbc-cbc]: https://www.mollie.com/payments/kbc-cbc
+[bank-transfer]: https://www.mollie.com/payments/bank-transfer
 [belfius]: https://www.mollie.com/payments/belfius
-[paysafecard]: https://www.mollie.com/payments/paysafecard
+[cartes-bancaires]: https://www.mollie.com/payments/cartes-bancaires
+[credit-card]: https://www.mollie.com/payments/credit-card
+[direct-debit]: https://www.mollie.com/payments/direct-debit
+[eps]: https://www.mollie.com/payments/eps
 [gift-cards]: https://www.mollie.com/payments/gift-cards
+[ideal]: https://www.mollie.com/payments/ideal
+[kbc-cbc]: https://www.mollie.com/payments/kbc-cbc
+[klarna-pay-later]: https://www.mollie.com/payments/klarna-pay-later
+[klarna-pay-now]: https://www.mollie.com/payments/klarna-pay-now
+[klarna-slice-it]: https://www.mollie.com/payments/klarna-slice-it
+[meal-eco-gift-vouchers]: https://www.mollie.com/payments/meal-eco-gift-vouchers
+[paypal]: https://www.mollie.com/payments/paypal
+[paysafecard]: https://www.mollie.com/payments/paysafecard
+[postepay]: https://www.mollie.com/payments/postepay
 [przelewy24]: https://www.mollie.com/payments/przelewy24
+[riverty]: https://www.mollie.com/payments/riverty
+[satispay]: https://www.mollie.com/payments/satispay
+[trustly]: https://www.mollie.com/payments/trustly
+[twint]: https://www.mollie.com/payments/twint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # About
 
-[Mollie](https://www.mollie.com/) builds payment products, commerce solutions and APIs that let you accept online and mobile payments, for small online stores and Fortune 500s alike. Accepting [Credit Card][credit-card], [Apple Pay][apple-pay], [PayPal][paypal], [Klarna: Pay now][klarna-pay-now], [Klarna: Pay later][klarna-pay-later], [Klarna: Slice it][klarna-slice-it], [iDeal][ideal], [vouchers][meal-eco-gift-vouchers], [SEPA Bank Transfer][bank-transfer], [SEPA Direct Debit][direct-debit], [SOFORT banking][sofort], [Bancontact][bancontact], [Cartes Bancaires][cartes-bancaires], [EPS][eps], [PostePay][postepay], [Giropay][giropay], [KBC Payment Button][kbc-cbc], [Belfius Pay Button][belfius], [paysafecard][paysafecard], [gift cards][gift-cards], and [Przelewy24][przelewy24] online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
+[Mollie](https://www.mollie.com/) builds payment products, commerce solutions and APIs that let you accept online and mobile payments, for small online stores and Fortune 500s alike. Accepting [credit and debit card][credit-card] ([Cartes Bancaires][cartes-bancaires], [PostePay][postepay]), [Alma][alma], [Apple Pay][apple-pay], [BACS Direct Debit][bacs], [BANCOMAT Pay][bancomat-pay], [Bancontact][bancontact], [SEPA Bank Transfer][bank-transfer], [Belfius Pay Button][belfius], [Billie][billie], [BLIK][blik], [SEPA Direct Debit][direct-debit], [EPS][eps], [iDEAL][ideal] ([in3][ideal-in3]), [KBC Payment Button][kbc-cbc], [Klarna][klarna] (Pay Later, Pay Now, Pay in 3, Financing), [PayPal][paypal], [paysafecard][paysafecard], [Przelewy24][przelewy24], [Riverty][riverty], [Satispay][satispay], [Trustly][trustly], [TWINT][twint], [eco- gift- and meal vouchers][meal-eco-gift-vouchers] and [gift cards][gift-cards] online payments without fixed monthly costs or any punishing registration procedures. Just use the Mollie API to receive payments directly on your website or easily refund transactions to your customers.
 
 ### A note on use outside of Node.js
 
@@ -147,21 +147,26 @@ Want to help us make our API client even better? We take [pull requests](https:/
 
 [New BSD (Berkeley Software Distribution) License](https://opensource.org/licenses/BSD-3-Clause). Copyright 2013-2021, Mollie B.V.
 
+[alma]: https://www.mollie.com/payments/alma
 [apple-pay]: https://www.mollie.com/payments/apple-pay
+[bacs]: https://www.mollie.com/payments/bacs
+[bancomat-pay]: https://www.mollie.com/payments/bancomat-pay
 [bancontact]: https://www.mollie.com/payments/bancontact
 [bank-transfer]: https://www.mollie.com/payments/bank-transfer
 [belfius]: https://www.mollie.com/payments/belfius
+[billie]: https://www.mollie.com/payments/billie
+[blik]: https://www.mollie.com/payments/blik
 [cartes-bancaires]: https://www.mollie.com/payments/cartes-bancaires
 [credit-card]: https://www.mollie.com/payments/credit-card
 [direct-debit]: https://www.mollie.com/payments/direct-debit
 [eps]: https://www.mollie.com/payments/eps
 [gift-cards]: https://www.mollie.com/payments/gift-cards
 [ideal]: https://www.mollie.com/payments/ideal
+[ideal-in3]: https://www.mollie.com/payments/ideal-in3
 [kbc-cbc]: https://www.mollie.com/payments/kbc-cbc
-[klarna-pay-later]: https://www.mollie.com/payments/klarna-pay-later
-[klarna-pay-now]: https://www.mollie.com/payments/klarna-pay-now
-[klarna-slice-it]: https://www.mollie.com/payments/klarna-slice-it
+[klarna]: https://www.mollie.com/payments/klarna
 [meal-eco-gift-vouchers]: https://www.mollie.com/payments/meal-eco-gift-vouchers
+[mybank]: https://www.mollie.com/payments/mybank
 [paypal]: https://www.mollie.com/payments/paypal
 [paysafecard]: https://www.mollie.com/payments/paysafecard
 [postepay]: https://www.mollie.com/payments/postepay

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -23,18 +23,23 @@ export enum Locale {
 }
 
 export enum PaymentMethod {
+  alma = 'alma',
   applepay = 'applepay',
+  bacs = 'bacs',
+  bancomatpay = 'bancomatpay',
   bancontact = 'bancontact',
   banktransfer = 'banktransfer',
   belfius = 'belfius',
+  billie = 'billie',
+  blik = 'blik',
   creditcard = 'creditcard',
   directdebit = 'directdebit',
   eps = 'eps',
   giftcard = 'giftcard',
-  giropay = 'giropay',
   ideal = 'ideal',
   in3 = 'in3',
   kbc = 'kbc',
+  klarna = 'klarna',
   klarnapaylater = 'klarnapaylater',
   klarnapaynow = 'klarnapaynow',
   klarnasliceit = 'klarnasliceit',
@@ -42,13 +47,18 @@ export enum PaymentMethod {
   paypal = 'paypal',
   paysafecard = 'paysafecard',
   przelewy24 = 'przelewy24',
-  sofort = 'sofort',
+  riverty = 'riverty',
+  satispay = 'satispay',
+  trustly = 'trustly',
+  twint = 'twint',
   voucher = 'voucher',
 }
 
 export enum HistoricPaymentMethod {
   bitcoin = 'bitcoin',
   inghomepay = 'inghomepay',
+  giropay = 'giropay',
+  sofort = 'sofort',
 }
 
 export enum ApiMode {


### PR DESCRIPTION
Fixes #357 

The reference list is taken from the [API docs for the get method](https://docs.mollie.com/reference/get-method).

1. **Added the following new payment methods to `PaymentMethod`**:
   - alma
   - bacs
   - bancomatpay
   - billie
   - blik
   - riverty
   - satispay
   - trustly
   - twint

2. **Moved outdated payment methods to `HistoricPaymentMethod`**:
   - giropay
   - sofort