### PR TITLE
FIX: order.getPayments() does not work

### DIFF
--- a/src/data/orders/OrderHelper.ts
+++ b/src/data/orders/OrderHelper.ts
@@ -6,6 +6,7 @@ import type TransformingNetworkClient from '../../communication/TransformingNetw
 import HelpfulIterator from '../../plumbing/iteration/HelpfulIterator';
 import makeAsync from '../../plumbing/iteration/makeAsync';
 import renege from '../../plumbing/renege';
+import resolveIf from '../../plumbing/resolveIf';
 import type Callback from '../../types/Callback';
 import type Nullable from '../../types/Nullable';
 import { type ThrottlingParameter } from '../../types/parameters';
@@ -118,7 +119,7 @@ export default class OrderHelper extends Helper<OrderData, Order> {
   public getPayments(this: OrderHelper & OrderData) {
     if (renege(this, this.getPayments, ...arguments)) return;
     return (
-      runIf(this.embedded?.payments, Promise.resolve) ??
+      resolveIf(this.embedded?.payments) ??
       // Getting the payments for an order is an odd case, in the sense that the Mollie API only supports it partially.
       // The Mollie API will embed the payments in an order if requested ‒ but unlike with other "embeddables", there
       // is no endpoint to get those payments directly. Therefore, the line below rerequests this order, this time with
@@ -154,6 +155,6 @@ export default class OrderHelper extends Helper<OrderData, Order> {
     // At the time of writing, the Mollie API does not return a link to the shipments of an order. This is why the line
     // below constructs its own URL. If the Mollie API ever starts to return such a link, use it instead for
     // consistency.
-    return runIf(this.embedded?.shipments, Promise.resolve) ?? this.networkClient.list<ShipmentData, Shipment>(getOrderShipmentsPathSegments(this.id), 'shipments');
+    return resolveIf(this.embedded?.shipments) ?? this.networkClient.list<ShipmentData, Shipment>(getOrderShipmentsPathSegments(this.id), 'shipments');
   }
 }

--- a/src/plumbing/resolveIf.ts
+++ b/src/plumbing/resolveIf.ts
@@ -7,5 +7,5 @@ type Nullish = null | undefined;
  * [nullish](https://developer.mozilla.org/docs/Glossary/Nullish), in which case it returns that value directly.
  */
 export default function resolveIf<T>(value: T extends Promise<unknown> ? never : T) {
-  return runIf(value, Promise.resolve) ?? (value as Extract<T, Nullish> | Promise<Exclude<T, Nullish>>);
+  return runIf(value, Promise.resolve.bind(Promise)) ?? (value as Extract<T, Nullish> | Promise<Exclude<T, Nullish>>);
 }


### PR DESCRIPTION
This resolves https://github.com/mollie/mollie-api-node/issues/391

This implements the proposed solution of properly`Promise.resolve` and consistent use of `resolveIf`, as discussed in the issue.