### PR TITLE
Update Interface Types

### DIFF
--- a/src/binders/customers/subscriptions/parameters.ts
+++ b/src/binders/customers/subscriptions/parameters.ts
@@ -8,7 +8,7 @@ interface ContextParameters {
 }
 
 export type CreateParameters = ContextParameters &
-  Pick<SubscriptionData, 'amount' | 'interval' | 'description' | 'mandateId'> &
+  Pick<SubscriptionData, 'amount' | 'interval' | 'description' | 'mandateId' | 'applicationFee' | 'profileId'> &
   PickOptional<SubscriptionData, 'times' | 'startDate' | 'method' | 'webhookUrl' | 'metadata'> &
   IdempotencyParameter;
 

--- a/src/binders/onboarding/parameters.ts
+++ b/src/binders/onboarding/parameters.ts
@@ -1,4 +1,4 @@
-import { type Address } from '../../data/global';
+import type { OrganizationAdress } from '../../data/organizations/Organizations';
 import { type IdempotencyParameter } from '../../types/parameters';
 
 export interface SubmitParameters extends IdempotencyParameter {
@@ -15,7 +15,7 @@ export interface SubmitParameters extends IdempotencyParameter {
     /**
      * Address of the organization.
      */
-    address?: Address;
+    address?: OrganizationAdress;
     /**
      * The Chamber of Commerce registration number of the company.
      */

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -1,3 +1,4 @@
+import { runIf } from 'ruply';
 import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import type Page from '../../data/page/Page';
 import { type PaymentData } from '../../data/payments/data';
@@ -32,7 +33,7 @@ export default class PaymentsBinder extends Binder<PaymentData, Payment> {
   public create(parameters: CreateParameters) {
     if (renege(this, this.create, ...arguments)) return;
     const { include, ...data } = parameters;
-    const query = include != undefined ? { include } : undefined;
+    const query = runIf(include, include => ({ include }));
     return this.networkClient.post<PaymentData, Payment>(pathSegment, data, query);
   }
 

--- a/src/binders/payments/captures/parameters.ts
+++ b/src/binders/payments/captures/parameters.ts
@@ -1,4 +1,5 @@
 import { type CaptureData, type CaptureInclude } from '../../../data/payments/captures/data';
+import type MaybeArray from '../../../types/MaybeArray';
 import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
 
@@ -9,13 +10,13 @@ interface ContextParameters {
 export type CreateParameters = ContextParameters & PickOptional<CaptureData, 'amount' | 'description' | 'metadata'> & IdempotencyParameter;
 
 export type GetParameters = ContextParameters & {
-  include?: CaptureInclude;
+  include?: MaybeArray<CaptureInclude>;
   testmode?: boolean;
 };
 
 export type PageParameters = ContextParameters &
   PaginationParameters & {
-    include?: CaptureInclude;
+    include?: MaybeArray<CaptureInclude>;
     testmode?: boolean;
   };
 

--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -1,11 +1,25 @@
-import { type Address, type Amount, type PaymentMethod } from '../../data/global';
-import { type Issuer } from '../../data/Issuer';
+import { type Amount, type PaymentMethod } from '../../data/global';
 import { type PaymentData, type PaymentEmbed, type PaymentInclude } from '../../data/payments/data';
 import type MaybeArray from '../../types/MaybeArray';
 import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
-export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'redirectUrl' | 'cancelUrl' | 'webhookUrl' | 'customerId' | 'mandateId'> &
+export type CreateParameters = Pick<
+  PaymentData,
+  | 'amount'
+  | 'description'
+  | 'redirectUrl'
+  | 'cancelUrl'
+  | 'webhookUrl'
+  | 'customerId'
+  | 'mandateId'
+  | 'lines'
+  | 'shippingAddress'
+  | 'billingAddress'
+  | 'routing'
+  | 'issuer'
+  | 'restrictPaymentMethodsToCountry'
+> &
   PickOptional<PaymentData, 'locale' | 'metadata' | 'sequenceType' | 'captureMode' | 'captureDelay'> & {
     /**
      * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
@@ -45,6 +59,9 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=applePayPaymentToken#apple-pay
      */
     applePayPaymentToken?: string;
+    /**
+     * @deprecated use billingAddress.email instead
+     */
     billingEmail?: string;
     /**
      * The date the payment should expire, in `YYYY-MM-DD` format. **Note:** the minimum date is tomorrow and the maximum date is 100 days after tomorrow.
@@ -55,26 +72,11 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      */
     dueDate?: string;
     /**
-     * The card holder's address details. We advise to provide these details to improve the credit card fraud protection, and thus improve conversion.
-     *
-     * If an address is provided, then the address has to be in a valid format. See the address object documentation for more information on which formats are accepted.
-     *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=billingAddress#credit-card
-     */
-    billingAddress?: Address;
-    /**
      * The card token you got from Mollie Components. The token contains the card information (such as card holder, card number, and expiry date) needed to complete the payment.
      *
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=cardToken#credit-card
      */
     cardToken?: string;
-    shippingAddress?: Address & {
-      // Note that this field is required for PayPal payments; but is disregarded for credit card payments.
-      givenName?: string;
-      // Note that this field is required for PayPal payments; but is disregarded for credit card payments.
-      familyName?: string;
-    };
-    issuer?: Issuer;
     /**
      * The card number on the gift card. You can supply this to prefill the card number.
      *
@@ -133,7 +135,13 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
      * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=consumerAccount#sepa-direct-debit
      */
     consumerAccount?: string;
-    include?: MaybeArray<PaymentInclude>;
+    /**
+     * This endpoint allows you to include additional information via the `include` query string parameter.
+     * * `details.qrCode`: Include a QR code object. Only available for iDEAL, Bancontact and bank transfer payments.
+     *
+     * __Note:__ In the REST API, this is not part of the request body, but a query Parameter. It is included here for consistency.
+     */
+    include?: MaybeArray<PaymentInclude.qrCode>; // currently only one valid value, but making 'MaybeArray' for consistency
     profileId?: string;
     testmode?: boolean;
     /**
@@ -163,13 +171,12 @@ export type CreateParameters = Pick<PaymentData, 'amount' | 'description' | 'red
   } & IdempotencyParameter;
 
 export interface GetParameters {
-  include?: PaymentInclude;
+  include?: MaybeArray<PaymentInclude>;
   embed?: MaybeArray<PaymentEmbed>;
   testmode?: boolean;
 }
 
 export type PageParameters = PaginationParameters & {
-  profileId?: string;
   testmode?: boolean;
 };
 

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -192,7 +192,7 @@ export { MandateMethod, MandateStatus } from './data/customers/mandates/data';
 export { MethodImageSize, MethodInclude } from './data/methods/data';
 export { OrderEmbed, OrderStatus } from './data/orders/data';
 export { OrderLineType } from './data/orders/orderlines/OrderLine';
-export { PaymentEmbed, PaymentInclude, PaymentStatus, CaptureMethod } from './data/payments/data';
+export { PaymentEmbed, PaymentInclude, PaymentStatus, CaptureMethod, PaymentLineType, PaymentLineCategory, RoutingType } from './data/payments/data';
 export { RefundEmbed, RefundStatus } from './data/refunds/data';
 export { SubscriptionStatus } from './data/subscriptions/data';
 export { ProfileStatus } from './data/profiles/data';

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -83,6 +83,24 @@ export interface Amount {
 
 export interface Address {
   /**
+   * The title of the person, for example _Mr._ or _Mrs._.
+   *
+   * @see https://docs.mollie.com/overview/common-data-types?path=title#address-object
+   */
+  title?: string;
+  /**
+   * The given name (first name) of the person should be more than 1 character and cannot contain only numbers.
+   *
+   * @see https://docs.mollie.com/overview/common-data-types?path=givenName#address-object
+   */
+  givenName?: string;
+  /**
+   * The family name (surname) of the person should be more than 1 character and cannot contain only numbers.
+   *
+   * @see https://docs.mollie.com/overview/common-data-types?path=familyName#address-object
+   */
+  familyName?: string;
+  /**
    * The street and street number of the address.
    *
    * @see https://docs.mollie.com/overview/common-data-types?path=streetAndNumber#address-object
@@ -102,7 +120,13 @@ export interface Address {
    *
    * @see https://docs.mollie.com/overview/common-data-types?path=postalCode#address-object
    */
-  postalCode: string;
+  postalCode?: string;
+  /**
+   * The customer's email address.
+   *
+   * @see https://docs.mollie.com/overview/common-data-types?path=email#address-object
+   */
+  email?: string;
   /**
    * The city of the address.
    *
@@ -111,6 +135,8 @@ export interface Address {
   city: string;
   /**
    * The region of the address.
+   *
+   * For certain PayPal payments the `region` field is required.
    *
    * @see https://docs.mollie.com/overview/common-data-types?path=region#address-object
    */

--- a/src/data/orders/data.ts
+++ b/src/data/orders/data.ts
@@ -70,7 +70,7 @@ export interface OrderData extends Model<'order'> {
    *
    * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=billingAddress#response
    */
-  billingAddress: OrderAddress;
+  billingAddress: Address;
   /**
    * The date of birth of your customer, if available.
    *
@@ -90,7 +90,7 @@ export interface OrderData extends Model<'order'> {
    *
    * @see https://docs.mollie.com/reference/v2/orders-api/get-order?path=shippingAddress#response
    */
-  shippingAddress: OrderAddress;
+  shippingAddress: Address;
   /**
    * The locale used during checkout. Note that the locale may have been changed by your customer during checkout.
    *
@@ -219,15 +219,6 @@ export enum OrderStatus {
   completed = 'completed',
   expired = 'expired',
   pending = 'pending',
-}
-
-export interface OrderAddress extends Address {
-  organizationName?: string;
-  title?: string;
-  givenName: string;
-  familyName: string;
-  email: string;
-  phone?: string;
 }
 
 export enum OrderEmbed {

--- a/src/data/organizations/Organizations.ts
+++ b/src/data/organizations/Organizations.ts
@@ -22,7 +22,7 @@ export interface OrganizationData extends Model<'organization'> {
    *
    * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=address#response
    */
-  address: Address;
+  address: OrganizationAdress;
   /**
    * The registration number of the organization at the (local) chamber of commerce.
    *
@@ -48,6 +48,8 @@ export interface OrganizationData extends Model<'organization'> {
    */
   _links: OrganizationLinks;
 }
+
+export type OrganizationAdress = Pick<Address, 'streetAndNumber' | 'postalCode' | 'city' | 'country'>;
 
 type Organization = Seal<OrganizationData, Helper<OrganizationData, Organization>>;
 

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -41,6 +41,27 @@ export interface PaymentData extends Model<'payment'> {
    */
   status: PaymentStatus;
   /**
+   * This object offers details about the status of a payment. Currently it is only available for point-of-sale payments.
+   *
+   * You can find more information about the possible values of this object on [this page](https://docs.mollie.com/reference/status-reasons).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=statusReason#response
+   */
+  statusReason?: {
+    /**
+     * A machine-readable code that indicates the reason for the payment's status.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=statusReason/code#response
+     */
+    code: string;
+    /**
+     * A description of the status reason, localized according to the payment `locale`.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=statusReason/message#response
+     */
+    message: string;
+  };
+  /**
    * Whether or not the payment can be canceled. This parameter is omitted if the payment reaches a final state.
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=isCancelable#response
@@ -146,6 +167,30 @@ export interface PaymentData extends Model<'payment'> {
    */
   webhookUrl?: string;
   /**
+   * Optionally provide the order lines for the payment. Each line contains details such as a description of the item ordered and its price.
+   *
+   * All lines must have the same currency as the payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines#response
+   */
+  lines?: PaymentLine[];
+  /**
+   * The customer's billing address details. We advise to provide these details to improve fraud protection and conversion.
+   *
+   * This is particularly relevant for card payments.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=billingAddress#response
+   */
+  billingAddress?: Address;
+  /**
+   * The customer's shipping address details. We advise to provide these details to improve fraud protection and conversion.
+   *
+   * This is particularly relevant for card payments.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=shippingAddress#response
+   */
+  shippingAddress?: Address;
+  /**
    * The payment method used for this payment, either forced on creation by specifying the `method` parameter, or chosen by the customer on our payment method selection screen.
    *
    * If the payment is only partially paid with a gift card, the method remains `giftcard`.
@@ -157,6 +202,34 @@ export interface PaymentData extends Model<'payment'> {
    */
   method?: PaymentMethod | HistoricPaymentMethod;
   /**
+   * **Only relevant for iDEAL, KBC/CBC, gift card, and voucher payments.**
+   *
+   * **⚠️ With the introduction of iDEAL 2 in 2025, this field will be ignored for iDEAL payments. For more information on the migration, refer to our [help center](https://help.mollie.com/hc/de/articles/19100313768338-iDEAL-2-0).**
+   *
+   * Some payment methods are a network of connected banks or card issuers. In these cases, after selecting the payment method, the customer may still need to select the appropriate issuer before the payment can proceed.
+   *
+   * We provide hosted issuer selection screens, but these screens can be skipped by providing the `issuer` via the API up front.
+   *
+   * The full list of issuers for a specific method can be retrieved via the Methods API by using the optional `issuers` include.
+   *
+   * A valid issuer for iDEAL is for example `ideal_INGBNL2A` (for ING Bank).
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=issuer#response
+   */
+  issuer?: string;
+  /**
+   * For digital goods in most jurisdictions, you must apply the VAT rate from your customer's country. Choose the VAT rates you have used for the order to ensure your customer's country matches the VAT country.
+   *
+   * Use this parameter to restrict the payment methods available to your customer to those from a single country.
+   *
+   * If available, the credit card method will still be offered, but only cards from the allowed country are accepted.
+   *
+   * The field expects a country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format, for example `NL`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=restrictPaymentMethodsToCountry#response
+   */
+  restrictPaymentMethodsToCountry?: string;
+  /**
    * The optional metadata you provided upon payment creation. Metadata can for example be used to link an order to a payment.
    *
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=metadata#response
@@ -164,31 +237,31 @@ export interface PaymentData extends Model<'payment'> {
   metadata: unknown;
   /**
    * **Only relevant if you wish to manage authorization and capturing separately.**
-   * 
+   *
    * By default, the customer's card or bank account is immediately charged when they complete the payment.
-   * 
+   *
    * Some payment methods also allow placing a hold on the card or bank account. This hold or 'authorization' can then at a later point either be 'captured' or canceled.
-   * 
+   *
    * To enable this way of working, set the capture mode to `manual` and capture the payment manually using the `paymentCaptures.create` API.
    */
   captureMode?: CaptureMethod;
   /**
    * **Only relevant if you wish to manage authorization and capturing separately.**
-   * 
+   *
    * Some payment methods allow placing a hold on the card or bank account. This hold or 'authorization' can then at a later point either be 'captured' or canceled.
-   * 
+   *
    * By default, we charge the customer's card or bank account immediately when they complete the payment. If you set a capture delay however, we will delay the automatic capturing of the payment for the specified amount of time. For example `8 hours` or `2 days`.
    *
    * To schedule an automatic capture, the `captureMode` must be set to `automatic`.
-   * 
+   *
    * The maximum delay is 7 days (168 hours).
-   * 
+   *
    * Possible values: `... hours`, `... days`
    */
   captureDelay?: string;
   /**
    * **Only relevant if you wish to manage authorization and capturing separately.**
-   * 
+   *
    * Indicates the date before which the payment needs to be captured, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. From this date onwards we can no longer guarantee a successful capture. The parameter is omitted if the payment is not authorized (yet).
    */
   captureBefore?: string;
@@ -269,6 +342,22 @@ export interface PaymentData extends Model<'payment'> {
     amount: Amount;
     description: string;
   };
+  /**
+   * _This functionality is not enabled by default. Reach out to our partner management team if you wish to use it._
+   *
+   * With Mollie Connect you can charge fees on payments that your app is processing on behalf of other Mollie merchants.
+   *
+   * If you create payments on your own account that you want to split between yourself and one or more connected merchants, you can use this `routing` parameter to route the payment accordingly.
+   *
+   * The routing parameter should contain an array of objects, with each object describing the destination for a specific portion of the payment.
+   *
+   * It is not necessary to indicate in the array which portion goes to yourself. After all portions of the total payment amount have been routed, the amount left will be routed to the current organization automatically.
+   *
+   * If instead you use OAuth to create payments on a connected merchant's account, refer to the `applicationFee` parameter.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=routing#parameters
+   */
+  routing?: PaymentRoutingInfo[];
   /**
    * An object with several URL objects relevant to the payment. Every URL object will contain an `href` and a `type` field.
    *
@@ -483,6 +572,7 @@ export interface BankTransferDetails {
   /**
    * Only available if filled out in the API or by the consumer – The email address which the consumer asked the payment instructions to be sent to.
    *
+   * @deprecated use billingAddress.email instead
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/billingEmail#bank-transfer
    */
   billingEmail: string;
@@ -931,4 +1021,207 @@ export interface GiftCard {
    * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/giftcards/voucherNumber#gift-cards
    */
   voucherNumber: string;
+}
+
+export interface PaymentLine {
+  /**
+   * The type of product purchased. For example, a physical or a digital product.
+   *
+   * The tip payment line type is not available when creating a payment.
+   *
+   * Possible values: `physical` `digital` `shipping_fee` `discount` `store_credit` `gift_card` `surcharge` `tip` (default: `physical`)
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/type#lines
+   */
+  type?: PaymentLineType;
+  /**
+   * A description of the line item. For example _LEGO 4440 Forest Police Station_.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/description#lines
+   */
+  description: string;
+  /**
+   * The number of items.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/quantity#lines
+   */
+  quantity: number;
+  /**
+   * The unit for the quantity. For example _pcs_, _kg_, or _cm_.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/quantityUnit#lines
+   */
+  quantityUnit?: string;
+  /**
+   *
+   * The price of a single item including VAT.
+   *
+   * For example: `{"currency":"EUR", "value":"89.00"}` if the box of LEGO costs €89.00 each.
+   *
+   * For types `discount`, `store_credit`, and `gift_card`, the unit price must be negative.
+   *
+   * The unit price can be zero in case of free items.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/unitPrice#lines
+   */
+  unitPrice: Amount;
+  /**
+   * Any line-specific discounts, as a positive amount. Not relevant if the line itself is already a discount type.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/discountAmount#lines
+   */
+  discountAmount?: Amount;
+  /**
+   * The details of subsequent recurring billing cycles.
+   *
+   * These parameters are used in the Mollie Checkout to inform the shopper of the details for recurring products in the payments.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/recurring#lines
+   */
+  recurring?: RecurringInfo;
+  /**
+   * The total amount of the line, including VAT and discounts.
+   *
+   * Should match the following formula: `(unitPrice × quantity) - discountAmount`.
+   *
+   * The sum of all `totalAmount` values of all order lines should be equal to the full payment amount.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/totalAmount#lines
+   */
+  totalAmount: Amount;
+  /**
+   * The VAT rate applied to the line, for example `21.00` for 21%.
+   *
+   * The vatRate should be passed as a string and not as a float, to ensure the correct number of decimals are passed.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/vatRate#lines
+   */
+  vatRate?: string;
+  /**
+   * The amount of value-added tax on the line. The `totalAmount` field includes VAT, so the `vatAmount` can be calculated with the formula `totalAmount × (vatRate / (100 + vatRate))`.
+   *
+   * Any deviations from this will result in an error.
+   *
+   * For example, for a `totalAmount` of SEK 100.00 with a 25.00% VAT rate, we expect a VAT amount of `SEK 100.00 × (25 / 125) = SEK 20.00`.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/vatAmount#lines
+   */
+  vatAmount?: Amount;
+  /**
+   * The SKU, EAN, ISBN or UPC of the product sold.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/sku#lines
+   */
+  sku?: string;
+  /**
+   * An array with the voucher categories, in case of a line eligible for a voucher. See the Integrating Vouchers guide for more information.
+   *
+   * Possible values: `meal` `eco` `gift` `sport_culture`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/categories#lines
+   */
+  categories?: PaymentLineCategory[];
+  /**
+   * A link pointing to an image of the product sold.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/_links/imageUrl#lines
+   */
+  imageUrl?: string;
+  /**
+   * A link pointing to the product page in your web shop of the product sold.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=lines/_links/productUrl#lines
+   */
+  productUrl?: string;
+}
+
+export interface RecurringInfo {
+  /**
+   * A description of the recurring item. If not present, the main description of the item will be used.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/recurring/description#recurring
+   */
+  description?: string;
+  /**
+   * TCadence unit of the recurring item. For example: `12 months`, `52 weeks` or `365 days`.
+   *
+   * Possible values: `... months` `... weeks` `... days`
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/recurring/interval#recurring
+   */
+  interval: string;
+  /**
+   * Total amount and currency of the recurring item.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/recurring/amount#recurring
+   */
+  amount?: Amount;
+  /**
+   * Total number of charges for the subscription to complete. Leave empty for ongoing subscription.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/recurring/times#recurring
+   */
+  times?: number;
+  /**
+   * The start date of the subscription if it does not start right away (format `YYYY-MM-DD`)
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=details/recurring/startDate#recurring
+   */
+  startDate?: string;
+}
+
+export enum PaymentLineType {
+  physical = 'physical',
+  digital = 'digital',
+  shipping_fee = 'shipping_fee',
+  discount = 'discount',
+  store_credit = 'store_credit',
+  gift_card = 'gift_card',
+  surcharge = 'surcharge',
+  tip = 'tip',
+}
+
+export enum PaymentLineCategory {
+  meal = 'meal',
+  eco = 'eco',
+  gift = 'gift',
+  sport_culture = 'sport_culture',
+}
+
+export interface PaymentRoutingInfo {
+  /**
+   * The portion of the total payment amount being routed. Currently only EUR payments can be routed.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=routing/rule#response
+   */
+  amount: Amount;
+  /**
+   * The destination of this portion of the payment.
+   *
+   * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=routing/rule#response
+   */
+  destination: {
+    /**
+     * The type of destination. Currently only the destination type `organization` is supported.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=routing/rule#response
+     */
+    type: RoutingType;
+    /**
+     * Required for destination type `organization`. The ID of the connected organization the funds should be routed to.
+     *
+     * @see https://docs.mollie.com/reference/v2/payments-api/get-payment?path=routing/rule#response
+     */
+    organizationId: string;
+  };
+  /**
+   * Optionally, schedule this portion of the payment to be transferred to its destination on a later date. The date must be given in `YYYY-MM-DD` format.
+   *
+   * If no date is given, the funds become available to the connected merchant as soon as the payment succeeds.
+   */
+  releaseDate?: string;
+}
+
+export enum RoutingType {
+  organization = 'organization',
 }

--- a/src/data/subscriptions/data.ts
+++ b/src/data/subscriptions/data.ts
@@ -71,12 +71,6 @@ export interface SubscriptionData extends Model<'subscription'> {
    */
   method: string | null;
   /**
-   * The mandate used for this subscription. When there is no mandate specified, this parameter will not be returned.
-   *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=mandateId#response
-   */
-  mandateId?: string;
-  /**
    * The subscription's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=createdAt#response
@@ -100,6 +94,26 @@ export interface SubscriptionData extends Model<'subscription'> {
    * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=metadata#response
    */
   metadata: unknown;
+  /**
+   * The customer this subscription belongs to.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=customerId#response
+   */
+  customerId: string;
+  /**
+   * The mandate used for this subscription. When there is no mandate specified, this parameter will not be returned.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=mandateId#response
+   */
+  mandateId?: string;
+  /**
+   * The identifier referring to the [profile](https://docs.mollie.com/reference/get-profile) this entity belongs to.
+   *
+   * Most API credentials are linked to a single profile. In these cases the `profileId` can be omitted in the creation request. For organization-level credentials such as OAuth access tokens however, the `profileId` parameter is required.
+   *
+   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=profileId#response
+   */
+  profileId?: string;
   /**
    * The application fee, if the subscription was created with one. This will be applied on each payment created for the subscription.
    *


### PR DESCRIPTION
This resolve several type discrepancies between the client and the mollie API.

Since the official docs are too inconsistent to be used as source of truth, the actual optional-ness of these properties was aligned directly with mollie.
No properties were removed and Types should be wider, not narrower, making this a backwards compatible change.

The only exception I could find was the `address.postCode`, which was defined to be required, when it is actually optional, since not all countries have a post code.
This change will concern the organization.address and order.address.
I don't believe this warrants a major version release.

This resolves:
- https://github.com/mollie/mollie-api-node/issues/390
- https://github.com/mollie/mollie-api-node/pull/396