### PR TITLE
feat: add Capabilities API support

### DIFF
--- a/src/binders/capabilities/CapabilitiesBinder.ts
+++ b/src/binders/capabilities/CapabilitiesBinder.ts
@@ -1,0 +1,29 @@
+import type NetworkClient from '../../communication/NetworkClient';
+import type Capability from '../../data/capabilities/Capability';
+import alias from '../../plumbing/alias';
+import renege from '../../plumbing/renege';
+import type Callback from '../../types/Callback';
+
+const pathSegment = 'capabilities';
+
+export default class CapabilitiesBinder {
+  constructor(protected readonly networkClient: NetworkClient) {
+    alias(this, { list: 'page' });
+  }
+
+  /**
+   * Retrieve a list of capabilities for an organization.
+   *
+   * This API provides detailed insights into the specific requirements and status of each
+   * client's onboarding journey.
+   *
+   * @since 4.4.0
+   * @see https://docs.mollie.com/reference/list-capabilities
+   */
+  public list(): Promise<Capability[]>;
+  public list(callback: Callback<Capability[]>): void;
+  public list() {
+    if (renege(this, this.list, ...arguments)) return;
+    return this.networkClient.list<Capability>(pathSegment, 'capabilities', {});
+  }
+}

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -67,6 +67,7 @@ import SubscriptionPaymentsBinder from './binders/subscriptions/payments/Subscri
 import TerminalsBinder from './binders/terminals/TerminalsBinder';
 import PaymentRoutesBinder from './binders/payments/routes/PaymentRoutesBinder';
 import BalanceTransfersBinder from './binders/balance-transfers/BalanceTransfersBinder';
+import CapabilitiesBinder from './binders/capabilities/CapabilitiesBinder';
 
 /**
  * Create Mollie client.
@@ -186,6 +187,9 @@ export default function createMollieClient(options: Options) {
 
       // Balance Transfers
       balanceTransfers: new BalanceTransfersBinder(transformingNetworkClient),
+
+      // Capabilities
+      capabilities: new CapabilitiesBinder(networkClient),
     },
     client =>
       alias(client, {
@@ -220,4 +224,5 @@ export { SubscriptionStatus } from './data/subscriptions/data';
 export { ProfileStatus } from './data/profiles/data';
 export { OnboardingStatus } from './data/onboarding/data';
 export { TerminalStatus } from './data/terminals/data';
+export { CapabilityStatus, CapabilityStatusReason, RequirementStatus } from './data/capabilities/data';
 export { default as MollieApiError } from './errors/ApiError';

--- a/src/data/capabilities/Capability.ts
+++ b/src/data/capabilities/Capability.ts
@@ -1,0 +1,5 @@
+import { type CapabilityData } from './data';
+
+type Capability = Readonly<CapabilityData>;
+
+export default Capability;

--- a/src/data/capabilities/data.ts
+++ b/src/data/capabilities/data.ts
@@ -1,0 +1,111 @@
+import { type Url } from '../global';
+import type Model from '../Model';
+/**
+ * Capability data for an organization.
+ *
+ * @see https://docs.mollie.com/reference/list-capabilities
+ */
+export interface CapabilityData
+  extends Omit<
+    Model<'capability'>,
+    'id' // Capabilities use `name` as identifier instead of `id`, so we omit `id` from Model.
+  > {
+  /**
+   * A unique name for this capability like `payments` or `settlements`.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=name#response
+   */
+  name: string;
+  /**
+   * The status of the capability.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=status#response
+   */
+  status: CapabilityStatus;
+  /**
+   * The reason why the capability is in its current status, if applicable.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=statusReason#response
+   */
+  statusReason?: CapabilityStatusReason;
+  /**
+   * Array of requirements that need to be fulfilled to enable or re-enable the capability.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=requirements#response
+   */
+  requirements: Requirement[];
+}
+
+/**
+ * A requirement for a capability.
+ *
+ * @see https://docs.mollie.com/reference/list-capabilities
+ */
+export interface Requirement {
+  /**
+   * The name of this requirement, referring to the task to be fulfilled by the organization
+   * to enable or re-enable the capability. The name is unique among other requirements of
+   * the same capability.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=id#response
+   */
+  id: string;
+  /**
+   * The status of the requirement depends on its due date. If no due date is given,
+   * the status will be `requested`.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=status#response
+   */
+  status: RequirementStatus;
+  /**
+   * Due date until the requirement must be fulfilled, if any.
+   * The date is shown in ISO-8601 format.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=dueDate#response
+   */
+  dueDate: string | null;
+  /**
+   * Links related to this requirement.
+   *
+   * @see https://docs.mollie.com/reference/list-capabilities?path=_links#response
+   */
+  _links: {
+    /**
+     * The dashboard URL where the requirement can be fulfilled.
+     */
+    dashboard: Url;
+  };
+}
+
+/**
+ * Capability status.
+ *
+ * @see https://docs.mollie.com/reference/list-capabilities
+ */
+export enum CapabilityStatus {
+  unrequested = 'unrequested',
+  enabled = 'enabled',
+  disabled = 'disabled',
+  pending = 'pending',
+}
+
+/**
+ * Reason why a capability is in its current status.
+ *
+ * @see https://docs.mollie.com/reference/list-capabilities
+ */
+export enum CapabilityStatusReason {
+  requirementPastDue = 'requirement-past-due',
+  onboardingInformationNeeded = 'onboarding-information-needed',
+}
+
+/**
+ * Requirement status.
+ *
+ * @see https://docs.mollie.com/reference/list-capabilities
+ */
+export enum RequirementStatus {
+  currentlyDue = 'currently-due',
+  pastDue = 'past-due',
+  requested = 'requested',
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export { default as Page } from './data/page/Page';
 export { default as BalanceTransfer } from './data/balance-transfers/BalanceTransfer';
 export { CreateParameters as BalanceTransferCreateParams, GetParameters as BalanceTransferGetParams, PageParameters as BalanceTransfersPageParams } from './binders/balance-transfers/parameters';
 
+export { default as Capability } from './data/capabilities/Capability';
+
 export { default as Capture } from './data/payments/captures/Capture';
 import { GetParameters as CapturesGetParameters, PageParameters as CapturesPageParameters } from './binders/payments/captures/parameters';
 export { CapturesGetParameters, CapturesPageParameters };

--- a/tests/unit/resources/capabilities.test.ts
+++ b/tests/unit/resources/capabilities.test.ts
@@ -1,0 +1,96 @@
+import createMollieClient from '../../..';
+import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
+
+test('listCapabilities', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker
+      .intercept('GET', '/capabilities', 200, {
+        count: 2,
+        _embedded: {
+          capabilities: [
+            {
+              resource: 'capability',
+              name: 'payments',
+              status: 'enabled',
+              requirements: [],
+            },
+            {
+              resource: 'capability',
+              name: 'settlements',
+              status: 'pending',
+              statusReason: 'onboarding-information-needed',
+              requirements: [
+                {
+                  id: 'legal-representatives',
+                  status: 'requested',
+                  dueDate: null,
+                  _links: {
+                    dashboard: {
+                      href: 'https://my.mollie.com/dashboard/...',
+                      type: 'text/html',
+                    },
+                  },
+                },
+                {
+                  id: 'bank-account',
+                  status: 'past-due',
+                  dueDate: '2024-05-14T01:29:09+00:00',
+                  _links: {
+                    dashboard: {
+                      href: 'https://my.mollie.com/dashboard/...',
+                      type: 'text/html',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/list-capabilities',
+            type: 'text/html',
+          },
+        },
+      })
+      .twice();
+
+    const capabilities = await bluster(mollieClient.capabilities.list.bind(mollieClient.capabilities))();
+
+    expect(capabilities).toHaveLength(2);
+
+    // First capability - enabled payments
+    expect(capabilities[0].resource).toBe('capability');
+    expect(capabilities[0].name).toBe('payments');
+    expect(capabilities[0].status).toBe('enabled');
+    expect(capabilities[0].statusReason).toBeUndefined();
+    expect(capabilities[0].requirements).toHaveLength(0);
+
+    // Second capability - pending settlements with requirements
+    expect(capabilities[1].resource).toBe('capability');
+    expect(capabilities[1].name).toBe('settlements');
+    expect(capabilities[1].status).toBe('pending');
+    expect(capabilities[1].statusReason).toBe('onboarding-information-needed');
+    expect(capabilities[1].requirements).toHaveLength(2);
+
+    // First requirement
+    expect(capabilities[1].requirements[0].id).toBe('legal-representatives');
+    expect(capabilities[1].requirements[0].status).toBe('requested');
+    expect(capabilities[1].requirements[0].dueDate).toBeNull();
+    expect(capabilities[1].requirements[0]._links.dashboard.href).toBe('https://my.mollie.com/dashboard/...');
+
+    // Second requirement
+    expect(capabilities[1].requirements[1].id).toBe('bank-account');
+    expect(capabilities[1].requirements[1].status).toBe('past-due');
+    expect(capabilities[1].requirements[1].dueDate).toBe('2024-05-14T01:29:09+00:00');
+  });
+});
+
+describe('capabilities binder', () => {
+  it('is available on the client', () => {
+    const mollieClient = createMollieClient({ apiKey: 'test_dummyKey' });
+    expect(mollieClient).toHaveProperty('capabilities');
+    expect(mollieClient.capabilities).toHaveProperty('list');
+    expect(typeof mollieClient.capabilities.list).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for the Capabilities API endpoint to retrieve organization capability information including onboarding requirements and status.

## Changes

- **Added Capability data model** in `src/data/capabilities/` with `CapabilityData`, `Requirement` interfaces and `CapabilityStatus`, `CapabilityStatusReason`, `RequirementStatus` enums
- **Implemented `CapabilitiesBinder`** with `list()` method to retrieve all capabilities for an organization
- **Exported Capability type** in `types.ts` and enums in `createMollieClient.ts`
- **Added unit tests** verifying list functionality and response parsing

## API Details

The Capabilities API provides:
- List of capabilities for an organization (payments, settlements, etc.)
- Capability status (unrequested, enabled, disabled, pending)
- Status reasons when applicable
- Requirements with due dates and dashboard links for onboarding tasks

## Implementation Notes

Uses `NetworkClient` directly (like `ApplePayBinder`) instead of `TransformingNetworkClient` because the Capabilities API response doesn't include an `id` field (it uses `name` as identifier), which doesn't satisfy the `Model` type constraint required by the transformer system. If the API changes to include an `id` field in the future, we should migrate to use `TransformingNetworkClient` for consistency.

## Note

Unable to add integration tests as this endpoint requires OAuth access tokens. Unit tests verify request/response handling but cannot verify actual API behavior.

**This is a beta feature - the final specification may still change. Will be released as a beta first.**

## References

- Closes #457
- [Capabilities API docs](https://docs.mollie.com/reference/list-capabilities)