### PR TITLE
feat: add TestModeParameter type to replace inline testmode definitions

### DIFF
--- a/src/binders/balance-transfers/parameters.ts
+++ b/src/binders/balance-transfers/parameters.ts
@@ -1,14 +1,7 @@
 import { type BalanceTransferData } from '../../data/balance-transfers/data';
-import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
-interface ContextParameters {
-  /**
-   * Set this to `true` to use test mode.
-   *
-   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=testmode#body-params
-   */
-  testmode?: boolean;
-}
+type ContextParameters = TestModeParameter;
 
 export type CreateParameters = ContextParameters & Pick<BalanceTransferData, 'amount' | 'source' | 'destination' | 'description' | 'category'> & IdempotencyParameter;
 

--- a/src/binders/customers/mandates/parameters.ts
+++ b/src/binders/customers/mandates/parameters.ts
@@ -1,9 +1,8 @@
 import { type MandateData } from '../../../data/customers/mandates/data';
-import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   customerId: string;
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters &

--- a/src/binders/customers/parameters.ts
+++ b/src/binders/customers/parameters.ts
@@ -1,10 +1,8 @@
 import { type CustomerData } from '../../data/customers/Customer';
-import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
-interface ContextParameter {
-  testmode?: boolean;
-}
+type ContextParameter = TestModeParameter;
 
 export type CreateParameters = ContextParameter & PickOptional<CustomerData, 'name' | 'email' | 'locale' | 'metadata'> & IdempotencyParameter;
 

--- a/src/binders/customers/subscriptions/parameters.ts
+++ b/src/binders/customers/subscriptions/parameters.ts
@@ -1,10 +1,9 @@
 import { type SubscriptionData } from '../../../data/subscriptions/data';
-import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   customerId: string;
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters &

--- a/src/binders/methods/parameters.ts
+++ b/src/binders/methods/parameters.ts
@@ -1,8 +1,9 @@
 import { type Amount, type Locale, type SequenceType } from '../../data/global';
 import { type MethodInclude } from '../../data/methods/data';
 import type MaybeArray from '../../types/MaybeArray';
+import { type TestModeParameter } from '../../types/parameters';
 
-export interface GetParameters {
+export interface GetParameters extends TestModeParameter {
   /**
    * Passing a locale will translate the payment method name in the corresponding language.
    *
@@ -13,7 +14,6 @@ export interface GetParameters {
   locale?: Locale;
   include?: MaybeArray<MethodInclude>;
   profileId?: string;
-  testmode?: boolean;
   /**
    * The currency to receiving the `minimumAmount` and `maximumAmount` in. We will return an error when the currency is not supported by the payment method.
    *
@@ -37,7 +37,7 @@ export interface GetParameters {
  *
  * @see https://docs.mollie.com/reference/v2/methods-api/list-methods
  */
-export interface ListParameters {
+export interface ListParameters extends TestModeParameter {
   /**
    * Passing `first` will only show payment methods eligible for making a first payment. Passing `recurring` shows payment methods which can be used to automatically charge your customer's account
    * when authorization has been given.
@@ -106,5 +106,4 @@ export interface ListParameters {
   orderLineCategories?: string[];
   include?: MaybeArray<MethodInclude>;
   profileId?: string;
-  testmode?: boolean;
 }

--- a/src/binders/orders/orderlines/parameters.ts
+++ b/src/binders/orders/orderlines/parameters.ts
@@ -1,11 +1,10 @@
 import { type Amount } from '../../../data/global';
 import { type OrderLineData } from '../../../data/orders/orderlines/OrderLine';
-import { type IdempotencyParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type TestModeParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   orderId: string;
-  testmode?: boolean;
 }
 
 export type UpdateParameters = ContextParameters &

--- a/src/binders/orders/parameters.ts
+++ b/src/binders/orders/parameters.ts
@@ -1,13 +1,15 @@
 import { type PaymentMethod } from '../../data/global';
 import { type OrderData, type OrderEmbed } from '../../data/orders/data';
 import { type OrderLineData } from '../../data/orders/orderlines/OrderLine';
-import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 import { type CreateParameters as PaymentCreateParameters } from '../payments/parameters';
 import type PickOptional from '../../types/PickOptional';
 import type MaybeArray from '../../types/MaybeArray';
 
 export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'consumerDateOfBirth' | 'webhookUrl' | 'locale' | 'expiresAt'> &
-  PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'cancelUrl' | 'metadata'> & {
+  PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'cancelUrl' | 'metadata'> &
+  TestModeParameter &
+  IdempotencyParameter & {
     /**
      * All order lines must have the same currency as the order. You cannot mix currencies within a single order.
      *
@@ -82,26 +84,21 @@ export type CreateParameters = Pick<OrderData, 'amount' | 'orderNumber' | 'consu
     shopperCountryMustMatchBillingCountry?: boolean;
     embed?: OrderEmbed.payments[];
     profileId?: string;
-    testmode?: boolean;
-  } & IdempotencyParameter;
+  };
 
-export interface GetParameters {
-  testmode?: boolean;
+export interface GetParameters extends TestModeParameter {
   embed?: OrderEmbed[];
 }
 
-export type UpdateParameters = PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'cancelUrl' | 'webhookUrl'> & {
-  orderNumber?: string;
-  testmode?: boolean;
-};
+export type UpdateParameters = PickOptional<OrderData, 'billingAddress' | 'shippingAddress' | 'redirectUrl' | 'cancelUrl' | 'webhookUrl'> &
+  TestModeParameter & {
+    orderNumber?: string;
+  };
 
-export type PageParameters = PaginationParameters & SortParameter & {
+export type PageParameters = PaginationParameters & SortParameter & TestModeParameter & {
   profileId?: string;
-  testmode?: boolean;
 };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
-export interface CancelParameters extends IdempotencyParameter {
-  testmode?: boolean;
-}
+export type CancelParameters = TestModeParameter & IdempotencyParameter;

--- a/src/binders/orders/shipments/parameters.ts
+++ b/src/binders/orders/shipments/parameters.ts
@@ -1,11 +1,10 @@
 import { type Amount } from '../../../data/global';
 import { type ShipmentData } from '../../../data/orders/shipments/Shipment';
-import { type IdempotencyParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type TestModeParameter } from '../../../types/parameters';
 import type PickRequired from '../../../types/PickRequired';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   orderId: string;
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters &

--- a/src/binders/paymentLinks/parameters.ts
+++ b/src/binders/paymentLinks/parameters.ts
@@ -1,27 +1,25 @@
 import { type PaymentLinkData } from '../../data/paymentLinks/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
+
+type ContextParameters = TestModeParameter;
 
 export type CreateParameters = Pick<PaymentLinkData, 'description'> &
   PickOptional<
     PaymentLinkData,
     'amount' | 'minimumAmount' | 'redirectUrl' | 'webhookUrl' | 'lines' | 'billingAddress' | 'shippingAddress' | 'profileId' | 'reusable' | 'expiresAt' | 'sequenceType' | 'customerId' | 'allowedMethods' | 'applicationFee'
-  > & {
-    testmode?: boolean;
-  } & IdempotencyParameter;
+  > &
+  ContextParameters &
+  IdempotencyParameter;
 
-export interface GetParameters {
-  testmode?: boolean;
-}
+export type GetParameters = ContextParameters;
 
-export type PageParameters = PaginationParameters & {
+export type PageParameters = ContextParameters & PaginationParameters & {
   profileId?: string;
-  testmode?: boolean;
 };
 
 export type UpdateParameters = Pick<PaymentLinkData, 'description' | 'minimumAmount' | 'archived' | 'allowedMethods' | 'applicationFee'> &
-  PickOptional<PaymentLinkData, 'profileId'> & {
-  testmode?: boolean;
-};
+  PickOptional<PaymentLinkData, 'profileId'> &
+  ContextParameters;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/payments/captures/parameters.ts
+++ b/src/binders/payments/captures/parameters.ts
@@ -1,6 +1,6 @@
 import { type CaptureData, type CaptureInclude } from '../../../data/payments/captures/data';
 import type MaybeArray from '../../../types/MaybeArray';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
 
 interface ContextParameters {
@@ -9,15 +9,15 @@ interface ContextParameters {
 
 export type CreateParameters = ContextParameters & PickOptional<CaptureData, 'amount' | 'description' | 'metadata'> & IdempotencyParameter;
 
-export type GetParameters = ContextParameters & {
-  include?: MaybeArray<CaptureInclude>;
-  testmode?: boolean;
-};
+export type GetParameters = ContextParameters &
+  TestModeParameter & {
+    include?: MaybeArray<CaptureInclude>;
+  };
 
 export type PageParameters = ContextParameters &
-  PaginationParameters & {
+  PaginationParameters &
+  TestModeParameter & {
     include?: MaybeArray<CaptureInclude>;
-    testmode?: boolean;
   };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/payments/orders/parameters.ts
+++ b/src/binders/payments/orders/parameters.ts
@@ -1,11 +1,10 @@
 import { type PaymentMethod } from '../../../data/global';
 import { type PaymentData } from '../../../data/payments/data';
 import type MaybeArray from '../../../types/MaybeArray';
-import { type IdempotencyParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type TestModeParameter } from '../../../types/parameters';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   orderId: string;
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters &

--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -1,7 +1,7 @@
 import { type Amount, type PaymentMethod } from '../../data/global';
 import { type PaymentData, type PaymentEmbed, type PaymentInclude } from '../../data/payments/data';
 import type MaybeArray from '../../types/MaybeArray';
-import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
 export type CreateParameters = Pick<
@@ -20,7 +20,9 @@ export type CreateParameters = Pick<
   | 'issuer'
   | 'restrictPaymentMethodsToCountry'
 > &
-  PickOptional<PaymentData, 'locale' | 'metadata' | 'sequenceType' | 'captureMode' | 'captureDelay'> & {
+  PickOptional<PaymentData, 'locale' | 'metadata' | 'sequenceType' | 'captureMode' | 'captureDelay'> &
+  TestModeParameter &
+  IdempotencyParameter & {
     /**
      * Normally, a payment method screen is shown. However, when using this parameter, you can choose a specific payment method and your customer will skip the selection screen and is sent directly to
      * the chosen payment method. The parameter enables you to fully integrate the payment method selection into your website.
@@ -178,7 +180,6 @@ export type CreateParameters = Pick<
      */
     include?: MaybeArray<PaymentInclude.qrCode>; // currently only one valid value, but making 'MaybeArray' for consistency
     profileId?: string;
-    testmode?: boolean;
     /**
      * Adding an application fee allows you to charge the merchant a small sum for the payment and transfer this to your own account.
      *
@@ -203,17 +204,14 @@ export type CreateParameters = Pick<
        */
       description: string;
     };
-  } & IdempotencyParameter;
+  };
 
-export interface GetParameters {
+export interface GetParameters extends TestModeParameter {
   include?: MaybeArray<PaymentInclude>;
   embed?: MaybeArray<PaymentEmbed>;
-  testmode?: boolean;
 }
 
-export type PageParameters = PaginationParameters & SortParameter & {
-  testmode?: boolean;
-};
+export type PageParameters = PaginationParameters & SortParameter & TestModeParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
@@ -234,10 +232,6 @@ export type UpdateParameters = Pick<PaymentData, 'redirectUrl' | 'cancelUrl' | '
     restrictPaymentMethodsToCountry?: string;
   };
 
-export interface CancelParameters extends IdempotencyParameter {
-  testmode?: boolean;
-}
+export type CancelParameters = TestModeParameter & IdempotencyParameter;
 
-export interface ReleaseParameters {
-  testmode?: boolean;
-}
+export type ReleaseParameters = TestModeParameter;

--- a/src/binders/payments/refunds/parameters.ts
+++ b/src/binders/payments/refunds/parameters.ts
@@ -1,10 +1,9 @@
 import { type RefundData, type RefundEmbed } from '../../../data/refunds/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   paymentId: string;
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters & Pick<RefundData, 'amount'> & PickOptional<RefundData, 'description' | 'metadata'> & IdempotencyParameter;

--- a/src/binders/payments/routes/parameters.ts
+++ b/src/binders/payments/routes/parameters.ts
@@ -1,19 +1,13 @@
 import { type RouteData } from '../../../data/payments/routes/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   /**
    * The ID of the payment to create a route for.
    *
    * @see https://docs.mollie.com/reference/payment-create-route
    */
   paymentId: string;
-  /**
-   * Set this to `true` to create a test mode route.
-   *
-   * @see https://docs.mollie.com/reference/payment-create-route?path=testmode#body-params
-   */
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters & Pick<RouteData, 'amount' | 'description' | 'destination'> & IdempotencyParameter;

--- a/src/binders/refunds/orders/parameters.ts
+++ b/src/binders/refunds/orders/parameters.ts
@@ -1,10 +1,9 @@
 import { type Amount } from '../../../data/global';
 import { type RefundData } from '../../../data/refunds/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 
-interface ContextParameters {
+interface ContextParameters extends TestModeParameter {
   orderId: string;
-  testmode?: boolean;
 }
 
 export type CreateParameters = ContextParameters &

--- a/src/binders/refunds/parameters.ts
+++ b/src/binders/refunds/parameters.ts
@@ -1,8 +1,7 @@
-import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & SortParameter & {
+export type PageParameters = PaginationParameters & SortParameter & TestModeParameter & {
   profileId?: string;
-  testmode?: boolean;
 };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/subscriptions/parameters.ts
+++ b/src/binders/subscriptions/parameters.ts
@@ -1,8 +1,7 @@
-import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & SortParameter & {
+export type PageParameters = PaginationParameters & SortParameter & TestModeParameter & {
   profileId?: string;
-  testmode?: boolean;
 };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/subscriptions/payments/parameters.ts
+++ b/src/binders/subscriptions/payments/parameters.ts
@@ -1,7 +1,6 @@
-import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
+import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 
-interface ContextParameters {
-  testmode?: boolean;
+interface ContextParameters extends TestModeParameter {
   customerId: string;
   subscriptionId: string;
 }

--- a/src/binders/terminals/parameters.ts
+++ b/src/binders/terminals/parameters.ts
@@ -1,7 +1,5 @@
-import { PaginationParameters, SortParameter, ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & SortParameter & {
-  testmode?: boolean;
-};
+export type PageParameters = PaginationParameters & SortParameter & TestModeParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -6,7 +6,7 @@ export interface PaginationParameters {
    */
   from?: string;
   /**
-   * The number of resources to return per page. Defaults to 250.
+   * The number of resources to return per page. Defaults to 50. Maximum 250.
    *
    * @see https://docs.mollie.com/reference/pagination
    */
@@ -22,6 +22,14 @@ export interface SortParameter {
    * @see https://docs.mollie.com/reference/pagination
    */
   sort?: 'asc' | 'desc';
+}
+
+export interface TestModeParameter {
+  /**
+   * Most API credentials are specifically created for either live mode or test mode, in which case this parameter does not need to be set.
+   * For organization-level credentials such as OAuth access tokens, set this to `true` to use test mode.
+   */
+  testmode?: boolean;
 }
 
 export interface ThrottlingParameter {


### PR DESCRIPTION
## Summary
- Adds `TestModeParameter` interface to `src/types/parameters.ts`, mirroring the existing `SortParameter` approach
- Replaces all inline `testmode?: boolean` definitions across 19 binder parameter files with extends/intersections of the shared type
- Empty interfaces that only contained `testmode` were converted to intersected type aliases