### PR TITLE
@types/node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint": "yarn lint:eslint:fix && yarn lint:prettier"
   },
   "dependencies": {
+    "@types/node-fetch": "^2.6.11",
     "node-fetch": "^2.7.0",
     "ruply": "^1.0.1"
   },
@@ -51,7 +52,6 @@
     "@mollie/eslint-config-typescript": "^1.6.5",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.5.4",
-    "@types/node-fetch": "^2.6.11",
     "babel-jest": "^29.7.0",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",


### PR DESCRIPTION
This PR makes `@types/node-fetch` a regular dependency instead of a dev one

As we are using and re-exporting types from this package, users of this client should install them as well. This dependency is not required for users who don't use TypeScript and thus don't rely on the types, but I don't think anyone would mind the overhead.