### PR TITLE
docs(capabilities): sync requirement field JSDoc with API spec

### DIFF
--- a/src/data/capabilities/data.ts
+++ b/src/data/capabilities/data.ts
@@ -45,7 +45,7 @@ export interface Requirement {
   /**
    * The name of this requirement, referring to the task to be fulfilled by the organization
    * to enable or re-enable the capability. The name is unique among other requirements of
-   * the same capability.
+   * the same capability. Examples include `needs-data` and `process-first-payment`.
    *
    * @see https://docs.mollie.com/reference/list-capabilities?path=id#response
    */
@@ -71,7 +71,8 @@ export interface Requirement {
    */
   _links: {
     /**
-     * The dashboard URL where the requirement can be fulfilled.
+     * If known, a deep link to the Mollie dashboard of the client, where the requirement
+     * can be fulfilled. For example, where necessary documents are to be uploaded.
      */
     dashboard: Url;
   };


### PR DESCRIPTION
Syncs the `Requirement` JSDoc in `src/data/capabilities/data.ts` with the master Mollie OpenAPI spec for the `list-capabilities` endpoint. The SDK descriptions had drifted from the spec — two fields were abbreviated and lost detail:

- **`Requirement.id`** — restored the spec's example values (`needs-data`, `process-first-payment`).
- **`Requirement._links.dashboard`** — restored the fuller "deep link to the client's Mollie dashboard, where the requirement can be fulfilled (e.g. uploading documents)" context.

Doc-only change; no type/signature changes. `tsc` (declarations) and ESLint pass.

### Not in scope (flagged for separate review)
The spec also disagrees on optionality of two response fields — left unchanged here since the docs are unreliable on nullability and this endpoint is still in beta:
- `CapabilityData.statusReason` — spec: required + nullable; SDK: optional.
- `Requirement._links.dashboard` — spec: optional within `_links`; SDK: required.

### Reference
- https://docs.mollie.com/reference/list-capabilities