### PR TITLE
feat: add Balance Transfers API

### DIFF
--- a/src/binders/balance-transfers/BalanceTransfersBinder.ts
+++ b/src/binders/balance-transfers/BalanceTransfersBinder.ts
@@ -1,0 +1,71 @@
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import type BalanceTransfer from '../../data/balance-transfers/BalanceTransfer';
+import { type BalanceTransferData } from '../../data/balance-transfers/data';
+import type Page from '../../data/page/Page';
+import alias from '../../plumbing/alias';
+import assertWellFormedId from '../../plumbing/assertWellFormedId';
+import renege from '../../plumbing/renege';
+import type Callback from '../../types/Callback';
+import Binder from '../Binder';
+import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
+
+const pathSegment = 'connect/balance-transfers';
+
+export default class BalanceTransfersBinder extends Binder<BalanceTransferData, BalanceTransfer> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+    alias(this, { page: ['all', 'list'] });
+  }
+
+  /**
+   * Create a balance transfer from your organization's balance to a connected organization's balance, or vice versa.
+   * You can also create a balance transfer between two connected organizations.
+   *
+   * @since 4.4.0
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer
+   */
+  public create(parameters: CreateParameters): Promise<BalanceTransfer>;
+  public create(parameters: CreateParameters, callback: Callback<BalanceTransfer>): void;
+  public create(parameters: CreateParameters) {
+    if (renege(this, this.create, ...arguments)) return;
+    return this.networkClient.post<BalanceTransferData, BalanceTransfer>(pathSegment, parameters);
+  }
+
+  /**
+   * Retrieve a single Connect balance transfer object by its ID.
+   *
+   * @since 4.4.0
+   * @see https://docs.mollie.com/reference/get-connect-balance-transfer
+   */
+  public get(id: string, parameters?: GetParameters): Promise<BalanceTransfer>;
+  public get(id: string, parameters: GetParameters, callback: Callback<BalanceTransfer>): void;
+  public get(id: string, parameters?: GetParameters) {
+    if (renege(this, this.get, ...arguments)) return;
+    assertWellFormedId(id, 'balance-transfer');
+    return this.networkClient.get<BalanceTransferData, BalanceTransfer>(`${pathSegment}/${id}`, parameters);
+  }
+
+  /**
+   * Retrieve all Connect balance transfers.
+   *
+   * @since 4.4.0
+   * @see https://docs.mollie.com/reference/list-connect-balance-transfers
+   */
+  public page(parameters?: PageParameters): Promise<Page<BalanceTransfer>>;
+  public page(parameters: PageParameters, callback: Callback<Page<BalanceTransfer>>): void;
+  public page(parameters: PageParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.page<BalanceTransferData, BalanceTransfer>(pathSegment, 'connect-balance-transfers', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve all Connect balance transfers.
+   *
+   * @since 4.4.0
+   * @see https://docs.mollie.com/reference/list-connect-balance-transfers
+   */
+  public iterate(parameters?: IterateParameters) {
+    const { valuesPerMinute, ...query } = parameters ?? {};
+    return this.networkClient.iterate<BalanceTransferData, BalanceTransfer>(pathSegment, 'connect-balance-transfers', query, valuesPerMinute);
+  }
+}

--- a/src/binders/balance-transfers/parameters.ts
+++ b/src/binders/balance-transfers/parameters.ts
@@ -1,0 +1,19 @@
+import { type BalanceTransferData } from '../../data/balance-transfers/data';
+import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+
+interface ContextParameters {
+  /**
+   * Set this to `true` to use test mode.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=testmode#body-params
+   */
+  testmode?: boolean;
+}
+
+export type CreateParameters = ContextParameters & Pick<BalanceTransferData, 'amount' | 'source' | 'destination' | 'description' | 'category'> & IdempotencyParameter;
+
+export type GetParameters = ContextParameters;
+
+export type PageParameters = ContextParameters & PaginationParameters;
+
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -28,6 +28,7 @@ import { transform as transformIssuer } from './data/issuer/IssuerModel';
 import { transform as transformSettlement } from './data/settlements/SettlementModel';
 import { transform as transformTerminal } from './data/terminals/Terminal';
 import { transform as transformRoute } from './data/payments/routes/Route';
+import { transform as transformBalanceTransfer } from './data/balance-transfers/BalanceTransfer';
 
 // Binders
 import ApplePayBinder from './binders/applePay/ApplePayBinder';
@@ -64,6 +65,7 @@ import SubscriptionsBinder from './binders/subscriptions/SubscriptionsBinder';
 import SubscriptionPaymentsBinder from './binders/subscriptions/payments/SubscriptionPaymentsBinder';
 import TerminalsBinder from './binders/terminals/TerminalsBinder';
 import PaymentRoutesBinder from './binders/payments/routes/PaymentRoutesBinder';
+import BalanceTransfersBinder from './binders/balance-transfers/BalanceTransfersBinder';
 
 /**
  * Create Mollie client.
@@ -102,7 +104,8 @@ export default function createMollieClient(options: Options) {
       .add('issuer', transformIssuer)
       .add('settlement', transformSettlement)
       .add('terminal', transformTerminal)
-      .add('route', transformRoute),
+      .add('route', transformRoute)
+      .add('connect-balance-transfer', transformBalanceTransfer),
   );
 
   return apply(
@@ -178,6 +181,9 @@ export default function createMollieClient(options: Options) {
 
       // Terminals
       terminals: new TerminalsBinder(transformingNetworkClient),
+
+      // Balance Transfers
+      balanceTransfers: new BalanceTransfersBinder(transformingNetworkClient),
     },
     client =>
       alias(client, {
@@ -200,6 +206,7 @@ export default function createMollieClient(options: Options) {
 export { createMollieClient };
 
 export { ApiMode, Locale, PaymentMethod, HistoricPaymentMethod, SequenceType } from './data/global';
+export { BalanceTransferStatus, BalanceTransferStatusReasonCode, BalanceTransferCategory } from './data/balance-transfers/data';
 export { CaptureStatus, CaptureInclude } from './data/payments/captures/data';
 export { MandateMethod, MandateStatus } from './data/customers/mandates/data';
 export { MethodImageSize, MethodInclude } from './data/methods/data';

--- a/src/data/balance-transfers/BalanceTransfer.ts
+++ b/src/data/balance-transfers/BalanceTransfer.ts
@@ -1,0 +1,12 @@
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import type Seal from '../../types/Seal';
+import BalanceTransferHelper from './BalanceTransferHelper';
+import { type BalanceTransferData } from './data';
+
+type BalanceTransfer = Seal<BalanceTransferData, BalanceTransferHelper>;
+
+export default BalanceTransfer;
+
+export function transform(networkClient: TransformingNetworkClient, input: BalanceTransferData): BalanceTransfer {
+  return Object.assign(Object.create(new BalanceTransferHelper(networkClient, input._links)), input);
+}

--- a/src/data/balance-transfers/BalanceTransferHelper.ts
+++ b/src/data/balance-transfers/BalanceTransferHelper.ts
@@ -1,0 +1,13 @@
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import Helper from '../Helper';
+import type BalanceTransfer from './BalanceTransfer';
+import { type BalanceTransferData } from './data';
+
+export default class BalanceTransferHelper extends Helper<BalanceTransferData, BalanceTransfer> {
+  constructor(
+    networkClient: TransformingNetworkClient,
+    protected readonly links: BalanceTransferData['_links'],
+  ) {
+    super(networkClient, links);
+  }
+}

--- a/src/data/balance-transfers/data.ts
+++ b/src/data/balance-transfers/data.ts
@@ -1,0 +1,137 @@
+import { type Amount, type ApiMode, type Links } from '../global';
+import type Model from '../Model';
+
+export interface BalanceTransferData extends Model<'connect-balance-transfer'> {
+  /**
+   * The amount to be transferred.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=amount#body-params
+   */
+  amount: Amount;
+  /**
+   * A party involved in the balance transfer (sender).
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=source#body-params
+   */
+  source: BalanceTransferParty;
+  /**
+   * A party involved in the balance transfer (receiver).
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=destination#body-params
+   */
+  destination: BalanceTransferParty;
+  /**
+   * The transfer description for initiating party.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=description#body-params
+   */
+  description: string;
+  /**
+   * The status of the transfer.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=status#response
+   */
+  status: BalanceTransferStatus;
+  /**
+   * The reason for the current status of the transfer, if applicable.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=statusReason#response
+   */
+  statusReason?: BalanceTransferStatusReason;
+  /**
+   * The type of the transfer. Different fees may apply to different types of transfers.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=category#body-params
+   */
+  category?: BalanceTransferCategory;
+  /**
+   * The entity's date and time of creation, in ISO 8601 format.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=createdAt#response
+   */
+  createdAt: string;
+  /**
+   * The date and time when the transfer was completed, in ISO 8601 format.
+   * This parameter is omitted if the transfer is not executed (yet).
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=executedAt#response
+   */
+  executedAt?: string;
+  /**
+   * Whether this entity was created in live mode or in test mode.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=mode#response
+   */
+  mode: ApiMode;
+  /**
+   * An object with several relevant URLs.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=_links#response
+   */
+  _links: Links;
+}
+
+export interface BalanceTransferParty {
+  /**
+   * Defines the type of the party. At the moment, only `organization` is supported.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=source/type#body-params
+   */
+  type: 'organization';
+  /**
+   * Identifier of the party. For example, this contains the organization token if the type is `organization`.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=source/id#body-params
+   */
+  id: string;
+  /**
+   * The transfer description for the transfer party. This is the description that will appear in the financial reports of the party.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=source/description#body-params
+   */
+  description: string;
+}
+
+export interface BalanceTransferStatusReason {
+  /**
+   * A machine-readable code that indicates the reason for the transfer's status.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=statusReason/code#response
+   */
+  code: BalanceTransferStatusReasonCode;
+  /**
+   * A description of the status reason, localized according to the transfer.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=statusReason/message#response
+   */
+  message: string;
+}
+
+export enum BalanceTransferStatus {
+  created = 'created',
+  failed = 'failed',
+  succeeded = 'succeeded',
+}
+
+export enum BalanceTransferStatusReasonCode {
+  request_created = 'request_created',
+  success = 'success',
+  source_not_allowed = 'source_not_allowed',
+  destination_not_allowed = 'destination_not_allowed',
+  insufficient_funds = 'insufficient_funds',
+  invalid_source_balance = 'invalid_source_balance',
+  invalid_destination_balance = 'invalid_destination_balance',
+  transfer_request_expired = 'transfer_request_expired',
+  transfer_limit_reached = 'transfer_limit_reached',
+}
+
+export enum BalanceTransferCategory {
+  invoice_collection = 'invoice_collection',
+  purchase = 'purchase',
+  chargeback = 'chargeback',
+  refund = 'refund',
+  service_penalty = 'service_penalty',
+  discount_compensation = 'discount_compensation',
+  manual_correction = 'manual_correction',
+  other_fee = 'other_fee',
+}

--- a/src/plumbing/assertWellFormedId.ts
+++ b/src/plumbing/assertWellFormedId.ts
@@ -2,6 +2,7 @@ import ApiError from '../errors/ApiError';
 import type Maybe from '../types/Maybe';
 
 const prefixes = {
+  'balance-transfer': 'cbtr_',
   'capture': 'cpt_',
   'chargeback': 'chb_',
   'customer': 'cst_',

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@ export { default as MollieOptions } from './Options';
 
 export { default as Page } from './data/page/Page';
 
+export { default as BalanceTransfer } from './data/balance-transfers/BalanceTransfer';
+export { CreateParameters as BalanceTransferCreateParams, GetParameters as BalanceTransferGetParams, PageParameters as BalanceTransfersPageParams } from './binders/balance-transfers/parameters';
+
 export { default as Capture } from './data/payments/captures/Capture';
 import { GetParameters as CapturesGetParameters, PageParameters as CapturesPageParameters } from './binders/payments/captures/parameters';
 export { CapturesGetParameters, CapturesPageParameters };

--- a/tests/unit/resources/balance-transfers.test.ts
+++ b/tests/unit/resources/balance-transfers.test.ts
@@ -1,0 +1,141 @@
+import { BalanceTransferStatus } from '../../..';
+import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
+
+function composeBalanceTransferResponse(id = 'cbtr_nBprRarXeqXi98AXSqCBJ') {
+  return {
+    resource: 'connect-balance-transfer',
+    id,
+    amount: {
+      value: '100.00',
+      currency: 'EUR',
+    },
+    source: {
+      type: 'organization',
+      id: 'org_1',
+      description: 'Description for source',
+    },
+    destination: {
+      type: 'organization',
+      id: 'org_2',
+      description: 'Description for destination',
+    },
+    description: 'Description for initiating party',
+    status: BalanceTransferStatus.succeeded,
+    statusReason: {
+      code: 'success',
+      message: 'Balance transfer completed successfully.',
+    },
+    category: 'invoice_collection',
+    createdAt: '2025-05-01T10:00:00Z',
+    executedAt: '2025-05-01T10:05:00Z',
+    mode: 'live',
+    _links: {
+      self: {
+        href: `https://api.mollie.com/v2/connect/balance-transfers/${id}`,
+        type: 'application/hal+json',
+      },
+      documentation: {
+        href: 'https://docs.mollie.com/reference/create-connect-balance-transfer',
+        type: 'text/html',
+      },
+    },
+  };
+}
+
+function testBalanceTransfer(transfer, id = 'cbtr_nBprRarXeqXi98AXSqCBJ') {
+  expect(transfer.resource).toBe('connect-balance-transfer');
+  expect(transfer.id).toBe(id);
+  expect(transfer.amount).toEqual({ value: '100.00', currency: 'EUR' });
+  expect(transfer.source).toEqual({
+    type: 'organization',
+    id: 'org_1',
+    description: 'Description for source',
+  });
+  expect(transfer.destination).toEqual({
+    type: 'organization',
+    id: 'org_2',
+    description: 'Description for destination',
+  });
+  expect(transfer.description).toBe('Description for initiating party');
+  expect(transfer.status).toBe('succeeded');
+  expect(transfer.statusReason).toEqual({
+    code: 'success',
+    message: 'Balance transfer completed successfully.',
+  });
+  expect(transfer.category).toBe('invoice_collection');
+  expect(transfer.createdAt).toBe('2025-05-01T10:00:00Z');
+  expect(transfer.executedAt).toBe('2025-05-01T10:05:00Z');
+  expect(transfer.mode).toBe('live');
+  expect(transfer._links.self).toEqual({
+    href: `https://api.mollie.com/v2/connect/balance-transfers/${id}`,
+    type: 'application/hal+json',
+  });
+}
+
+test('createBalanceTransfer', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('POST', '/connect/balance-transfers', 201, composeBalanceTransferResponse('cbtr_test123')).twice();
+
+    const transfer = await bluster(mollieClient.balanceTransfers.create.bind(mollieClient.balanceTransfers))({
+      amount: { value: '100.00', currency: 'EUR' },
+      source: { type: 'organization', id: 'org_1', description: 'Description for source' },
+      destination: { type: 'organization', id: 'org_2', description: 'Description for destination' },
+      description: 'Description for initiating party',
+      category: 'invoice_collection',
+    });
+
+    testBalanceTransfer(transfer, 'cbtr_test123');
+  });
+});
+
+test('getBalanceTransfer', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/connect/balance-transfers/cbtr_test456', 200, composeBalanceTransferResponse('cbtr_test456')).twice();
+
+    const transfer = await bluster(mollieClient.balanceTransfers.get.bind(mollieClient.balanceTransfers))('cbtr_test456');
+
+    testBalanceTransfer(transfer, 'cbtr_test456');
+  });
+});
+
+test('listBalanceTransfers', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker
+      .intercept('GET', '/connect/balance-transfers', 200, {
+        count: 2,
+        _embedded: {
+          'connect-balance-transfers': [composeBalanceTransferResponse('cbtr_1'), composeBalanceTransferResponse('cbtr_2')],
+        },
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/list-connect-balance-transfers',
+            type: 'text/html',
+          },
+          self: {
+            href: 'https://api.mollie.com/v2/connect/balance-transfers?limit=50',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: null,
+        },
+      })
+      .twice();
+
+    const transfers = await bluster(mollieClient.balanceTransfers.page.bind(mollieClient.balanceTransfers))();
+
+    expect(transfers.length).toBe(2);
+    expect(transfers.links.documentation).toEqual({
+      href: 'https://docs.mollie.com/reference/list-connect-balance-transfers',
+      type: 'text/html',
+    });
+    expect(transfers.links.self).toEqual({
+      href: 'https://api.mollie.com/v2/connect/balance-transfers?limit=50',
+      type: 'application/hal+json',
+    });
+    expect(transfers.links.previous).toBeNull();
+    expect(transfers.links.next).toBeNull();
+
+    testBalanceTransfer(transfers[0], 'cbtr_1');
+    testBalanceTransfer(transfers[1], 'cbtr_2');
+  });
+});


### PR DESCRIPTION
## Summary

Implements support for the Mollie Connect Balance Transfers API, enabling organizations to transfer funds between connected organization balances.

## Changes

- **Added BalanceTransfersBinder** in `src/binders/balance-transfers/` with `create()`, `get()`, `page()`, and `iterate()` methods
- **Added BalanceTransfer data model** with comprehensive typing for:
  - Transfer parties (source/destination)
  - Transfer status and status reasons
  - Transfer categories and fees
  - Amount and description
- **Added balance transfer parameters** for creating transfers
- **Registered 'connect-balance-transfer' resource** in `createMollieClient`
- **Added ID validation** for balance transfer IDs in `assertWellFormedId`
- **Exported BalanceTransfer types** in `types.ts`
- **Added comprehensive test coverage** in `balance-transfers.test.ts`

The implementation follows the established patterns for top-level resources (similar to payments, refunds).

## API Details

The Balance Transfers API provides:
- **Create transfer**: Initiate a fund transfer between organizations
- **Get transfer**: Retrieve transfer details by ID
- **List transfers**: Paginated listing with filtering options
- **Iterate transfers**: Async iteration over all transfers

Transfer properties:
- Amount and currency
- Source and destination organizations
- Status tracking (pending, completed, failed)
- Category (balance-correction, fee-reimbursement, etc.)
- Timestamps

## Use Cases

- Transfer funds between platform and connected merchants
- Balance corrections
- Fee reimbursements
- Fund management for marketplaces

## Documentation

- [Mollie Balance Transfers Guide](https://docs.mollie.com/connect/balance-transfers)
- [API Reference](https://docs.mollie.com/reference/create-connect-balance-transfer)

## References

Closes #450

## Dependencies

This PR builds on #454 (Delayed Routing API) and should be merged after it.