### PR TITLE
chore: deprecate Orders API binders and methods

### DIFF
--- a/src/binders/orders/OrdersBinder.ts
+++ b/src/binders/orders/OrdersBinder.ts
@@ -32,6 +32,7 @@ export const pathSegment = 'orders';
  * -   Eco vouchers, gift vouchers, and meal vouchers
  *
  * @see https://docs.mollie.com/orders/overview#orders-api
+ * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
  */
 export default class OrdersBinder extends Binder<OrderData, Order> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
@@ -52,6 +53,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public create(parameters: CreateParameters): Promise<Order>;
   public create(parameters: CreateParameters, callback: Callback<Order>): void;
@@ -67,6 +69,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/get-order
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public get(id: string, parameters?: GetParameters): Promise<Order>;
   public get(id: string, parameters: GetParameters, callback: Callback<Order>): void;
@@ -83,6 +86,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public page(parameters?: PageParameters): Promise<Page<Order>>;
   public page(parameters: PageParameters, callback: Callback<Page<Order>>): void;
@@ -98,6 +102,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    *
    * @since 3.6.0
    * @see https://docs.mollie.com/reference/v2/orders-api/list-orders
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};
@@ -112,6 +117,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/update-order
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public update(id: string, parameters: UpdateParameters): Promise<Order>;
   public update(id: string, parameters: UpdateParameters, callback: Callback<Order>): void;
@@ -138,6 +144,7 @@ export default class OrdersBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public cancel(id: string, parameters?: CancelParameters): Promise<Order>;
   public cancel(id: string, parameters: CancelParameters, callback: Callback<Order>): void;

--- a/src/binders/orders/orderlines/OrderLinesBinder.ts
+++ b/src/binders/orders/orderlines/OrderLinesBinder.ts
@@ -12,6 +12,9 @@ function getPathSegments(orderId: string) {
   return `orders/${orderId}/lines`;
 }
 
+/**
+ * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
+ */
 export default class OrderLinesBinder extends Binder<OrderData, Order> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
@@ -33,6 +36,7 @@ export default class OrderLinesBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/update-order-line
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public update(id: string, parameters: UpdateParameters): Promise<Order>;
   public update(id: string, parameters: UpdateParameters, callback: Callback<Order>): void;
@@ -62,6 +66,7 @@ export default class OrderLinesBinder extends Binder<OrderData, Order> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public cancel(parameters: CancelParameters): Promise<true>;
   public cancel(parameters: CancelParameters, callback: Callback<true>): void;

--- a/src/binders/orders/shipments/OrderShipmentsBinder.ts
+++ b/src/binders/orders/shipments/OrderShipmentsBinder.ts
@@ -12,6 +12,9 @@ export function getPathSegments(orderId: string) {
   return `orders/${orderId}/shipments`;
 }
 
+/**
+ * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
+ */
 export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
@@ -28,6 +31,7 @@ export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment>
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/shipments-api/create-shipment
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public create(parameters: CreateParameters): Promise<Shipment>;
   public create(parameters: CreateParameters, callback: Callback<Shipment>): void;
@@ -43,6 +47,7 @@ export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment>
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/shipments-api/get-shipment
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public get(id: string, parameters: GetParameters): Promise<Shipment>;
   public get(id: string, parameters: GetParameters, callback: Callback<Shipment>): void;
@@ -59,6 +64,7 @@ export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment>
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/shipments-api/list-shipments
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public list(parameters: ListParameters): Promise<Shipment[]>;
   public list(parameters: ListParameters, callback: Callback<Shipment[]>): void;
@@ -74,6 +80,7 @@ export default class OrderShipmentsBinder extends Binder<ShipmentData, Shipment>
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/shipments-api/update-shipment
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public update(id: string, parameters: UpdateParameters): Promise<Shipment>;
   public update(id: string, parameters: UpdateParameters, callback: Callback<Shipment>): void;

--- a/src/binders/payments/orders/OrderPaymentsBinder.ts
+++ b/src/binders/payments/orders/OrderPaymentsBinder.ts
@@ -11,6 +11,9 @@ function getPathSegments(orderId: string) {
   return `orders/${orderId}/payments`;
 }
 
+/**
+ * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
+ */
 export default class OrderPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
@@ -26,6 +29,7 @@ export default class OrderPaymentsBinder extends Binder<PaymentData, Payment> {
    *
    * @since 3.1.0
    * @see https://docs.mollie.com/reference/v2/orders-api/create-order-payment
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public create(parameters: CreateParameters): Promise<Payment>;
   public create(parameters: CreateParameters, callback: Callback<Payment>): void;

--- a/src/binders/refunds/orders/OrderRefundsBinder.ts
+++ b/src/binders/refunds/orders/OrderRefundsBinder.ts
@@ -13,6 +13,9 @@ export function getPathSegments(orderId: string) {
   return `orders/${orderId}/refunds`;
 }
 
+/**
+ * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
+ */
 export default class OrderRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
@@ -30,6 +33,7 @@ export default class OrderRefundsBinder extends Binder<RefundData, Refund> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/create-order-refund
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public create(parameters: CreateParameters): Promise<Refund>;
   public create(parameters: CreateParameters, callback: Callback<Refund>): void;
@@ -47,6 +51,7 @@ export default class OrderRefundsBinder extends Binder<RefundData, Refund> {
    *
    * @since 3.0.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public page(parameters: PageParameters): Promise<Page<Refund>>;
   public page(parameters: PageParameters, callback: Callback<Page<Refund>>): void;
@@ -64,6 +69,7 @@ export default class OrderRefundsBinder extends Binder<RefundData, Refund> {
    *
    * @since 3.6.0
    * @see https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
+   * @deprecated We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.
    */
   public iterate(parameters: IterateParameters) {
     const { orderId, valuesPerMinute, ...query } = parameters;


### PR DESCRIPTION
## Why

Mollie has [deprecated the entire Orders API](https://docs.mollie.com/reference/orders-api) in favour of the Payments API. The SDK should surface this to consumers so they migrate.

## What

Adds an `@deprecated` JSDoc note to every Orders binder — **class level and all public methods** — so editors/TypeScript flag a deprecation hint at each call site, pointing to the Payments API and the migration guide:

> We no longer recommend using the Orders API. Please refer to the [Payments API](https://docs.mollie.com/reference/payments-api) instead. Already using the Orders API? See the [migrating from Orders to Payments guide](https://docs.mollie.com/docs/migrating-from-orders-to-payments) for more information.

Covered binders (21 annotations total):

| Binder | Methods |
|---|---|
| `OrdersBinder` | `create`, `get`, `page`, `iterate`, `update`, `cancel` |
| `OrderLinesBinder` | `update`, `cancel` |
| `OrderShipmentsBinder` | `create`, `get`, `list`, `update` |
| `OrderPaymentsBinder` | `create` |
| `OrderRefundsBinder` | `create`, `page`, `iterate` |

## Scope notes

- **Comment-only change** — no runtime/type behaviour changes; Prettier passes.
- `OrderHelper` (the methods sealed onto `Order` response objects, e.g. `order.getPayments()`, `order.isPaid()`) and the data-type interfaces are **intentionally left untouched** — the deprecation lives on the binder surface consumers call.
- `OrderShipmentsBinder` is included as part of the Orders flow (shipments only exist for orders).

## Reference

- https://docs.mollie.com/reference/orders-api