### PR TITLE
fix(captures): embed the payment via the `embed` query parameter

### DIFF
--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -4,6 +4,7 @@ import type Capture from '../../../data/payments/captures/Capture';
 import { type CaptureData } from '../../../data/payments/captures/data';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
+import foldParameters from '../../../plumbing/foldParameters';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
@@ -22,6 +23,10 @@ export default class PaymentCapturesBinder extends Binder<CaptureData, Capture> 
   /**
    * Capture an *authorized* payment.
    *
+   * Some payment methods allow you to first collect a customer's authorization, and capture the amount at a later point.
+   *
+   * By default, Mollie captures payments automatically. If however you configured your payment with `captureMode: manual`, you can capture the payment using this endpoint after having collected the customer's authorization.
+   *
    * @since 4.1.0
    * @see https://docs.mollie.com/reference/create-capture
    */
@@ -35,50 +40,48 @@ export default class PaymentCapturesBinder extends Binder<CaptureData, Capture> 
   }
 
   /**
-   * Retrieve a single capture by its ID. Note the original payment's ID is needed as well.
-   *
-   * Captures are used for payments that have the *authorize-then-capture* flow. Mollie currently supports captures for **Cards** and **Klarna**.
+   * Retrieve a single payment capture by its ID and the ID of its parent payment.
    *
    * @since 1.1.1
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture
+   * @see https://docs.mollie.com/reference/get-capture
    */
   public get(id: string, parameters: GetParameters): Promise<Capture>;
   public get(id: string, parameters: GetParameters, callback: Callback<Capture>): void;
   public get(id: string, parameters: GetParameters) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'capture');
-    const { paymentId, ...query } = parameters;
+    const { paymentId, ...query } = foldParameters(parameters, { embed: ['include'] });
     assertWellFormedId(paymentId, 'payment');
     return this.networkClient.get<CaptureData, Capture>(`${getPathSegments(paymentId)}/${id}`, query);
   }
 
   /**
-   * Retrieve all captures for a certain payment.
+   * Retrieve a list of all captures created for a specific payment.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. Mollie currently supports captures for **Cards** and **Klarna**.
+   * The results are paginated.
    *
    * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
+   * @see https://docs.mollie.com/reference/list-captures
    */
   public page(parameters: PageParameters): Promise<Page<Capture>>;
   public page(parameters: PageParameters, callback: Callback<Page<Capture>>): void;
   public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
-    const { paymentId, ...query } = parameters;
+    const { paymentId, ...query } = foldParameters(parameters, { embed: ['include'] });
     assertWellFormedId(paymentId, 'payment');
     return this.networkClient.page<CaptureData, Capture>(getPathSegments(paymentId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**
-   * Retrieve all captures for a certain payment.
+   * Retrieve a list of all captures created for a specific payment.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. Mollie currently supports captures for **Cards** and **Klarna**.
+   * The results are paginated.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/captures-api/list-captures
+   * @see https://docs.mollie.com/reference/list-captures
    */
   public iterate(parameters: IterateParameters) {
-    const { paymentId, valuesPerMinute, ...query } = parameters;
+    const { paymentId, valuesPerMinute, ...query } = foldParameters(parameters, { embed: ['include'] });
     assertWellFormedId(paymentId, 'payment');
     return this.networkClient.iterate<CaptureData, Capture>(getPathSegments(paymentId), 'captures', query, valuesPerMinute);
   }

--- a/src/binders/payments/captures/parameters.ts
+++ b/src/binders/payments/captures/parameters.ts
@@ -1,4 +1,4 @@
-import { type CaptureData, type CaptureInclude } from '../../../data/payments/captures/data';
+import { type CaptureData, type CaptureEmbed, type CaptureInclude } from '../../../data/payments/captures/data';
 import type MaybeArray from '../../../types/MaybeArray';
 import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 import type PickOptional from '../../../types/PickOptional';
@@ -11,12 +11,34 @@ export type CreateParameters = ContextParameters & PickOptional<CaptureData, 'am
 
 export type GetParameters = ContextParameters &
   TestModeParameter & {
+    /**
+     * Using the `embed` query parameter, you can request related resources to be embedded in the response.
+     * * `payment`: Embed the payment this capture was created for.
+     *
+     * __Note:__ In the REST API, this is not part of the request body, but a query parameter. It is included here for consistency.
+     */
+    embed?: MaybeArray<CaptureEmbed>;
+    /**
+     * @deprecated Use `embed` instead. The Captures API embeds related resources via the `embed` query parameter,
+     * not `include` — passing `include` had no effect.
+     */
     include?: MaybeArray<CaptureInclude>;
   };
 
 export type PageParameters = ContextParameters &
   PaginationParameters &
   TestModeParameter & {
+    /**
+     * Using the `embed` query parameter, you can request related resources to be embedded in the response.
+     * * `payment`: Embed the payment this capture was created for.
+     *
+     * __Note:__ In the REST API, this is not part of the request body, but a query parameter. It is included here for consistency.
+     */
+    embed?: MaybeArray<CaptureEmbed>;
+    /**
+     * @deprecated Use `embed` instead. The Captures API embeds related resources via the `embed` query parameter,
+     * not `include` — passing `include` had no effect.
+     */
     include?: MaybeArray<CaptureInclude>;
   };
 

--- a/src/binders/settlements/captures/SettlementCapturesBinder.ts
+++ b/src/binders/settlements/captures/SettlementCapturesBinder.ts
@@ -2,6 +2,7 @@ import type TransformingNetworkClient from '../../../communication/TransformingN
 import type Page from '../../../data/page/Page';
 import type Capture from '../../../data/payments/captures/Capture';
 import { type CaptureData } from '../../../data/payments/captures/data';
+import foldParameters from '../../../plumbing/foldParameters';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
@@ -17,33 +18,31 @@ export default class SettlementCapturesBinder extends Binder<CaptureData, Captur
   }
 
   /**
-   * Retrieve all captures in a certain settlement.
+   * Retrieve all captures included in the given settlement.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
-   * it*. Captures are created when (part of) an Order is shipped. The capture is then settled to the merchant.
+   * The response is in the same format as the response of the [List captures endpoint](https://docs.mollie.com/reference/list-captures).
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
+   * @see https://docs.mollie.com/reference/list-settlement-captures
    */
   public page(parameters: PageParameters): Promise<Page<Capture>>;
   public page(parameters: PageParameters, callback: Callback<Page<Capture>>): void;
   public page(parameters: PageParameters) {
     if (renege(this, this.page, ...arguments)) return;
-    const { settlementId, ...query } = parameters;
+    const { settlementId, ...query } = foldParameters(parameters, { embed: ['include'] });
     return this.networkClient.page<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query).then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**
-   * Retrieve all captures in a certain settlement.
+   * Retrieve all captures included in the given settlement.
    *
-   * Captures are used for payments that have the *authorize-then-capture* flow. The only payment methods at the moment that have this flow are *Klarna Pay now*, *Klarna Pay later* and *Klarna Slice
-   * it*. Captures are created when (part of) an Order is shipped. The capture is then settled to the merchant.
+   * The response is in the same format as the response of the [List captures endpoint](https://docs.mollie.com/reference/list-captures).
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
+   * @see https://docs.mollie.com/reference/list-settlement-captures
    */
   public iterate(parameters: IterateParameters) {
-    const { settlementId, valuesPerMinute, ...query } = parameters;
+    const { settlementId, valuesPerMinute, ...query } = foldParameters(parameters, { embed: ['include'] });
     return this.networkClient.iterate<CaptureData, Capture>(getPathSegments(settlementId), 'captures', query, valuesPerMinute);
   }
 }

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -229,7 +229,7 @@ export { createMollieClient };
 
 export { ApiMode, Locale, PaymentMethod, HistoricPaymentMethod, SequenceType } from './data/global';
 export { BalanceTransferStatus, BalanceTransferStatusReasonCode, BalanceTransferCategory } from './data/balance-transfers/data';
-export { CaptureStatus, CaptureInclude } from './data/payments/captures/data';
+export { CaptureStatus, CaptureEmbed, CaptureInclude } from './data/payments/captures/data';
 export { MandateMethod, MandateStatus } from './data/customers/mandates/data';
 export { MethodImageSize, MethodInclude } from './data/methods/data';
 export { OrderEmbed, OrderStatus } from './data/orders/data';

--- a/src/data/payments/captures/data.ts
+++ b/src/data/payments/captures/data.ts
@@ -8,19 +8,19 @@ export interface CaptureData extends Model<'capture'> {
    *
    * Possible values: `live` `test`
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=mode#response
+   * @see https://docs.mollie.com/reference/get-capture?path=mode#response
    */
   mode: ApiMode;
   /**
    * The description of the capture.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=description#response
+   * @see https://docs.mollie.com/reference/get-capture?path=description#response
    */
   description: string;
   /**
    * The amount captured. If no amount is provided, the full authorized amount is captured.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=amount#response
+   * @see https://docs.mollie.com/reference/get-capture?path=amount#response
    */
   amount: Amount;
   /**
@@ -28,50 +28,50 @@ export interface CaptureData extends Model<'capture'> {
    *
    * Since the field contains an estimated amount during capture processing, it may change over time. To retrieve accurate settlement amounts we recommend using the List balance transactions endpoint instead.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=settlementAmount#response
+   * @see https://docs.mollie.com/reference/get-capture?path=settlementAmount#response
    */
   settlementAmount: Amount;
   /**
    * The capture's status.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=status#response
+   * @see https://docs.mollie.com/reference/get-capture?path=status#response
    */
   status: CaptureStatus;
   /**
    * Provide any data you like, for example a string or a JSON object. We will save the data alongside the entity. Whenever you fetch the entity with our API, we will also include the metadata.
    * You can use up to approximately 1kB.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=metadata#response
+   * @see https://docs.mollie.com/reference/get-capture?path=metadata#response
    */
   metadata: unknown;
   /**
    * The unique identifier of the payment this capture was created for, for example: `tr_7UhSN1zuXS`. The full payment object can be retrieved via the `payment` URL in the `_links` object.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=paymentId#response
+   * @see https://docs.mollie.com/reference/get-capture?path=paymentId#response
    */
   paymentId: string;
   /**
    * The unique identifier of the shipment that triggered the creation of this capture, if applicable. For example: `shp_3wmsgCJN4U`.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=shipmentId#response
+   * @see https://docs.mollie.com/reference/get-capture?path=shipmentId#response
    */
   shipmentId?: string;
   /**
    * The identifier referring to the settlement this capture was settled with. For example, `stl_BkEjN2eBb`. This field is omitted if the capture is not settled (yet).
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=settlementId#response
+   * @see https://docs.mollie.com/reference/get-capture?path=settlementId#response
    */
   settlementId?: string;
   /**
    * The capture's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=createdAt#response
+   * @see https://docs.mollie.com/reference/get-capture?path=createdAt#response
    */
   createdAt: string;
   /**
    * An object with several URL objects relevant to the capture. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links#response
+   * @see https://docs.mollie.com/reference/get-capture?path=_links#response
    */
   _links: CaptureLinks;
   _embedded?: {
@@ -85,6 +85,14 @@ export enum CaptureStatus {
   failed = 'failed',
 }
 
+export enum CaptureEmbed {
+  payment = 'payment',
+}
+
+/**
+ * @deprecated Use {@link CaptureEmbed} instead. The Captures API embeds related resources via the `embed` query
+ * parameter, not `include` — passing `include` had no effect.
+ */
 export enum CaptureInclude {
   payment = 'payment',
 }
@@ -93,19 +101,19 @@ interface CaptureLinks extends Links {
   /**
    * The API resource URL of the payment the capture belongs to.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links/payment#response
+   * @see https://docs.mollie.com/reference/get-capture?path=_links/payment#response
    */
   payment: Url;
   /**
    * The API resource URL of the shipment that triggered the capture to be created.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links/shipment#response
+   * @see https://docs.mollie.com/reference/get-capture?path=_links/shipment#response
    */
   shipment?: Url;
   /**
    * The API resource URL of the settlement this capture has been settled with. Not present if not yet settled.
    *
-   * @see https://docs.mollie.com/reference/v2/captures-api/get-capture?path=_links/settlement#response
+   * @see https://docs.mollie.com/reference/get-capture?path=_links/settlement#response
    */
   settlement?: Url;
 }

--- a/src/plumbing/foldParameters.ts
+++ b/src/plumbing/foldParameters.ts
@@ -1,0 +1,26 @@
+import type MaybeArray from '../types/MaybeArray';
+
+/** The union of every source key referenced in a `folds` map (unwrapping array values). */
+type SourceKeys<F> = { [K in keyof F]: F[K] extends ReadonlyArray<infer E> ? E : F[K] }[keyof F];
+
+/**
+ * Folds parameters into other parameters, removing the folded-away keys. `folds` maps each target parameter to the
+ * source parameter(s) whose value should fold into it: `{ to: ['from'] }` moves `from` onto `to`. A target that already
+ * holds a value wins and the source value is discarded. A source key is removed whenever it is present, even when its
+ * value is `undefined` — so `{ to: 1, from: undefined }` folds to `{ to: 1 }`, not `{ to: 1, from: undefined }`. Sources
+ * that are not present are ignored. Every name — target and source — must exist on the parameter type, so a mistyped
+ * name is a compile error rather than a silent no-op.
+ */
+export default function foldParameters<T extends Record<string, any>, F extends Partial<Record<keyof T, MaybeArray<keyof T>>>>(parameters: T, folds: F): Omit<T, SourceKeys<F> & keyof T> {
+  return Object.entries(folds).reduce<Record<string, any>>(
+    (result, [to, sources]) =>
+      (Array.isArray(sources) ? sources : [sources]).reduce((acc, from) => {
+        if (!(from in acc)) {
+          return acc;
+        }
+        const { [from]: value, ...rest } = acc;
+        return { ...rest, [to]: acc[to] ?? value };
+      }, result),
+    parameters,
+  ) as Omit<T, SourceKeys<F> & keyof T>;
+}

--- a/tests/unit/plumbing/foldParameters.test.ts
+++ b/tests/unit/plumbing/foldParameters.test.ts
@@ -1,0 +1,40 @@
+import foldParameters from '../../../src/plumbing/foldParameters';
+
+test('movesValueToTargetAndRemovesSource', () => {
+  const result = foldParameters({ include: 'payment', embed: undefined as string | undefined }, { embed: ['include'] });
+  expect(result).toStrictEqual({ embed: 'payment' });
+  expect('include' in result).toBe(false);
+});
+
+test('acceptsASingleSourceAsWellAsAnArray', () => {
+  const result = foldParameters({ include: 'payment', embed: undefined as string | undefined }, { embed: 'include' });
+  expect(result).toStrictEqual({ embed: 'payment' });
+});
+
+test('keepsExistingTargetValueOverSource', () => {
+  const result = foldParameters({ include: 'old', embed: 'new' as string | undefined }, { embed: ['include'] });
+  expect(result).toStrictEqual({ embed: 'new' });
+});
+
+test('removesSourceEvenWhenItsValueIsUndefined', () => {
+  // `toStrictEqual` (unlike `toEqual`) does not ignore undefined-valued keys, so this asserts the key is gone.
+  const result = foldParameters({ include: undefined as string | undefined, embed: 1 }, { embed: ['include'] });
+  expect(result).toStrictEqual({ embed: 1 });
+  expect('include' in result).toBe(false);
+});
+
+test('ignoresSourcesThatAreNotPresent', () => {
+  const result = foldParameters({ embed: 5 } as { include?: string; embed?: number }, { embed: ['include'] });
+  expect(result).toStrictEqual({ embed: 5 });
+});
+
+test('preservesUnrelatedParameters', () => {
+  const result = foldParameters({ include: 'payment', embed: undefined as string | undefined, testmode: true }, { embed: ['include'] });
+  expect(result).toStrictEqual({ embed: 'payment', testmode: true });
+});
+
+test('doesNotMutateTheInput', () => {
+  const input = { include: 'payment', embed: undefined as string | undefined };
+  foldParameters(input, { embed: ['include'] });
+  expect(input).toStrictEqual({ include: 'payment', embed: undefined });
+});

--- a/tests/unit/resources/payments/captures.test.ts
+++ b/tests/unit/resources/payments/captures.test.ts
@@ -1,4 +1,4 @@
-import { CaptureStatus } from '../../../..';
+import { CaptureEmbed, CaptureInclude, CaptureStatus } from '../../../..';
 import NetworkMocker, { getApiKeyClientProvider } from '../../../NetworkMocker';
 
 function composeCaptureResponse(paymentId = 'tr_WDqYK6vllg', captureId = 'cpt_4qqhO89gsT') {
@@ -153,6 +153,72 @@ test('listCaptures', () => {
     expect(captures.links.previous).toBeNull();
     expect(captures.links.next).toBeNull();
 
+    testCapture(captures[0]);
+  });
+});
+
+test('getCaptureEmbeddingPayment', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    // nock only replies on an exact path+query match, so this asserts the SDK sends `?embed=payment`.
+    networkMocker.intercept('GET', '/payments/tr_WDqYK6vllg/captures/cpt_4qqhO89gsT?embed=payment', 200, composeCaptureResponse()).twice();
+
+    const capture = await bluster(mollieClient.paymentCaptures.get.bind(mollieClient.paymentCaptures))('cpt_4qqhO89gsT', {
+      paymentId: 'tr_WDqYK6vllg',
+      embed: [CaptureEmbed.payment],
+    });
+
+    testCapture(capture);
+  });
+});
+
+test('getCaptureMappingDeprecatedIncludeOntoEmbed', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    // The deprecated `include` parameter must be sent as `embed`, not `include`.
+    networkMocker.intercept('GET', '/payments/tr_WDqYK6vllg/captures/cpt_4qqhO89gsT?embed=payment', 200, composeCaptureResponse()).twice();
+
+    const capture = await bluster(mollieClient.paymentCaptures.get.bind(mollieClient.paymentCaptures))('cpt_4qqhO89gsT', {
+      paymentId: 'tr_WDqYK6vllg',
+      include: [CaptureInclude.payment],
+    });
+
+    testCapture(capture);
+  });
+});
+
+test('listCapturesEmbeddingPayment', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker
+      .intercept('GET', '/payments/tr_WDqYK6vllg/captures?embed=payment', 200, {
+        _embedded: {
+          captures: [composeCaptureResponse('tr_WDqYK6vllg', 'cpt_4qqhO89gsT')],
+        },
+        count: 1,
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/list-captures',
+            type: 'text/html',
+          },
+          self: {
+            href: 'https://api.mollie.dev/v2/payments/tr_WDqYK6vllg/captures?embed=payment',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: null,
+        },
+      })
+      .twice();
+
+    const paymentCaptures = mollieClient.paymentCaptures;
+    // `all` and `list` are non-enumerable aliases holding the same function reference as `page`, so they carry the embed fix too.
+    expect((paymentCaptures as any).all).toBe(paymentCaptures.page);
+    expect((paymentCaptures as any).list).toBe(paymentCaptures.page);
+
+    const captures = await bluster(paymentCaptures.page.bind(paymentCaptures))({
+      paymentId: 'tr_WDqYK6vllg',
+      embed: [CaptureEmbed.payment],
+    });
+
+    expect(captures.length).toBe(1);
     testCapture(captures[0]);
   });
 });


### PR DESCRIPTION
## What

Captures could never embed the related payment. The Captures API embeds it through the `embed` query parameter, but the SDK sent `include`, which Mollie silently ignores — so `_embedded.payment` was never populated and `capture.getPayment()` always made a second request. The embed option was effectively dead.

## Fix (non-breaking)

- Add `embed` / `CaptureEmbed`.
- Keep `include` / `CaptureInclude` as `@deprecated` aliases that now resolve onto `embed`, so existing code keeps compiling **and** starts embedding correctly.
- Applies to payment captures (`get` / `list` / `iterate`) and settlement captures (`list` / `iterate`).

The deprecated→canonical mapping goes through a new generic `foldParameters` plumbing helper: target and source keys are both constrained to `keyof T` (a mistyped name is a compile error, not a silent no-op), the return type is a precise `Omit<T, source>`, and the key is left off the wire entirely when absent.

## Docs synced to spec

- Field and endpoint (binder-method) JSDoc refreshed against the current OpenAPI spec; dropped stale "supported methods" / legacy Orders-shipment-flow claims.
- `@see` URLs moved to the `/reference/...` format.

## Tests / verification

- Regression tests assert `?embed=payment` is actually sent — for both `embed` and the deprecated `include`, on `get` and `list` (including that the `all` / `list` aliases share the patched method).
- Unit tests for `foldParameters` (incl. the `{ to, from: undefined } -> { to }` edge).
- Full unit suite green; bundle loads and tests pass on Node 14.

## Notes / follow-ups

- `embed=payment` is taken from the spec; I couldn't reach the live API — worth a quick confirmation before release that `?embed=payment` populates `_embedded.payment`.
- `settlementAmount`: the spec omits it on the standalone capture response (it appears only on settlement-embedded captures). Left as-is (required) — flagged, not changed, since removing/narrowing it would be breaking and it is likely present in real responses.
