### PR TITLE
docs: enrich OAuth token JSDoc from the API spec

### DIFF
--- a/src/binders/oauth/OAuthBinder.ts
+++ b/src/binders/oauth/OAuthBinder.ts
@@ -47,6 +47,8 @@ export default class OAuthBinder {
   /**
    * Revoke an access token or refresh token. Once revoked, the token can no longer be used.
    *
+   * Revoking a refresh token revokes all access tokens that were created using the same authorization.
+   *
    * @since 4.4.0
    * @see https://docs.mollie.com/reference/oauth-revoke-tokens
    */

--- a/src/data/oauth/data.ts
+++ b/src/data/oauth/data.ts
@@ -31,7 +31,7 @@ export default interface Token {
    */
   token_type: 'bearer';
   /**
-   * A space-separated list of permissions.
+   * A space-separated list of [permissions](https://docs.mollie.com/docs/permissions).
    *
    * @see https://docs.mollie.com/reference/oauth-generate-tokens?path=scope#response
    */


### PR DESCRIPTION
Syncs the OAuth resource's JSDoc with the Mollie OpenAPI spec (`/sync-api oauth`). Documentation only — no type or runtime changes.

## Changes
- **`revoke()` method** (`OAuthBinder.ts`): documents that revoking a refresh token cascades to every access token issued under the same authorization — a behavioural consequence the spec states but the SDK had dropped.
- **`scope` field** (`oauth/data.ts`): links the description to the permissions reference.

## Verified in sync (no change needed)
- Token response (5/5 fields), `CreateParameters`, `RevokeParameters` all structurally correct.
- The `grant_type`/`code`/`refresh_token` request fields live in the `AuthorizationCodeGrant | RefreshTokenGrant` discriminated union (stronger than the spec's flat shape).
- `clientId`/`clientSecret` are Basic-auth header credentials, intentionally not body params.
- Neither operation is deprecated; no `_links`/`_embedded` wiring.

## Docs references
- [Generate tokens](https://docs.mollie.com/reference/oauth-generate-tokens)
- [Revoke tokens](https://docs.mollie.com/reference/oauth-revoke-tokens)
- [Permissions](https://docs.mollie.com/docs/permissions)