### PR TITLE
NTR: Update github actions image to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.x, 18.x, 20.x]


### PR DESCRIPTION
Github Actions will deprecate the ubuntu-20.04 image, we should always run on ubuntu-latest.