### PR TITLE
docs(customers): sync JSDoc with Mollie API reference

### DIFF
--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -22,7 +22,7 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * appear in your [Mollie Dashboard](https://www.mollie.com/dashboard) where you can manage their details, and also see their payments and subscriptions.
    *
    * @since 2.0.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/create-customer
+   * @see https://docs.mollie.com/reference/create-customer
    */
   public create(parameters: CreateParameters): Promise<Customer>;
   public create(parameters: CreateParameters, callback: Callback<Customer>): void;
@@ -35,7 +35,7 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * Retrieve a single customer by its ID.
    *
    * @since 2.0.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer
+   * @see https://docs.mollie.com/reference/get-customer
    */
   public get(id: string, parameters?: GetParameters): Promise<Customer>;
   public get(id: string, parameters: GetParameters, callback: Callback<Customer>): void;
@@ -51,7 +51,7 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * The results are paginated. See pagination for more information.
    *
    * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
+   * @see https://docs.mollie.com/reference/list-customers
    */
   public page(parameters?: PageParameters): Promise<Page<Customer>>;
   public page(parameters: PageParameters, callback: Callback<Page<Customer>>): void;
@@ -66,7 +66,7 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * The results are paginated. See pagination for more information.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customers
+   * @see https://docs.mollie.com/reference/list-customers
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};
@@ -77,7 +77,7 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * Update an existing customer.
    *
    * @since 2.0.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/update-customer
+   * @see https://docs.mollie.com/reference/update-customer
    */
   public update(id: string, parameters: UpdateParameters): Promise<Customer>;
   public update(id: string, parameters: UpdateParameters, callback: Callback<Customer>): void;
@@ -91,7 +91,7 @@ export default class CustomersBinder extends Binder<CustomerData, Customer> {
    * Delete a customer. All mandates and subscriptions created for this customer will be canceled as well.
    *
    * @since 2.0.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/delete-customer
+   * @see https://docs.mollie.com/reference/delete-customer
    */
   public delete(id: string, parameters?: DeleteParameters): Promise<true>;
   public delete(id: string, parameters: DeleteParameters, callback: Callback<true>): void;

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -30,7 +30,7 @@ export default class CustomerPaymentsBinder extends Binder<PaymentData, Payment>
    * -   Recurring payments.
    *
    * @since 1.1.1
-   * @see https://docs.mollie.com/reference/v2/customers-api/create-customer-payment
+   * @see https://docs.mollie.com/reference/create-customer-payment
    */
   public create(parameters: CreateParameters): Promise<Payment>;
   public create(parameters: CreateParameters, callback: Callback<Payment>): void;
@@ -45,7 +45,7 @@ export default class CustomerPaymentsBinder extends Binder<PaymentData, Payment>
    * Retrieve all Payments linked to the Customer.
    *
    * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+   * @see https://docs.mollie.com/reference/list-customer-payments
    */
   public page(parameters: PageParameters): Promise<Page<Payment>>;
   public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
@@ -60,7 +60,7 @@ export default class CustomerPaymentsBinder extends Binder<PaymentData, Payment>
    * Retrieve all Payments linked to the Customer.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+   * @see https://docs.mollie.com/reference/list-customer-payments
    */
   public iterate(parameters: IterateParameters) {
     const { customerId, valuesPerMinute, ...query } = parameters;

--- a/src/data/customers/Customer.ts
+++ b/src/data/customers/Customer.ts
@@ -10,47 +10,49 @@ export interface CustomerData extends Model<'customer'> {
    *
    * Possible values: `live` `test`
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=mode#response
+   * @see https://docs.mollie.com/reference/get-customer?path=mode#response
    */
   mode: ApiMode;
   /**
    * The full name of the customer as provided when the customer was created.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=name#response
+   * @see https://docs.mollie.com/reference/get-customer?path=name#response
    */
   name: string;
   /**
    * The email address of the customer as provided when the customer was created.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=email#response
+   * If the domain contains non-ASCII characters, encode it as Punycode per [RFC 3492](https://www.rfc-editor.org/rfc/rfc3492).
+   *
+   * @see https://docs.mollie.com/reference/get-customer?path=email#response
    */
   email: string;
   /**
    * Allows you to preset the language to be used in the hosted payment pages shown to the consumer. If this parameter was not provided when the customer was created, the browser language will be used
    * instead in the payment flow (which is usually more accurate).
    *
-   * Possible values: `en_US` `en_GB` `nl_NL` `nl_BE` `fr_FR` `fr_BE` `de_DE` `de_AT` `de_CH` `es_ES` `ca_ES` `pt_PT` `it_IT` `nb_NO` `sv_SE` `fi_FI` `da_DK` `is_IS` `hu_HU` `pl_PL` `lv_LV` `lt_LT`
+   * Possible values: `en_US` `en_GB` `nl_NL` `nl_BE` `de_DE` `de_AT` `de_CH` `de_LU` `fr_FR` `fr_BE` `fr_LU` `es_ES` `ca_ES` `pt_PT` `it_IT` `nb_NO` `sv_SE` `fi_FI` `da_DK` `is_IS` `hu_HU` `pl_PL` `lv_LV` `lt_LT`
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=locale#response
+   * @see https://docs.mollie.com/reference/get-customer?path=locale#response
    */
   locale: Locale;
   recentlyUsedMethods: PaymentMethod[];
   /**
    * Data provided during the customer creation.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=metadata#response
+   * @see https://docs.mollie.com/reference/get-customer?path=metadata#response
    */
   metadata: unknown;
   /**
    * The customer's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=createdAt#response
+   * @see https://docs.mollie.com/reference/get-customer?path=createdAt#response
    */
   createdAt: string;
   /**
    * An object with several URL objects relevant to the customer. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links#response
+   * @see https://docs.mollie.com/reference/get-customer?path=_links#response
    */
   _links: CustomerLinks;
 }
@@ -63,19 +65,19 @@ export interface CustomerLinks extends Links {
   /**
    * The API resource URL of the mandates belonging to the Customer, if there are no mandates this parameter is omitted.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links/mandates#response
+   * @see https://docs.mollie.com/reference/get-customer?path=_links/mandates#response
    */
   mandates: Url;
   /**
    * The API resource URL of the subscriptions belonging to the Customer, if there are no subscriptions this parameter is omitted.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links/subscriptions#response
+   * @see https://docs.mollie.com/reference/get-customer?path=_links/subscriptions#response
    */
   subscriptions: Url;
   /**
    * The API resource URL of the payments belonging to the Customer, if there are no payments this parameter is omitted.
    *
-   * @see https://docs.mollie.com/reference/v2/customers-api/get-customer?path=_links/payments#response
+   * @see https://docs.mollie.com/reference/get-customer?path=_links/payments#response
    */
   payments: Url;
 }


### PR DESCRIPTION
Reconciles the customer resource's inline documentation with the master Mollie OpenAPI spec. **No type-surface changes** — JSDoc/`@see` only.

### Changes
- **`@see` migration** — legacy `/reference/v2/<api>/…` links → current `/reference/…` form across `Customer` data and both binders (`CustomersBinder`, `CustomerPaymentsBinder`). All target slugs HTTP-200 verified.
- **`email`** — restored the Punycode / [RFC 3492](https://www.rfc-editor.org/rfc/rfc3492) encoding note that had drifted from the spec.
- **`locale`** — added `de_LU` and `fr_LU` to the documented value list (the `Locale` enum already carried them; doc-only catch-up).

### Deliberately out of scope
- **`?include=events` / `events[]`** — the spec under-documents this (opaque integer `type`, no field descriptions, undocumented `_links.url` target, no `id`). Left out until the docs are clarified — tracked in #497.
- **`recentlyUsedMethods`** (present in SDK, absent from spec) and **`name`/`email`/`locale` nullability** — unchanged; the latter is a breaking response change for #489.

### Docs reference
- https://docs.mollie.com/reference/get-customer
- https://docs.mollie.com/reference/create-customer
- https://docs.mollie.com/reference/list-customers
- https://docs.mollie.com/reference/update-customer
- https://docs.mollie.com/reference/delete-customer
- https://docs.mollie.com/reference/create-customer-payment
- https://docs.mollie.com/reference/list-customer-payments
