### PR TITLE
Change path of the types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "dist/mollie.cjs.js",
   "module": "dist/mollie.esm.js",
   "jsnext:main": "dist/mollie.esm.js",
-  "types": "dist/types/src/types.d.ts",
+  "types": "dist/types/types.d.ts",
   "engines": {
     "node": ">=8"
   },


### PR DESCRIPTION
It seems that the TypeScript compiler previously put the type definitions into `dist/types/src`, but now puts them in `dist/types`. This may have happened [during our recent upgrade of TypeScript](https://github.com/mollie/mollie-api-node/pull/360).

This PR updates package.json to use the new path.

Please do check my work!