### PR TITLE
Fixed and deprecated payment.isRefundable

### DIFF
--- a/src/data/payments/PaymentHelper.ts
+++ b/src/data/payments/PaymentHelper.ts
@@ -30,9 +30,10 @@ export default class PaymentHelper extends Helper<PaymentData, Payment> {
    * Returns whether the payment is refundable.
    *
    * @since 2.0.0-rc.2
+   * @deprecated Use `canBeRefunded` instead.
    */
   public isRefundable(this: PaymentData): boolean {
-    return this.amountRemaining !== null;
+    return this.amountRemaining != undefined;
   }
 
   /**


### PR DESCRIPTION
The `isRefundable` helper on a payment actually never returned `false`, because the strict `null` comparison is incorrect.
If `amountRemaining` is not provided (as it is for non-refundable payments), it is `undefined` rather than `null`.

This is also reflected in `canBeRefunded`, which is correct and should be used instead.
To not make this a breaking change, I fixed the behaviour and deprecated the method.

supersedes #385 