### PR TITLE
set up github actions as trusted publisher on npmjs.com

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,26 +1,66 @@
-name: Publish Package
+# Publishes @mollie/api-client to npm when a GitHub Release is published.
+#
+# Authentication uses npm Trusted Publishing (OIDC) — there is NO npm token.
+# npm validates the workflow's OIDC claim against the Trusted Publisher
+# configured on the package (org `mollie`, repo `mollie-api-node`, and this
+# workflow's filename). Provenance attestations are generated on every publish.
+#
+# Cutting a release: bump the version (`npm version <major|minor|patch>`), push
+# the commit and its tag, then publish a GitHub Release for that tag — that is
+# what triggers this workflow. Who may publish a release is governed by the
+# repository's tag/release ruleset.
+name: Publish to npm
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
-  id-token: write
   contents: read
+  id-token: write # required for npm Trusted Publishing (OIDC)
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
+      - name: Checkout the released tag
+        uses: actions/checkout@v6
         with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-          package-manager-cache: false
-      - run: npm ci
-      - run: npm run build --if-present
-      - run: npm test
-      - run: npm publish
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node.js
+        # Node 24 bundles npm >= 11.5.1, which npm Trusted Publishing requires.
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # never cache in release builds
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Verify tag matches package.json and resolve dist-tag
+        id: release
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Release tag '$TAG' (version '$TAG_VERSION') does not match package.json version '$PKG_VERSION'."
+            exit 1
+          fi
+          # Stable -> 'latest'. Prereleases (e.g. 4.4.0-rc.1) go to their own
+          # channel (rc/beta/…) so they never become the default install.
+          DIST_TAG="$(node -p "const v=require('./package.json').version; v.includes('-') ? (v.match(/-([a-zA-Z]+)/)?.[1] ?? 'next') : 'latest'")"
+          echo "dist-tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Publishing $PKG_VERSION to dist-tag '$DIST_TAG'."
+
+      - name: Build
+        run: yarn build
+
+      - name: Run unit tests
+        run: yarn test:unit
+
+      - name: Publish to npm
+        run: npm publish --provenance --tag "${{ steps.release.outputs.dist-tag }}"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
+    "test:unit": "jest ./tests/unit",
     "test:unit:cov": "jest ./tests/unit --coverage",
     "build": "yarn build:library && yarn build:declarations",
     "build:library": "rollup --config rollup.config.js",


### PR DESCRIPTION
When a new version is tagged, build and publish to npm without needing tokens. @janpaepke not sure if the testing step is necessary here, happy to hear your input