### PR TITLE
Fix Documentation for async iterators in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The `page` methods do not fit every use case. If you find yourself retrieving mu
 
 ```javascript
 // Iterate over all payments.
-for await (let payment in mollieClient.payments.iterate()) {
+for await (const payment of mollieClient.payments.iterate()) {
   // (Use break to end the loop prematurely.)
 }
 ```


### PR DESCRIPTION
This is the current example for async iterators:
```ts
// Iterate over all payments.
for await (let payment in mollieClient.payments.iterate()) {
  // (Use break to end the loop prematurely.)
}
```
This has two issues, one being a mistake and one being a style issue.

1. Mistake: It should be `of` rather than `in`.
2. Style: The example should recommend using `const` rather than `let`.

Usually when iterating over payments we do not expect them to be reassigned within the for block.
If anyone would for some reason, it would be specific to their implementation and they would know to change it to 'let'.
Preferring const here is in line with the `prefer-const` [rule from eslint](https://archive.eslint.org/docs/4.0.0/rules/prefer-const).