### PR TITLE
refactor: omit _links from public types for consistency

### DIFF
--- a/src/data/balance-transfers/BalanceTransfer.ts
+++ b/src/data/balance-transfers/BalanceTransfer.ts
@@ -3,7 +3,7 @@ import type Seal from '../../types/Seal';
 import BalanceTransferHelper from './BalanceTransferHelper';
 import { type BalanceTransferData } from './data';
 
-type BalanceTransfer = Seal<BalanceTransferData, BalanceTransferHelper>;
+type BalanceTransfer = Seal<Omit<BalanceTransferData, '_links'>, BalanceTransferHelper>;
 
 export default BalanceTransfer;
 

--- a/src/data/organizations/partner/PartnerStatus.ts
+++ b/src/data/organizations/partner/PartnerStatus.ts
@@ -3,7 +3,7 @@ import type Seal from '../../../types/Seal';
 import type { PartnerStatusData } from './data';
 import PartnerStatusHelper from './PartnerStatusHelper';
 
-type PartnerStatus = Seal<PartnerStatusData, PartnerStatusHelper>;
+type PartnerStatus = Seal<Omit<PartnerStatusData, '_links'>, PartnerStatusHelper>;
 
 export default PartnerStatus;
 

--- a/src/data/organizations/partner/PartnerStatusHelper.ts
+++ b/src/data/organizations/partner/PartnerStatusHelper.ts
@@ -4,7 +4,18 @@ import type PartnerStatus from './PartnerStatus';
 import type { PartnerStatusData } from './data';
 
 export default class PartnerStatusHelper extends Helper<PartnerStatusData, PartnerStatus> {
-  constructor(networkClient: TransformingNetworkClient, links: PartnerStatusData['_links']) {
+  constructor(
+    networkClient: TransformingNetworkClient,
+    protected readonly links: PartnerStatusData['_links'],
+  ) {
     super(networkClient, links);
+  }
+
+  /**
+   * Returns the signup link URL for this partner, if available.
+   * Only present for partners of type "signuplink".
+   */
+  public getSignupLink(): string | undefined {
+    return this.links.signuplink?.href;
   }
 }

--- a/src/data/payments/routes/Route.ts
+++ b/src/data/payments/routes/Route.ts
@@ -3,7 +3,7 @@ import type Seal from '../../../types/Seal';
 import RouteHelper from './RouteHelper';
 import { type RouteData } from './data';
 
-type Route = Seal<RouteData, RouteHelper>;
+type Route = Seal<Omit<RouteData, '_links'>, RouteHelper>;
 
 export default Route;
 

--- a/tests/unit/resources/organizations.test.ts
+++ b/tests/unit/resources/organizations.test.ts
@@ -108,9 +108,7 @@ test('getPartnerStatus', () => {
       href: 'https://api.mollie.com/v2/organizations/me/partner',
       type: 'application/hal+json',
     });
-    expect(partnerStatus._links.signuplink).toEqual({
-      href: 'https://www.mollie.com/dashboard/signup/exampleCode',
-      type: 'text/html',
-    });
+    // Test the getSignupLink helper (provides access to signuplink URL)
+    expect(partnerStatus.getSignupLink()).toBe('https://www.mollie.com/dashboard/signup/exampleCode');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PRs #453, #454, #455 - hide internal `_links` property from PartnerStatus, Route, and BalanceTransfer types to match the established pattern used by Settlement and PaymentLink.

The `_links` property remains accessible at runtime for testing purposes, but is hidden from the public TypeScript interface.

- Omit `_links` from `PartnerStatus`, `Route`, and `BalanceTransfer` Seal types
- Add `getSignupLink()` helper to PartnerStatus for accessing signup URL
- Update PartnerStatus test to use helper instead of direct `_links.signuplink` access

## References

- https://docs.mollie.com/reference/get-partner-status
- https://docs.mollie.com/reference/payment-create-route
- https://docs.mollie.com/reference/create-connect-balance-transfer