### PR TITLE
sync Params of payments.create to customersPayments.create

### DIFF
--- a/src/binders/customers/payments/parameters.ts
+++ b/src/binders/customers/payments/parameters.ts
@@ -1,29 +1,11 @@
-import { type PaymentMethod } from '../../../data/global';
-import { type PaymentData } from '../../../data/payments/data';
-import type MaybeArray from '../../../types/MaybeArray';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
-import type PickOptional from '../../../types/PickOptional';
+import type { PaginationParameters, ThrottlingParameter } from '../../../types/parameters';
+import type { CreateParameters as PaymentCreateParameters } from '../../payments/parameters';
 
 interface ContextParameters {
   customerId: string;
 }
 
-export type CreateParameters = ContextParameters &
-  Pick<PaymentData, 'amount' | 'description'> &
-  PickOptional<PaymentData, 'locale' | 'mandateId' | 'metadata' | 'sequenceType' | 'webhookUrl' | 'redirectUrl'> & {
-    /**
-     * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
-     * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
-     *
-     * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
-     * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius']`.
-     *
-     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `mybank` `paypal` `paysafecard` `przelewy24` `sofort`
-     *
-     * @see https://docs.mollie.com/reference/v2/payments-api/create-payment?path=method#parameters
-     */
-    method?: MaybeArray<PaymentMethod>;
-  } & IdempotencyParameter;
+export type CreateParameters = Omit<PaymentCreateParameters, 'customerId'> & ContextParameters;
 
 export type PageParameters = ContextParameters & PaginationParameters;
 


### PR DESCRIPTION
The types of `payment.create` have been extensively updated recently.
Unfortunately `customerPayments.create` was neglected, even though it supports the same parameters (with the exception of `customerId`, as it's part of the request URL.

This PR fixes this mismatch and ensures long-term compatibility by importing and using the same types.

This fixes #441 