### PR TITLE
feat: add sort parameter to list endpoints

### DIFF
--- a/src/binders/balance-transfers/parameters.ts
+++ b/src/binders/balance-transfers/parameters.ts
@@ -1,5 +1,5 @@
 import { type BalanceTransferData } from '../../data/balance-transfers/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 
 interface ContextParameters {
   /**
@@ -14,6 +14,6 @@ export type CreateParameters = ContextParameters & Pick<BalanceTransferData, 'am
 
 export type GetParameters = ContextParameters;
 
-export type PageParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/chargebacks/parameters.ts
+++ b/src/binders/chargebacks/parameters.ts
@@ -1,7 +1,7 @@
 import { type ChargebackEmbed } from '../../data/chargebacks/Chargeback';
-import { type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & SortParameter & {
   profileId?: string;
   embed?: ChargebackEmbed[];
 };

--- a/src/binders/customers/mandates/parameters.ts
+++ b/src/binders/customers/mandates/parameters.ts
@@ -1,5 +1,5 @@
 import { type MandateData } from '../../../data/customers/mandates/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
 
 interface ContextParameters {
   customerId: string;
@@ -54,7 +54,7 @@ export type CreateParameters = ContextParameters &
 
 export type GetParameters = ContextParameters;
 
-export type PageParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 

--- a/src/binders/customers/parameters.ts
+++ b/src/binders/customers/parameters.ts
@@ -1,5 +1,5 @@
 import { type CustomerData } from '../../data/customers/Customer';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
 interface ContextParameter {
@@ -10,7 +10,7 @@ export type CreateParameters = ContextParameter & PickOptional<CustomerData, 'na
 
 export type GetParameters = ContextParameter;
 
-export type PageParameters = ContextParameter & PaginationParameters;
+export type PageParameters = ContextParameter & PaginationParameters & SortParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 

--- a/src/binders/customers/payments/parameters.ts
+++ b/src/binders/customers/payments/parameters.ts
@@ -1,4 +1,4 @@
-import type { PaginationParameters, ThrottlingParameter } from '../../../types/parameters';
+import type { PaginationParameters, SortParameter, ThrottlingParameter } from '../../../types/parameters';
 import type { CreateParameters as PaymentCreateParameters } from '../../payments/parameters';
 
 interface ContextParameters {
@@ -7,6 +7,6 @@ interface ContextParameters {
 
 export type CreateParameters = Omit<PaymentCreateParameters, 'customerId'> & ContextParameters;
 
-export type PageParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/customers/subscriptions/parameters.ts
+++ b/src/binders/customers/subscriptions/parameters.ts
@@ -1,5 +1,5 @@
 import { type SubscriptionData } from '../../../data/subscriptions/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
 
 interface ContextParameters {
@@ -14,7 +14,7 @@ export type CreateParameters = ContextParameters &
 
 export type GetParameters = ContextParameters;
 
-export type PageParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 

--- a/src/binders/orders/parameters.ts
+++ b/src/binders/orders/parameters.ts
@@ -1,7 +1,7 @@
 import { type PaymentMethod } from '../../data/global';
 import { type OrderData, type OrderEmbed } from '../../data/orders/data';
 import { type OrderLineData } from '../../data/orders/orderlines/OrderLine';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 import { type CreateParameters as PaymentCreateParameters } from '../payments/parameters';
 import type PickOptional from '../../types/PickOptional';
 import type MaybeArray from '../../types/MaybeArray';
@@ -95,7 +95,7 @@ export type UpdateParameters = PickOptional<OrderData, 'billingAddress' | 'shipp
   testmode?: boolean;
 };
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & SortParameter & {
   profileId?: string;
   testmode?: boolean;
 };

--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -1,7 +1,7 @@
 import { type Amount, type PaymentMethod } from '../../data/global';
 import { type PaymentData, type PaymentEmbed, type PaymentInclude } from '../../data/payments/data';
 import type MaybeArray from '../../types/MaybeArray';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
 export type CreateParameters = Pick<
@@ -211,7 +211,7 @@ export interface GetParameters {
   testmode?: boolean;
 }
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & SortParameter & {
   testmode?: boolean;
 };
 

--- a/src/binders/refunds/parameters.ts
+++ b/src/binders/refunds/parameters.ts
@@ -1,6 +1,6 @@
-import { type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & SortParameter & {
   profileId?: string;
   testmode?: boolean;
 };

--- a/src/binders/subscriptions/parameters.ts
+++ b/src/binders/subscriptions/parameters.ts
@@ -1,6 +1,6 @@
-import { type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & SortParameter & {
   profileId?: string;
   testmode?: boolean;
 };

--- a/src/binders/subscriptions/payments/parameters.ts
+++ b/src/binders/subscriptions/payments/parameters.ts
@@ -1,4 +1,4 @@
-import { type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
 
 interface ContextParameters {
   testmode?: boolean;
@@ -6,6 +6,6 @@ interface ContextParameters {
   subscriptionId: string;
 }
 
-export type PageParameters = ContextParameters & PaginationParameters;
+export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/terminals/parameters.ts
+++ b/src/binders/terminals/parameters.ts
@@ -1,6 +1,6 @@
-import { PaginationParameters, ThrottlingParameter } from '../../types/parameters';
+import { PaginationParameters, SortParameter, ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = PaginationParameters & SortParameter & {
   testmode?: boolean;
 };
 

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -1,6 +1,27 @@
 export interface PaginationParameters {
+  /**
+   * Offset the result set to the resource with the given ID. The returned result set will start with the resource after the given one.
+   *
+   * @see https://docs.mollie.com/reference/pagination
+   */
   from?: string;
+  /**
+   * The number of resources to return per page. Defaults to 250.
+   *
+   * @see https://docs.mollie.com/reference/pagination
+   */
   limit?: number;
+}
+
+export interface SortParameter {
+  /**
+   * Determines the sorting direction of the results. By default, the results are sorted in descending order (newest first).
+   *
+   * Possible values: `asc` `desc`
+   *
+   * @see https://docs.mollie.com/reference/pagination
+   */
+  sort?: 'asc' | 'desc';
 }
 
 export interface ThrottlingParameter {


### PR DESCRIPTION
## Summary
- Adds `SortParameter` type (`sort?: 'asc' | 'desc'`) to `src/types/parameters.ts`
- Mixes it into `PageParameters` for all 12 list endpoints that support it per the Mollie API docs: payments, orders, customers, chargebacks, subscriptions, terminals, refunds (all), customer payments, mandates, customer subscriptions, subscription payments, and balance transfers
- Adds JSDoc to `PaginationParameters` fields

## Test plan
- [x] TypeScript build passes
- [x] Verify `sort` param is correctly passed through to the API on list calls