### PR TITLE
NTR: Add release payment authorization endpoint

### DIFF
--- a/examples/payments/release.js
+++ b/examples/payments/release.js
@@ -1,0 +1,16 @@
+/**
+ * @docs https://docs.mollie.com/reference/release-authorization
+ */
+const { createMollieClient } = require('@mollie/api-client');
+
+const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+(async () => {
+  try {
+    const payment = await mollieClient.payments.releaseAuthorization('tr_Eq8xzWUPA4');
+
+    console.log(payment);
+  } catch (error) {
+    console.warn(error);
+  }
+})();

--- a/examples/payments/release.ts
+++ b/examples/payments/release.ts
@@ -1,0 +1,16 @@
+/**
+ * @docs https://docs.mollie.com/reference/release-authorization
+ */
+import createMollieClient, { Payment } from '@mollie/api-client';
+
+const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
+
+(async () => {
+  try {
+    const payment: Payment = await mollieClient.payments.releaseAuthorization('tr_Eq8xzWUPA4');
+
+    console.log(payment);
+  } catch (error) {
+    console.warn(error);
+  }
+})();

--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -202,3 +202,7 @@ export type UpdateParameters = Pick<PaymentData, 'redirectUrl' | 'cancelUrl' | '
 export interface CancelParameters extends IdempotencyParameter {
   testmode?: boolean;
 }
+
+export interface ReleaseParameters {
+  testmode?: boolean;
+}

--- a/tests/integration/payments.test.ts
+++ b/tests/integration/payments.test.ts
@@ -44,7 +44,7 @@ describe('payments', () => {
             return payment;
           })
           .catch(fail));
-      console.log('If you want to test the full refund flow, set the payment to paid:', openPayment.getCheckoutUrl());
+      console.log(`If you want to test the full refund flow, set the payment ${openPayment.id} to paid:`, openPayment.getCheckoutUrl());
       return;
     }
 
@@ -153,7 +153,7 @@ describe('payments', () => {
             return payment;
           })
           .catch(fail));
-      console.log('If you want to test the full authorize-then-capture flow, set the payment to authorized:', openPayment.getCheckoutUrl());
+      console.log(`If you want to test the full authorize-then-capture flow, set the payment ${openPayment.id} to authorized:`, openPayment.getCheckoutUrl());
       return;
     }
 
@@ -175,5 +175,64 @@ describe('payments', () => {
     const updatedPayment = await authorizedPayment.refresh();
     const captureOnPayment = await getHead(updatedPayment.getCaptures());
     expect(capture.id).toBe(captureOnPayment.id);
+  });
+
+  it('should release authorization', async () => {
+    /**
+     * This test will
+     * - check if an authorized payment created by this test exists (verified using metadata)
+     * - if yes: release the authorization - this tests the full flow and will work exactly once for every payment created by this test.
+     * - if no:
+     *   - check if there's an open payment created by this test and if not create one
+     *   - log the checkout URL of the open payment, which a user can use to set the status to `authorized` to be able to test the full flow
+     *   - exit the test
+     */
+    const metaIdentifier = 'release-auth-test';
+
+    const payments = await mollieClient.payments.page();
+    const releaseAuthPayments = payments.filter(payment => payment.metadata == metaIdentifier);
+    const authorizedPayment = releaseAuthPayments.find(payment => payment.status == PaymentStatus.authorized);
+
+    if (null == authorizedPayment) {
+      const openPayment =
+        releaseAuthPayments.find(payment => payment.status == PaymentStatus.open) ??
+        (await mollieClient.payments
+          .create({
+            amount: { value: '10.00', currency: 'EUR' },
+            description: 'Integration test payment',
+            redirectUrl: 'https://example.com/redirect',
+            metadata: metaIdentifier,
+            captureMode: CaptureMethod.manual,
+            method: PaymentMethod.creditcard,
+          })
+          .then(payment => {
+            expect(payment).toBeDefined();
+            expect(payment.captureMode).toBe('manual');
+            expect(payment.authorizedAt).toBeUndefined();
+            expect(payment.captureDelay).toBeUndefined();
+            expect(payment.captureBefore).toBeUndefined();
+
+            return payment;
+          })
+          .catch(fail));
+      console.log(`If you want to test the release authorization flow, set the payment ${openPayment.id} to authorized:`, openPayment.getCheckoutUrl());
+      return;
+    }
+
+    expect(authorizedPayment.authorizedAt).toBeDefined();
+    expect(authorizedPayment.captureBefore).toBeDefined();
+
+    // Release the authorization
+    const releaseResult = await mollieClient.payments
+      .releaseAuthorization(authorizedPayment.id)
+      .then(result => {
+        expect(result).toBe(true);
+        return result;
+      })
+      .catch(fail);
+
+    // Note: The payment status might not be updated immediately after calling releaseAuthorization (response code 202)
+    // Eventually, the payment status should change to 'canceled' for payments without captures
+    // or to 'paid' if there was a successful capture
   });
 });


### PR DESCRIPTION
This adds the [release payment authorization endpoint](https://docs.mollie.com/reference/release-authorization).

Note that this endpoint currently erroneously returns an empty response (rather than an empty json object).
Currently the package only expected empty responses for 204 status codes.
This is in line with the intentions of REST, but since this is convention rather than a strict requirement I adapted our NetworkClient to not fail in these scenarios.

Regardless I will recommend to mollie to update their endpoint for consistency.