### PR TITLE
feat(balance-transfers): support metadata on connect balance transfers

### DIFF
--- a/src/binders/balance-transfers/BalanceTransfersBinder.ts
+++ b/src/binders/balance-transfers/BalanceTransfersBinder.ts
@@ -21,6 +21,8 @@ export default class BalanceTransfersBinder extends Binder<BalanceTransferData, 
    * Create a balance transfer from your organization's balance to a connected organization's balance, or vice versa.
    * You can also create a balance transfer between two connected organizations.
    *
+   * To create a balance transfer, you must be authenticated as the source organization, and the destination organization must be a connected organization that has authorized the `balance-transfers.write` scope for your organization.
+   *
    * @since 4.4.0
    * @see https://docs.mollie.com/reference/create-connect-balance-transfer
    */

--- a/src/binders/balance-transfers/parameters.ts
+++ b/src/binders/balance-transfers/parameters.ts
@@ -1,9 +1,13 @@
 import { type BalanceTransferData } from '../../data/balance-transfers/data';
 import { type IdempotencyParameter, type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
+import type PickOptional from '../../types/PickOptional';
 
 type ContextParameters = TestModeParameter;
 
-export type CreateParameters = ContextParameters & Pick<BalanceTransferData, 'amount' | 'source' | 'destination' | 'description' | 'category'> & IdempotencyParameter;
+export type CreateParameters = ContextParameters &
+  Pick<BalanceTransferData, 'amount' | 'source' | 'destination' | 'description' | 'category'> &
+  PickOptional<BalanceTransferData, 'metadata'> &
+  IdempotencyParameter;
 
 export type GetParameters = ContextParameters;
 

--- a/src/data/balance-transfers/data.ts
+++ b/src/data/balance-transfers/data.ts
@@ -3,7 +3,7 @@ import type Model from '../Model';
 
 export interface BalanceTransferData extends Model<'connect-balance-transfer'> {
   /**
-   * The amount to be transferred.
+   * The amount to be transferred, e.g. `{"currency":"EUR", "value":"1000.00"}` if you would like to transfer €1000.00.
    *
    * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=amount#body-params
    */
@@ -44,6 +44,13 @@ export interface BalanceTransferData extends Model<'connect-balance-transfer'> {
    * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=category#body-params
    */
   category?: BalanceTransferCategory;
+  /**
+   * A JSON object that you can attach to a balance transfer.
+   * This can be useful for storing additional information about the transfer in a structured format. Maximum size is approximately 1KB.
+   *
+   * @see https://docs.mollie.com/reference/create-connect-balance-transfer?path=metadata#body-params
+   */
+  metadata: unknown;
   /**
    * The entity's date and time of creation, in ISO 8601 format.
    *


### PR DESCRIPTION
## Summary

Syncs the `balance-transfers` types with Mollie's OpenAPI spec for `/v2/connect/balance-transfers`.

- **`metadata`** — add the free-form `metadata` object to `BalanceTransferData` (response) and expose it as an optional field on `CreateParameters`. It is part of the connect-balance-transfer entity but was missing from the SDK, so consumers could neither send nor read it.
- **JSDoc** — restore the `amount` example from the spec and document the source-organization authentication / `balance-transfers.write` scope requirement on `create()`.

## Deliberately not changed

`statusReason` stays optional (`statusReason?`) on the response. The spec marks it `required`, but its own description ("if applicable") and observed behaviour indicate it can be absent — forcing it required would be a semantically-wrong, breaking change.

## Reference

- [Create a Connect balance transfer](https://docs.mollie.com/reference/create-connect-balance-transfer)
- [Get a Connect balance transfer](https://docs.mollie.com/reference/get-connect-balance-transfer)
- [List Connect balance transfers](https://docs.mollie.com/reference/list-connect-balance-transfers)

## Verification

- `yarn build:declarations` — passes (full type graph)
- `eslint` on touched dirs — clean
- `prettier` on edited files — clean
