### PR TITLE
feat: add missing payment methods (bizum, mobilepay, swish, vipps)

### DIFF
--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -31,6 +31,7 @@ export enum PaymentMethod {
   banktransfer = 'banktransfer',
   belfius = 'belfius',
   billie = 'billie',
+  bizum = 'bizum',
   blik = 'blik',
   creditcard = 'creditcard',
   directdebit = 'directdebit',
@@ -44,6 +45,7 @@ export enum PaymentMethod {
   klarnapaynow = 'klarnapaynow',
   klarnasliceit = 'klarnasliceit',
   mbway = 'mbway',
+  mobilepay = 'mobilepay',
   multibanco = 'multibanco',
   mybank = 'mybank',
   paybybank = 'paybybank',
@@ -54,8 +56,10 @@ export enum PaymentMethod {
   przelewy24 = 'przelewy24',
   riverty = 'riverty',
   satispay = 'satispay',
+  swish = 'swish',
   trustly = 'trustly',
   twint = 'twint',
+  vipps = 'vipps',
   voucher = 'voucher',
 }
 


### PR DESCRIPTION
## Summary

Adds four payment methods that are available in the Mollie API but were missing from the SDK.

## Changes

Added the following payment methods to the `PaymentMethod` enum:

- **bizum**: Popular payment method in Spain
- **mobilepay**: Standard payment method in Denmark and Finland  
- **swish**: Popular payment method in Sweden
- **vipps**: Leading digital wallet in Norway

All methods are inserted alphabetically to maintain consistency with the existing enum structure.

## References

Closes #447