### PR TITLE
Add `update` and `delete` methods for payment links 

### DIFF
--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -6,7 +6,13 @@ import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
+import {
+  type CreateParameters,
+  type GetParameters,
+  type IterateParameters,
+  type PageParameters,
+  type UpdateParameters,
+} from './parameters';
 
 const pathSegment = 'payment-links';
 
@@ -67,5 +73,31 @@ export default class PaymentsLinksBinder extends Binder<PaymentLinkData, Payment
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};
     return this.networkClient.iterate<PaymentLinkData, PaymentLink>(pathSegment, 'payment_links', query, valuesPerMinute);
+  }
+
+  /**
+   * Update a payment link object by its token.
+   *
+   * @see https://docs.mollie.com/reference/update-payment-link
+   */
+  public update(id: string, parameters: Partial<UpdateParameters>): Promise<PaymentLink>;
+  public update(id: string, parameters: Partial<UpdateParameters>, callback: Callback<PaymentLink>): void;
+  public update(id: string, parameters: Partial<UpdateParameters>) {
+    if (renege(this, this.update, ...arguments)) return;
+    assertWellFormedId(id, 'payment-link');
+    return this.networkClient.patch<PaymentLinkData, PaymentLink>(`${pathSegment}/${id}`, parameters);
+  }
+
+  /**
+   * Delete a payment link object by its token.
+   *
+   * @see https://docs.mollie.com/reference/delete-payment-link
+   */
+  public delete(id: string): Promise<true>;
+  public delete(id: string, callback: Callback<true>): void;
+  public delete(id: string) {
+    if (renege(this, this.delete, ...arguments)) return;
+    assertWellFormedId(id, 'payment-link');
+    return this.networkClient.delete<PaymentLinkData, true>(`${pathSegment}/${id}`);
   }
 }

--- a/src/binders/paymentLinks/parameters.ts
+++ b/src/binders/paymentLinks/parameters.ts
@@ -16,4 +16,9 @@ export type PageParameters = PaginationParameters & {
   testmode?: boolean;
 };
 
+export type UpdateParameters = Pick<PaymentLinkData, 'description' | 'minimumAmount' | 'archived' | 'allowedMethods' | 'applicationFee'> &
+  PickOptional<PaymentLinkData, 'profileId'> & {
+  testmode?: boolean;
+};
+
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/paymentLinks/parameters.ts
+++ b/src/binders/paymentLinks/parameters.ts
@@ -1,10 +1,11 @@
 import { type PaymentLinkData } from '../../data/paymentLinks/data';
 import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import type PickOptional from '../../types/PickOptional';
 
-export type CreateParameters = Pick<PaymentLinkData, 'description' | 'amount' | 'redirectUrl' | 'webhookUrl' | 'expiresAt'> & {
-  profileId?: string;
-  testmode?: boolean;
-} & IdempotencyParameter;
+export type CreateParameters = Pick<PaymentLinkData, 'description' | 'amount' | 'minimumAmount' | 'redirectUrl' | 'webhookUrl' | 'reusable' | 'expiresAt' | 'allowedMethods' | 'applicationFee'> &
+  PickOptional<PaymentLinkData, 'profileId'> & {
+    testmode?: boolean;
+  } & IdempotencyParameter;
 
 export interface GetParameters {
   testmode?: boolean;

--- a/src/data/paymentLinks/data.ts
+++ b/src/data/paymentLinks/data.ts
@@ -1,14 +1,7 @@
-import { type Amount, type ApiMode, type Links, type Url } from '../global';
+import { type Amount, type ApiMode, type Links, type PaymentMethod, type Url } from '../global';
 import type Model from '../Model';
 
 export interface PaymentLinkData extends Model<'payment-link'> {
-  /**
-   * A short description of the payment link. The description is visible in the Dashboard and will be shown on the customer's bank or card statement when possible. This description will eventual been
-   * used as payment description.
-   *
-   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=description#response
-   */
-  description: string;
   /**
    * The mode used to create this payment link. Mode determines whether a payment link is *real* (live mode) or a *test* payment link.
    *
@@ -18,17 +11,30 @@ export interface PaymentLinkData extends Model<'payment-link'> {
    */
   mode: ApiMode;
   /**
-   * The identifier referring to the profile this payment link was created on. For example, `pfl_QkEhN94Ba`.
+   * A short description of the payment link. The description is visible in the Dashboard and will be shown on the customer's bank or card statement when possible. This description will eventual been
+   * used as payment description.
    *
-   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=profileId#response
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=description#response
    */
-  profileId: string;
+  description: string;
   /**
    * The amount of the payment link, e.g. `{"currency":"EUR", "value":"100.00"}` for a €100.00 payment link.
    *
    * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=amount#response
    */
-  amount: Amount;
+  amount?: Amount;
+  /**
+   * The minimum amount of the payment link. This property is only allowed when there is no amount provided. The customer will be prompted to enter a value greater than or equal to the minimum amount.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=minimumAmount#response
+   */
+  minimumAmount?: Amount;
+  /**
+   * Whether the payment link is archived. Customers will not be able to complete payments on archived payment links.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=archived#response
+   */
+  archived: boolean;
   /**
    * The URL your customer will be redirected to after completing the payment process.
    *
@@ -41,6 +47,22 @@ export interface PaymentLinkData extends Model<'payment-link'> {
    * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=redirectUrl#response
    */
   webhookUrl?: string;
+  /**
+   * The identifier referring to the profile this payment link was created on. For example, `pfl_QkEhN94Ba`.
+   *
+   * Most API credentials are linked to a single profile. In these cases the profileId can be omitted in the creation request. For organization-level credentials such as OAuth access tokens however, the profileId parameter is required.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=profileId#response
+   */
+  profileId: string;
+  /**
+   * Indicates whether the payment link is reusable. If this field is set to true, customers can make multiple payments using the same link.
+   *
+   * If no value is specified, the field defaults to false, allowing only a single payment per link.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=reusable#response
+   */
+  reusable?: boolean;
   /**
    * The payment link's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
@@ -65,5 +87,30 @@ export interface PaymentLinkData extends Model<'payment-link'> {
    * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=expiresAt#response
    */
   expiresAt?: string;
+  /**
+   * An array of payment methods that are allowed to be used for this payment link. When this parameter is not provided or is an empty array, all enabled payment methods will be available.
+   *
+   * Possible values: `applepay` `bancomatpay` `bancontact` `banktransfer` `belfius` `blik` `creditcard` `eps` `giftcard` `ideal` `kbc` `mybank` `paybybank` `paypal` `paysafecard` `pointofsale` `przelewy24` `satispay` `trustly` `twint`
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=allowedMethods#response
+   */
+  allowedMethods?: PaymentMethod[];
+  /**
+   * With Mollie Connect you can charge fees on payment links that your app is processing on behalf of other Mollie merchants.
+   *
+   * If you use OAuth to create payment links on a connected merchant's account, you can charge a fee using this applicationFee parameter.
+   *
+   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=applicationFee#response
+   */
+  applicationFee?: {
+    /**
+     * The fee that you wish to charge.
+     */
+    amount: Amount;
+    /**
+     * The description of the application fee. This will appear on settlement reports towards both you and the connected merchant.
+     */
+    description: string;
+  };
   _links: Links & { paymentLink: Url };
 }


### PR DESCRIPTION
Introduce `update` and `delete` functionality to the `PaymentLinksBinder`. The `update` method allows modifying payment link details, while the `delete` method enables removal of payment links. Also, extend `parameters.ts` to include `UpdateParameters` for supporting these changes.


replaces #420 