### PR TITLE
Remove `updatedAt` field from payment links

### DIFF
--- a/src/data/paymentLinks/data.ts
+++ b/src/data/paymentLinks/data.ts
@@ -76,11 +76,10 @@ export interface PaymentLinkData extends Model<'payment-link'> {
    */
   paidAt?: string;
   /**
-   * The date and time the payment link last status change, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
-   *
-   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link?path=updatedAt#response
+   * @deprecated This field currently always returns null and will be removed from the API in the future.
    */
-  updatedAt?: string;
+  // TODO: Remove in v5.0.0
+  updatedAt?: null;
   /**
    * The expiry date and time of the payment link, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *

--- a/tests/__nock-fixtures__/paymentLinks.json
+++ b/tests/__nock-fixtures__/paymentLinks.json
@@ -25,7 +25,6 @@
       "redirectUrl": null,
       "createdAt": "2021-11-24T11:44:29+00:00",
       "paidAt": null,
-      "updatedAt": null,
       "expiresAt": null,
       "_links": {
         "self": {
@@ -80,7 +79,6 @@
       "redirectUrl": null,
       "createdAt": "2021-11-24T11:44:29+00:00",
       "paidAt": null,
-      "updatedAt": null,
       "expiresAt": null,
       "_links": {
         "self": {
@@ -135,7 +133,6 @@
       "redirectUrl": null,
       "createdAt": "2021-11-24T11:44:29+00:00",
       "paidAt": null,
-      "updatedAt": null,
       "expiresAt": null,
       "_links": {
         "self": {


### PR DESCRIPTION
As discussed [here](https://github.com/mollie/mollie-api-node/issues/415#issuecomment-2747217823), the `updatedAt`  field in payment links always returns null should not exist.

Since it has been in the package for more than 3 years I decided on deprecating it, rather than removing it straight away.