### PR TITLE
add `organizationName` to Address Object

### DIFF
--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -105,6 +105,12 @@ export interface Address {
    */
   familyName?: string;
   /**
+   * The name of the organization, in case the addressee is an organization.
+   *
+   * @see https://docs.mollie.com/overview/common-data-types?path=organizationName#address
+   */
+  organizationName?: string;
+  /**
    * The street and street number of the address.
    *
    * @see https://docs.mollie.com/overview/common-data-types?path=streetAndNumber#address-object


### PR DESCRIPTION
Field can be found in details for get payment: https://docs.mollie.com/reference/get-payment

The docs are still not consistent on which fields are `required` and `optional`, but here it's pretty clear: The docs say it is only included 'if the adressee is an organization'.

fixes #410 