### PR TITLE
feat: support non-Node.js runtimes (Bun, Deno, edge)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,34 @@ jobs:
           # then only be required to update those snapshots. The API key can then be removed from this file.
           API_KEY: ${{ secrets.TEST_API_KEY }}
 
-  # Bun and Deno run the Node-oriented Jest suite unmodified, guarding the SDK's runtime-agnostic support. Dependencies
-  # are installed with Node/yarn (which also builds the bundle via the `prepare` hook); only the test runtime differs.
-  # Floor versions are pinned so the lowest supported runtime is exercised, not only the latest.
-  test-bun:
+  # Build the publishable package once on Node (same version as publish.yml), then check on Bun and Deno that the
+  # resulting tarball installs by package name (so module resolution is exercised) and works: tests/compat/check.mjs
+  # constructs a client and round-trips a request. This guards runtime-agnostic support without running the
+  # Node-oriented Jest suite under Bun/Deno — jest is incompatible with Bun, and the suite's default-import of the
+  # bundle trips Deno's CJS interop; neither reflects whether the SDK itself works on those runtimes. (Node itself is
+  # covered by the `test` job above, and the packaging is exercised by the Bun/Deno checks here.)
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24' # match publish.yml: build the artifact with the same Node that publishes it
+          cache: yarn
+      - name: Install dependencies
+        run: yarn --frozen-lockfile # builds the bundle via the prepare hook
+      - name: Pack the package
+        run: mkdir -p artifact && npm pack --ignore-scripts --pack-destination ./artifact
+      - name: Upload package tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-tarball
+          path: artifact/*.tgz
+
+  compat-bun:
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -46,44 +70,49 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20.x
-          cache: yarn
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
       - name: Use Bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ matrix.bun-version }}
-      - name: Run test suite on Bun
-        # Explicit local jest path (not `bun x jest`, which can fetch a mismatched jest@latest when .bin/jest is absent).
-        run: bun node_modules/jest/bin/jest.js
-        env:
-          API_KEY: ${{ secrets.TEST_API_KEY }}
+      - name: Download package tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: package-tarball
+          path: artifact
+      - name: Compatibility check
+        # Run outside the repo checkout, so the runtime doesn't treat it as the @mollie/api-client package itself.
+        working-directory: ${{ runner.temp }}
+        run: |
+          cp "$GITHUB_WORKSPACE/tests/compat/check.mjs" .
+          echo '{"name":"compat-check","private":true}' > package.json
+          bun add "$GITHUB_WORKSPACE"/artifact/*.tgz
+          bun check.mjs
 
-  test-deno:
+  compat-deno:
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [v2.0.0, v2.x]
+        deno-version: [v2.0.0, latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Use Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20.x
-          cache: yarn
-      - name: Install dependencies
-        run: yarn --frozen-lockfile
       - name: Use Deno ${{ matrix.deno-version }}
         uses: denoland/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno-version }}
-      - name: Run test suite on Deno
-        run: deno run -A --node-modules-dir=auto ./node_modules/jest/bin/jest.js
-        env:
-          API_KEY: ${{ secrets.TEST_API_KEY }}
+      - name: Download package tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: package-tarball
+          path: artifact
+      - name: Compatibility check
+        # Run outside the repo checkout (else Deno treats it as the @mollie/api-client package). npm populates
+        # node_modules from the tarball; Deno runs against it via --node-modules-dir=manual.
+        working-directory: ${{ runner.temp }}
+        run: |
+          cp "$GITHUB_WORKSPACE/tests/compat/check.mjs" .
+          npm init -y >/dev/null
+          npm install "$GITHUB_WORKSPACE"/artifact/*.tgz
+          deno run -A --node-modules-dir=manual check.mjs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,57 @@ jobs:
           # Set the API key for the integration tests. In the future, all tests will rely on snapshots. An API key will
           # then only be required to update those snapshots. The API key can then be removed from this file.
           API_KEY: ${{ secrets.TEST_API_KEY }}
+
+  # Bun and Deno run the Node-oriented Jest suite unmodified, guarding the SDK's runtime-agnostic support. Dependencies
+  # are installed with Node/yarn (which also builds the bundle via the `prepare` hook); only the test runtime differs.
+  # Floor versions are pinned so the lowest supported runtime is exercised, not only the latest.
+  test-bun:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun-version: ['1.0.0', 'latest']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: yarn
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Use Bun ${{ matrix.bun-version }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+      - name: Run test suite on Bun
+        # Explicit local jest path (not `bun x jest`, which can fetch a mismatched jest@latest when .bin/jest is absent).
+        run: bun node_modules/jest/bin/jest.js
+        env:
+          API_KEY: ${{ secrets.TEST_API_KEY }}
+
+  test-deno:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: [v2.0.0, v2.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: yarn
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Use Deno ${{ matrix.deno-version }}
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno-version }}
+      - name: Run test suite on Deno
+        run: deno run -A --node-modules-dir=auto ./node_modules/jest/bin/jest.js
+        env:
+          API_KEY: ${{ secrets.TEST_API_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Thanks for helping make the Mollie API client for Node.js better. This document covers how to report issues, set up the project, and get a change merged and released.
+
+## Reporting issues
+
+Bugs and feature requests are tracked as [GitHub issues](https://github.com/mollie/mollie-api-node/issues). Before opening one, please search existing issues to avoid duplicates, and include a minimal reproduction (SDK version, Node version, and a code snippet) where relevant.
+
+## Reporting security vulnerabilities
+
+**Do not report security issues through public GitHub issues.** Mollie operates a responsible disclosure program — please email [responsible-disclosure@mollie.com](mailto:responsible-disclosure@mollie.com) and follow the [responsible disclosure policy](https://www.mollie.com/legal/responsible-disclosure).
+
+## Development
+
+Requires a recent LTS release of Node.js and [Yarn](https://yarnpkg.com/) (Classic).
+
+```bash
+yarn                # install dependencies
+yarn build          # bundle (CJS + ESM) and emit TypeScript declarations
+yarn test           # run the full Jest test suite
+yarn lint           # ESLint (fix) + Prettier
+```
+
+### Tests
+
+- `yarn test` runs everything. The **integration** tests (`tests/integration`) hit the live Mollie API and require a test-mode API key in the `API_KEY` environment variable — get one from your [dashboard](https://www.mollie.com/dashboard/developers/api-keys).
+- To run only the **unit** tests (no API key needed): `yarn test:unit`.
+
+### Code style
+
+Linting and formatting are enforced with ESLint and Prettier. Run `yarn lint` before committing, or wire it into your editor.
+
+### Commit messages
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/). The first line must be a conventional commit (`feat:`, `fix:`, `chore:`, …); the changelog is derived from it. You can use `yarn commit` for an interactive [commitizen](https://commitizen-tools.github.io/commitizen/) prompt that formats the message for you.
+
+## Pull requests
+
+- Open pull requests against `master`.
+- Make sure `yarn test` and `yarn lint` pass, and that CI (tests + CodeQL) is green.
+- Every PR requires at least one review approval before it can be merged.
+
+## Releasing
+
+Releases are published to npm **automatically** by [`.github/workflows/publish.yml`](.github/workflows/publish.yml) when a GitHub Release is published. Authentication uses [npm Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) — there is no npm token, and there is no manual `npm publish` step.
+
+To cut a release:
+
+1. Update `CHANGELOG.md`.
+2. `npm version <major|minor|patch>` — bumps `package.json`, creates a commit and a `vX.Y.Z` tag.
+3. `git push --follow-tags` — pushes the commit and the tag.
+4. Publish a [GitHub Release](https://github.com/mollie/mollie-api-node/releases) for the new tag. **This is what triggers publishing.**
+
+The workflow then:
+
+- verifies the release tag matches the `package.json` version (and fails loudly if not),
+- builds the package and runs the unit tests,
+- publishes to npm with provenance, routing prereleases (e.g. `4.4.0-rc.1`) to their own dist-tag (`rc`, `beta`, …) so they never become the default `latest` install.
+
+Permission to create the tag / publish the release is governed by the repository's tag/release ruleset.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ See [the migration guide](MIGRATION.md) if you are migrating from an older versi
 
 ## Contributing
 
-Want to help us make our API client even better? We take [pull requests](https://github.com/mollie/mollie-api-node/pulls), sure. But how would you like to contribute to a technology oriented organization? Mollie is hiring developers and system engineers. [Check out our vacancies](https://jobs.mollie.com/) or [get in touch](mailto:personeel@mollie.com).
+Want to help us make our API client even better? We take [pull requests](https://github.com/mollie/mollie-api-node/pulls), sure. See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, our commit conventions, and the release process.
+
+But how would you like to contribute to a technology oriented organization? Mollie is hiring developers and system engineers. [Check out our vacancies](https://jobs.mollie.com/) or [get in touch](mailto:personeel@mollie.com).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 This library runs on any server-side JavaScript runtime that provides `fetch` and Node-compatible APIs — Node.js, Bun, and Deno, as well as edge runtimes such as Cloudflare Workers (with the `nodejs_compat` flag and a recent compatibility date). See [Requirements](#requirements) for the versions tested in CI.
 
-What it is _not_ meant for is the browser. In the typical setup you make calls to the Mollie API ‒ through one of our libraries ‒ from your server, where your API key sits safely out of reach of the outside world. If you were to include this library in a website or mobile app, your API key would be shipped to your users, who could then act on your behalf.
+What it is _not_ meant for is the browser. In the typical setup you make calls to the Mollie API ‒ through one of our libraries ‒ from your server, where your credentials sit safely out of reach of the outside world. If you were to include this library in a website or mobile app, your credentials would be shipped to your users, who could then act on your behalf.
 
 To prevent this, the client throws when it detects a browser-like environment. If you understand the risk and have appropriate mitigations in place (for example a short-lived, narrowly-scoped access token rather than a full API key), you can bypass the check with the `dangerouslyAllowBrowser` option:
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,28 @@
 
 ### A note on use outside of Node.js
 
-This is a JavaScript library, a language which is universal by nature. While it is theoretically possible to include this library into a website or mobile app, it is not recommended to do so.
+This library runs on any server-side JavaScript runtime that provides `fetch` and Node-compatible APIs — Node.js, Bun, and Deno, as well as edge runtimes such as Cloudflare Workers (with the `nodejs_compat` flag and a recent compatibility date). See [Requirements](#requirements) for the versions tested in CI.
 
-In the typical setup, you will make calls to the Mollie API ‒ through one of our libraries ‒ from your server (e.g. a Node.js server). Your API key sits safely on this server, out of reach to the outside world.
+What it is _not_ meant for is the browser. In the typical setup you make calls to the Mollie API ‒ through one of our libraries ‒ from your server, where your API key sits safely out of reach of the outside world. If you were to include this library in a website or mobile app, your API key would be shipped to your users, who could then act on your behalf.
 
-If you include this library in a website or app, however, your API key will be shipped to users. With this key, users will be able to act on your behalf.
+To prevent this, the client throws when it detects a browser-like environment. If you understand the risk and have appropriate mitigations in place (for example a short-lived, narrowly-scoped access token rather than a full API key), you can bypass the check with the `dangerouslyAllowBrowser` option:
+
+```js
+const mollieClient = createMollieClient({ apiKey: 'test_...', dangerouslyAllowBrowser: true });
+```
 
 ## Requirements
 
-- Node.js 14.× or greater.
+This library runs on any server-side JavaScript runtime with `fetch` and Node-compatible APIs. The following are verified in CI:
+
+- Node.js 14 or greater.
+- Bun 1.0 or greater.
+- Deno 2.0 or greater.
+
+It also runs on edge runtimes such as Cloudflare Workers, provided the `nodejs_compat` compatibility flag is enabled and a compatibility date of `2025-08-15` or later is set.
+
+You will also need:
+
 - A free [Mollie account](https://www.mollie.com/dashboard/signup).
 - Your API keys, which you can find on your [dashboard](https://www.mollie.com/dashboard/developers/api-keys).
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 This library runs on any server-side JavaScript runtime that provides `fetch` and Node-compatible APIs — Node.js, Bun, and Deno, as well as edge runtimes such as Cloudflare Workers (with the `nodejs_compat` flag and a recent compatibility date). See [Requirements](#requirements) for the versions tested in CI.
 
+On Deno, use the **named** import — `import { createMollieClient } from "npm:@mollie/api-client"` — rather than a default import, which Deno's CommonJS interop does not yet expose as callable.
+
 What it is _not_ meant for is the browser. In the typical setup you make calls to the Mollie API ‒ through one of our libraries ‒ from your server, where your credentials sit safely out of reach of the outside world. If you were to include this library in a website or mobile app, your credentials would be shipped to your users, who could then act on your behalf.
 
 To prevent this, the client throws when it detects a browser-like environment. If you understand the risk and have appropriate mitigations in place (for example a short-lived, narrowly-scoped access token rather than a full API key), you can bypass the check with the `dangerouslyAllowBrowser` option:

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -28,6 +28,13 @@ type Options = Xor<
    * The URL of the root of the Mollie API. Default: `'https://api.mollie.com:443/v2/'`.
    */
   apiEndpoint?: string;
+  /**
+   * By default, this client refuses to run in a browser-like environment, as doing so would ship your API key to the
+   * public and allow anyone to act on your behalf. Set this to `true` only if you understand the risks and have
+   * appropriate mitigations in place (e.g. a short-lived, narrowly-scoped token).
+   * @see https://github.com/mollie/mollie-api-node/#a-note-on-use-outside-of-nodejs
+   */
+  dangerouslyAllowBrowser?: boolean;
 };
 
 const falsyDescriptions = new Map<any, string>([

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -29,9 +29,9 @@ type Options = Xor<
    */
   apiEndpoint?: string;
   /**
-   * By default, this client refuses to run in a browser-like environment, as doing so would ship your API key to the
-   * public and allow anyone to act on your behalf. Set this to `true` only if you understand the risks and have
-   * appropriate mitigations in place (e.g. a short-lived, narrowly-scoped token).
+   * By default, this client refuses to run in a browser-like environment, as doing so would ship your credentials (API
+   * key or access token) to the public and allow anyone to act on your behalf. Set this to `true` only if you understand
+   * the risks and have appropriate mitigations in place (e.g. a short-lived, narrowly-scoped token).
    * @see https://github.com/mollie/mollie-api-node/#a-note-on-use-outside-of-nodejs
    */
   dangerouslyAllowBrowser?: boolean;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -75,20 +75,38 @@ import OAuthBinder from './binders/oauth/OAuthBinder';
 import ClientLinksBinder from './binders/client-links/ClientLinksBinder';
 
 /**
+ * Returns whether the code appears to be running in a browser-like environment, where shipping an API key would expose
+ * it to the public. It checks for `window`, `window.document`, and `navigator` ‒ all present in real browsers, but
+ * absent in Node.js, Bun, Deno, and server-side edge runtimes (Cloudflare Workers, Vercel/Netlify edge), which are
+ * therefore not flagged. Property access on `globalThis` (rather than a bare identifier) keeps this safe in runtimes
+ * where these are undeclared globals.
+ */
+function isBrowserLike() {
+  const globals = globalThis as { window?: { document?: unknown }; navigator?: unknown };
+  return globals.window?.document != undefined && globals.navigator != undefined;
+}
+
+/**
  * Create Mollie client.
  * @since 2.0.0
  */
 export default function createMollieClient(options: Options) {
-  // Attempt to catch cases where this library is integrated into a frontend app.
-  if (['node', 'io.js'].includes(process?.release?.name) == false) {
+  // Refuse to run in a browser-like environment by default, as doing so would ship the API key to the public. This is
+  // a guardrail against accidental misuse, not a security boundary (any global can be spoofed); it can be bypassed with
+  // `dangerouslyAllowBrowser`. Unlike the previous `process.release.name` check, this lets the library run on non-Node
+  // server runtimes (Bun, Deno, Cloudflare Workers, and other edge runtimes), none of which define `window.document`.
+  if (options.dangerouslyAllowBrowser !== true && isBrowserLike()) {
     throw new Error(
-      `Unexpected process release name ${process?.release?.name}. This may indicate that the Mollie API client is integrated into a website or app. This is not recommended, please see https://github.com/mollie/mollie-api-node/#a-note-on-use-outside-of-nodejs. If this is a mistake, please let us know: https://github.com/mollie/mollie-api-node/issues`,
+      "It looks like you're running in a browser-like environment, which is disabled by default as it risks exposing your API key to the public. If you understand the risks and have appropriate mitigations in place, set the `dangerouslyAllowBrowser` option to `true`, e.g. `createMollieClient({ apiKey, dangerouslyAllowBrowser: true })`. See https://github.com/mollie/mollie-api-node/#a-note-on-use-outside-of-nodejs",
     );
   }
 
   checkCredentials(options);
 
-  const networkClient = new NetworkClient({ ...options, libraryVersion, nodeVersion: process.version, caCertificates });
+  // `process` is not defined in every runtime (browsers, some edge runtimes). `typeof` is ReferenceError-safe even when
+  // the identifier is undeclared, whereas `process?.version` would still throw.
+  const nodeVersion = typeof process != 'undefined' && process.version ? process.version : 'unknown';
+  const networkClient = new NetworkClient({ ...options, libraryVersion, nodeVersion, caCertificates });
 
   const transformingNetworkClient = new TransformingNetworkClient(
     networkClient,

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -75,8 +75,8 @@ import OAuthBinder from './binders/oauth/OAuthBinder';
 import ClientLinksBinder from './binders/client-links/ClientLinksBinder';
 
 /**
- * Returns whether the code appears to be running in a browser-like environment, where shipping an API key would expose
- * it to the public. It checks for `window`, `window.document`, and `navigator` ‒ all present in real browsers, but
+ * Returns whether the code appears to be running in a browser-like environment, where shipping credentials would expose
+ * them to the public. It checks for `window`, `window.document`, and `navigator` ‒ all present in real browsers, but
  * absent in Node.js, Bun, Deno, and server-side edge runtimes (Cloudflare Workers, Vercel/Netlify edge), which are
  * therefore not flagged. Property access on `globalThis` (rather than a bare identifier) keeps this safe in runtimes
  * where these are undeclared globals.
@@ -91,13 +91,13 @@ function isBrowserLike() {
  * @since 2.0.0
  */
 export default function createMollieClient(options: Options) {
-  // Refuse to run in a browser-like environment by default, as doing so would ship the API key to the public. This is
+  // Refuse to run in a browser-like environment by default, as doing so would ship credentials to the public. This is
   // a guardrail against accidental misuse, not a security boundary (any global can be spoofed); it can be bypassed with
   // `dangerouslyAllowBrowser`. Unlike the previous `process.release.name` check, this lets the library run on non-Node
   // server runtimes (Bun, Deno, Cloudflare Workers, and other edge runtimes), none of which define `window.document`.
   if (options.dangerouslyAllowBrowser !== true && isBrowserLike()) {
     throw new Error(
-      "It looks like you're running in a browser-like environment, which is disabled by default as it risks exposing your API key to the public. If you understand the risks and have appropriate mitigations in place, set the `dangerouslyAllowBrowser` option to `true`, e.g. `createMollieClient({ apiKey, dangerouslyAllowBrowser: true })`. See https://github.com/mollie/mollie-api-node/#a-note-on-use-outside-of-nodejs",
+      "It looks like you're running in a browser-like environment, which is disabled by default as it risks exposing your credentials (API key or access token) to the public. If you understand the risks and have appropriate mitigations in place, set the `dangerouslyAllowBrowser` option to `true`, e.g. `createMollieClient({ apiKey, dangerouslyAllowBrowser: true })`. See https://github.com/mollie/mollie-api-node/#a-note-on-use-outside-of-nodejs",
     );
   }
 

--- a/tests/compat/check.mjs
+++ b/tests/compat/check.mjs
@@ -1,0 +1,36 @@
+// Cross-runtime compatibility check.
+//
+// Unlike the Jest tests (which import `../../src`), this runs against an INSTALLED `@mollie/api-client`, imported by
+// package name so module resolution is exercised. Run it under Node, Bun, or Deno (see .github/workflows/test.yml): it
+// verifies the package installs, resolves, constructs a client with its binders attached, and that a request
+// round-trips to the Mollie API as a `MollieApiError` (i.e. the HTTP transport works on this runtime). It uses the
+// NAMED import deliberately — the default import is not callable on Deno until the `exports` map lands. A bogus API key
+// is used, so no credentials are required; the expected result is an authentication error.
+import { createMollieClient, MollieApiError, PaymentMethod } from '@mollie/api-client';
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error('COMPAT FAIL: ' + message);
+};
+
+// Named export resolves to the factory.
+assert(typeof createMollieClient === 'function', `createMollieClient named export is ${typeof createMollieClient}, not a function`);
+
+// Enum exports resolve.
+assert(PaymentMethod?.creditcard === 'creditcard', 'enum export PaymentMethod did not resolve');
+
+// Construct + binders attached.
+const mollieClient = createMollieClient({ apiKey: 'test_' + 'x'.repeat(30) });
+assert(typeof mollieClient.payments?.page === 'function', 'client.payments.page missing — binders not attached');
+assert(typeof mollieClient.payments?.create === 'function', 'client.payments.create missing — binders not attached');
+
+// End-to-end transport: a bogus key must reach Mollie and come back as a MollieApiError, not a transport error.
+let error;
+try {
+  await mollieClient.payments.page({ limit: 1 });
+} catch (caught) {
+  error = caught;
+}
+assert(error != undefined, 'request with a bogus key unexpectedly succeeded');
+assert(error instanceof MollieApiError, `expected a MollieApiError (transport reached Mollie), got ${error?.constructor?.name}: ${error?.message ?? error}`);
+
+console.log('COMPAT OK');

--- a/tests/unit/createMollieClient.guard.test.ts
+++ b/tests/unit/createMollieClient.guard.test.ts
@@ -1,0 +1,53 @@
+import createMollieClient from '../..';
+
+/**
+ * The client refuses to run in a browser-like environment (where the API key would be exposed) unless
+ * `dangerouslyAllowBrowser` is set. The check keys on `window.document` + `navigator`, so non-browser server runtimes
+ * (Node, Bun, Deno, edge) are not flagged. See the `isBrowserLike` guard in `createMollieClient`.
+ */
+describe('createMollieClient browser guard', () => {
+  const apiKey = 'test_dummydummydummydummydummy00';
+  const globals = globalThis as Record<string, unknown>;
+  let teardown: Array<() => void> = [];
+
+  // Set a global, recording how to restore it afterwards.
+  const define = (key: string, value: unknown) => {
+    const had = key in globals;
+    const previous = globals[key];
+    teardown.push(() => {
+      if (had) {
+        globals[key] = previous;
+      } else {
+        delete globals[key];
+      }
+    });
+    globals[key] = value;
+  };
+
+  // navigator exists as a global from Node 21 onwards but not on older versions, so define it only when absent.
+  const simulateBrowser = () => {
+    define('window', { document: {} });
+    if (typeof navigator == 'undefined') {
+      define('navigator', { userAgent: 'Mozilla/5.0 (test browser)' });
+    }
+  };
+
+  afterEach(() => {
+    teardown.forEach(restore => restore());
+    teardown = [];
+  });
+
+  it('throws in a browser-like environment', () => {
+    simulateBrowser();
+    expect(() => createMollieClient({ apiKey })).toThrow(/browser-like environment/);
+  });
+
+  it('does not throw in a browser-like environment when dangerouslyAllowBrowser is true', () => {
+    simulateBrowser();
+    expect(() => createMollieClient({ apiKey, dangerouslyAllowBrowser: true })).not.toThrow();
+  });
+
+  it('does not throw in a non-browser server runtime', () => {
+    expect(() => createMollieClient({ apiKey })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `process.release.name` guard in `createMollieClient` with a positive browser check (`window.document` + `navigator`, read off `globalThis` so it stays `ReferenceError`-safe) plus a `dangerouslyAllowBrowser` opt-out, following the pattern used by the OpenAI SDK.

The old check rejected any environment whose `process.release.name` was not `node`/`io.js`, which falsely blocked legitimate **server** runtimes (Bun, Deno, Cloudflare Workers and other edge runtimes) — and where `process` is undeclared it threw an opaque `ReferenceError` instead of the intended message. Browsers are still blocked by default to avoid shipping the API key to end users; the guard is a footgun-check, not a security boundary, hence the explicit escape hatch.

Verified end-to-end (construct + real request) on Node, Bun 1.0/1.3, Deno 2.0/2.9, and Cloudflare Workers (local `workerd`, `nodejs_compat` + compatibility date ≥ `2025-08-15`).

## Changes

- **feat**: browser guard + `dangerouslyAllowBrowser` option, with a unit test.
- **docs**: README — supported runtimes (Node 14, Bun 1.0, Deno 2.0, Cloudflare Workers) and the new option.
- **ci**: run the Jest suite on Bun and Deno. Dependencies are installed with yarn (which also builds the bundle via the `prepare` hook) and Jest is executed under each runtime; floor versions are pinned. Jobs are *appended* so they don't collide with the in-flight `test.yml` change in #482.
- **docs**: add `CONTRIBUTING.md` and link it from the README.

## Scope / follow-up

This covers runtimes that provide Node-compatible `http`/`fetch`:

- **Bun** and **Deno** (CLI) work unchanged — this resolves the investigation in #278 and the Deno side of #460.
- **Cloudflare Workers** works with `nodejs_compat` + a recent compatibility date.

Full runtime-agnosticism for edge isolates without Node compat (Vercel Edge, Netlify/Deno-Deploy) and removing the `nodejs_compat` requirement need the **native-`fetch` migration** — dropping `node-fetch` + the `https.Agent`/bundled CA and adding an `exports` map (which also fixes the Deno default-import interop, where `import createMollieClient from '...'` currently resolves to an object; use the named `import { createMollieClient }` until then). That's a breaking change, tracked separately for 5.0.

Addresses #208, #278, #460.

## Testing

- Full Jest suite green on Node, Bun, and Deno (164 tests).
- New unit test covers the guard: throws in a browser-like environment, is bypassed by `dangerouslyAllowBrowser`, and passes on server runtimes.
