### PR TITLE
feat(chargebacks): sync types with API spec

### DIFF
--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -22,7 +22,7 @@ export default class ChargebacksBinder extends Binder<ChargebackData, Chargeback
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+   * @see https://docs.mollie.com/reference/list-all-chargebacks
    */
   public page(parameters?: PageParameters): Promise<Page<Chargeback>>;
   public page(parameters: PageParameters, callback: Callback<Page<Chargeback>>): void;
@@ -37,7 +37,7 @@ export default class ChargebacksBinder extends Binder<ChargebackData, Chargeback
    * The results are paginated. See pagination for more information.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+   * @see https://docs.mollie.com/reference/list-all-chargebacks
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};

--- a/src/binders/chargebacks/parameters.ts
+++ b/src/binders/chargebacks/parameters.ts
@@ -1,9 +1,11 @@
 import { type ChargebackEmbed } from '../../data/chargebacks/Chargeback';
-import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & SortParameter & {
-  profileId?: string;
-  embed?: ChargebackEmbed[];
-};
+export type PageParameters = PaginationParameters &
+  SortParameter &
+  TestModeParameter & {
+    profileId?: string;
+    embed?: ChargebackEmbed[];
+  };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -25,7 +25,7 @@ export default class PaymentChargebacksBinder extends Binder<ChargebackData, Cha
    * If you do not know the original payment's ID, you can use the chargebacks list endpoint.
    *
    * @since 1.1.1
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback
+   * @see https://docs.mollie.com/reference/get-chargeback
    */
   public get(id: string, parameters: GetParameters): Promise<Chargeback>;
   public get(id: string, parameters: GetParameters, callback: Callback<Chargeback>): void;
@@ -38,12 +38,12 @@ export default class PaymentChargebacksBinder extends Binder<ChargebackData, Cha
   }
 
   /**
-   * Retrieve all chargebacks filed for your payments.
+   * Retrieve the chargebacks initiated for a specific payment.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+   * @see https://docs.mollie.com/reference/list-payment-chargebacks
    */
   public page(parameters: PageParameters): Promise<Page<Chargeback>>;
   public page(parameters: PageParameters, callback: Callback<Page<Chargeback>>): void;
@@ -55,12 +55,12 @@ export default class PaymentChargebacksBinder extends Binder<ChargebackData, Cha
   }
 
   /**
-   * Retrieve all chargebacks filed for your payments.
+   * Retrieve the chargebacks initiated for a specific payment.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+   * @see https://docs.mollie.com/reference/list-payment-chargebacks
    */
   public iterate(parameters: IterateParameters) {
     const { paymentId, valuesPerMinute, ...query } = parameters;

--- a/src/binders/payments/chargebacks/parameters.ts
+++ b/src/binders/payments/chargebacks/parameters.ts
@@ -1,9 +1,9 @@
 import { type ChargebackEmbed } from '../../../data/chargebacks/Chargeback';
-import { type PaginationParameters, type ThrottlingParameter } from '../../../types/parameters';
+import { type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../../types/parameters';
 
-interface ContextParameters {
+type ContextParameters = TestModeParameter & {
   paymentId: string;
-}
+};
 
 export type GetParameters = ContextParameters & {
   embed?: ChargebackEmbed[];

--- a/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
+++ b/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
@@ -20,7 +20,7 @@ export default class SettlementChargebacksBinder extends Binder<ChargebackData, 
    * Retrieve all chargebacks included in a settlement.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
+   * @see https://docs.mollie.com/reference/list-settlement-chargebacks
    */
   public page(parameters: PageParameters): Promise<Page<Chargeback>>;
   public page(parameters: PageParameters, callback: Callback<Page<Chargeback>>): void;
@@ -34,7 +34,7 @@ export default class SettlementChargebacksBinder extends Binder<ChargebackData, 
    * Retrieve all chargebacks included in a settlement.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
+   * @see https://docs.mollie.com/reference/list-settlement-chargebacks
    */
   public iterate(parameters: IterateParameters) {
     const { settlementId, valuesPerMinute, ...query } = parameters;

--- a/src/data/chargebacks/Chargeback.ts
+++ b/src/data/chargebacks/Chargeback.ts
@@ -12,7 +12,7 @@ export interface ChargebackData extends Model<'chargeback'> {
   /**
    * The amount charged back by the consumer.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=amount#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=amount#response
    */
   amount: Amount;
   /**
@@ -22,53 +22,59 @@ export interface ChargebackData extends Model<'chargeback'> {
    *
    * Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal chargebacks.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=settlementAmount#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=settlementAmount#response
    */
   settlementAmount: Amount;
   /**
    * The date and time the chargeback was issued, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=createdAt#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=createdAt#response
    */
   createdAt: string;
   /**
-   * Reason for the chargeback as given by the bank.
+   * Reason for the chargeback as given by the bank. Only available for chargebacks of SEPA Direct Debit payments.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=reason#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=reason#response
    */
   reason: {
     /**
      * Bank code of the chargeback reason.
      *
-     * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=reason/code#response
+     * @see https://docs.mollie.com/reference/get-chargeback?path=reason/code#response
      */
     code: string;
     /**
      * Detailed description of the reason.
      *
-     * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=reason/description#response
+     * @see https://docs.mollie.com/reference/get-chargeback?path=reason/description#response
      */
     description: string;
   };
   /**
    * The date and time the chargeback was reversed if applicable, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=reversedAt#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=reversedAt#response
    */
   reversedAt: string;
   /**
    * The unique identifier of the payment this chargeback was issued for. For example: `tr_7UhSN1zuXS`. The full payment object can be retrieved via the `payment` URL in the `_links` object.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=paymentId#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=paymentId#response
    */
   paymentId: string;
+  /**
+   * The identifier referring to the settlement this chargeback was settled with. For example: `stl_BkEjN2eBb`. This field is omitted if the chargeback is not settled (yet).
+   *
+   * @see https://docs.mollie.com/reference/get-chargeback?path=settlementId#response
+   */
+  settlementId?: string;
   _embedded?: {
     payment?: Omit<PaymentData, '_embedded'>;
   };
   /**
    * An object with several URL objects relevant to the chargeback. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=_links#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=_links#response
    */
   _links: ChargebackLinks;
 }
@@ -88,13 +94,13 @@ export interface ChargebackLinks extends Links {
   /**
    * The API resource URL of the payment this chargeback belongs to.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=_links/payment#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=_links/payment#response
    */
   payment: Url;
   /**
    * The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
    *
-   * @see https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback?path=_links/settlement#response
+   * @see https://docs.mollie.com/reference/get-chargeback?path=_links/settlement#response
    */
   settlement?: Url;
 }

--- a/src/data/chargebacks/Chargeback.ts
+++ b/src/data/chargebacks/Chargeback.ts
@@ -98,7 +98,7 @@ export interface ChargebackLinks extends Links {
    */
   payment: Url;
   /**
-   * The API resource URL of the settlement this payment has been settled with. Not present if not yet settled.
+   * The API resource URL of the settlement this chargeback has been settled with. Not present if not yet settled.
    *
    * @see https://docs.mollie.com/reference/get-chargeback?path=_links/settlement#response
    */


### PR DESCRIPTION
## What

Syncs the **chargebacks** resource against the current Mollie OpenAPI spec.

### Types
- **`ChargebackData.settlementId`** — added (optional `string`). Returned on every chargeback response variant but previously unmodelled; omitted until the chargeback is settled.
- **`testmode`** — now accepted on all chargeback get/list parameters via the shared `TestModeParameter`, matching the rest of the SDK.

### Docs
- **`@see` links repointed.** The old `get-payment-chargeback` and `list-chargebacks` slugs now **404**. Corrected to the live slugs and migrated to the slug-only `/reference/...` format:
  - Get chargeback → https://docs.mollie.com/reference/get-chargeback
  - List payment chargebacks → https://docs.mollie.com/reference/list-payment-chargebacks
  - List all chargebacks → https://docs.mollie.com/reference/list-all-chargebacks
  - List settlement chargebacks → https://docs.mollie.com/reference/list-settlement-chargebacks
- Restored the "SEPA Direct Debit only" note on `reason`; fixed the per-payment list JSDoc that described the list-all behaviour.

### Style
- `ContextParameters` expressed as a `type` alias for local consistency.

## Deliberately deferred (breaking — not in this PR)
- **`settlementAmount` required → optional.** The spec omits it from get/list/list-all responses and types it nullable on settlement-chargebacks, and the field's own JSDoc already calls it "optional". Flipping it would break consumers doing `chargeback.settlementAmount.value`, so it stays required pending a decision.
- **`mode`** not added — the spec only evidences it on the settlement-chargebacks variant.

## Verification
- `yarn build:declarations` ✅
- `eslint` clean ✅
- `prettier` ✅
