### PR TITLE
fix(tests): refund remaining balance in orders integration test

### DIFF
--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -99,19 +99,21 @@ describe('orders', () => {
       return;
     }
 
-    // `isRefundable()` only signals that `amountRemaining` is present, not that a given amount fits within it.
-    // Refund the actual remaining balance so the request never exceeds what the payment can absorb.
-    const { amountRemaining } = payment;
-    if (amountRemaining == undefined || Number.parseFloat(amountRemaining.value) <= 0) {
-      console.log('This payment has no remaining refundable amount, you cannot test the full flow.');
-      return;
-    }
-
     const paymentRefunds = await mollieClient.paymentRefunds.page({ paymentId: payment.id });
 
     let refundExists;
 
-    if (!paymentRefunds.length) {
+    if (paymentRefunds.length) {
+      refundExists = Promise.resolve(paymentRefunds[0]);
+    } else {
+      // No refund yet — create one. `isRefundable()` only signals that `amountRemaining` is present, not that a
+      // given amount fits within it, so refund the actual remaining balance (a fixed amount could exceed it).
+      const { amountRemaining } = payment;
+      if (amountRemaining == undefined || Number.parseFloat(amountRemaining.value) <= 0) {
+        console.log('This payment has no remaining refundable amount and no existing refund, you cannot test the full flow.');
+        return;
+      }
+
       refundExists = mollieClient.paymentRefunds
         .create({
           paymentId: payment.id,
@@ -123,8 +125,6 @@ describe('orders', () => {
           return refund;
         })
         .catch(fail);
-    } else {
-      refundExists = Promise.resolve(paymentRefunds[0]);
     }
 
     const paymentRefund = await refundExists;

--- a/tests/integration/orders.test.ts
+++ b/tests/integration/orders.test.ts
@@ -99,8 +99,11 @@ describe('orders', () => {
       return;
     }
 
-    if (!payment.isRefundable()) {
-      console.log('This payment is not refundable, you cannot test the full flow.');
+    // `isRefundable()` only signals that `amountRemaining` is present, not that a given amount fits within it.
+    // Refund the actual remaining balance so the request never exceeds what the payment can absorb.
+    const { amountRemaining } = payment;
+    if (amountRemaining == undefined || Number.parseFloat(amountRemaining.value) <= 0) {
+      console.log('This payment has no remaining refundable amount, you cannot test the full flow.');
       return;
     }
 
@@ -112,7 +115,7 @@ describe('orders', () => {
       refundExists = mollieClient.paymentRefunds
         .create({
           paymentId: payment.id,
-          amount: { value: '5.00', currency: payment.amount.currency },
+          amount: amountRemaining,
         })
         .then(refund => {
           expect(refund).toBeDefined();


### PR DESCRIPTION
## Problem

`tests/integration/orders.test.ts › orders › should integrate` fails against the live API with `ApiError: The specified amount cannot be refunded`, breaking CI on otherwise-unrelated PRs (e.g. #480).

The test hard-codes a **€5.00** refund, guarded only by `payment.isRefundable()`. That helper just checks `amountRemaining != undefined` — it does **not** verify the requested amount fits within the remaining refundable balance. Once a payment's remaining balance drops below €5.00, the refund is rejected and the suite fails. The failure is purely account-state dependent and has nothing to do with the code under test.

## Fix

When a refund has to be created, refund the payment's actual `amountRemaining` instead of a magic number, so the request can never exceed what the payment can absorb. The balance check gates refund **creation** only — if a refund already exists it is reused, so the retrieval path is still exercised on fully-refunded payments. The full flow is skipped only when there is nothing left to refund **and** no existing refund.

Verified locally against the test account — `should integrate` now passes.