### PR TITLE
feat: sync onboarding types with the current API spec

### DIFF
--- a/src/binders/onboarding/OnboardingBinder.ts
+++ b/src/binders/onboarding/OnboardingBinder.ts
@@ -17,7 +17,7 @@ export default class OnboardingBinder extends Binder<OnboardingData, Onboarding>
    * Get the status of onboarding of the authenticated organization.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status
+   * @see https://docs.mollie.com/reference/get-onboarding-status
    */
   public get(): Promise<Onboarding>;
   public get(callback: Callback<Onboarding>): void;
@@ -27,10 +27,11 @@ export default class OnboardingBinder extends Binder<OnboardingData, Onboarding>
   }
 
   /**
-   * Submit data that will be prefilled in the merchant's onboarding. The data you submit will only be processed when the onboarding status is `needs-data`.
+   * Submit data that will be prefilled in the merchant's onboarding. The data you submit will only be processed when the onboarding status is `needs-data`. Information that the merchant has entered in their dashboard will not be overwritten.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data
+   * @deprecated Implementing this endpoint is no longer recommended. Use the Client Links API instead to kick off the onboarding process for your merchants.
+   * @see https://docs.mollie.com/reference/submit-onboarding-data
    */
   public submit(parameters?: SubmitParameters): Promise<true>;
   public submit(parameters: SubmitParameters, callback: Callback<true>): void;

--- a/src/binders/onboarding/parameters.ts
+++ b/src/binders/onboarding/parameters.ts
@@ -1,11 +1,15 @@
 import type { OrganizationAdress } from '../../data/organizations/Organizations';
 import { type IdempotencyParameter } from '../../types/parameters';
 
+/**
+ * @deprecated Submitting onboarding data is no longer recommended. Use the Client Links API instead to kick off the
+ * onboarding process for your merchants.
+ */
 export interface SubmitParameters extends IdempotencyParameter {
   /**
    * Data of the organization you want to provide.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data?path=organization#parameters
+   * @see https://docs.mollie.com/reference/submit-onboarding-data?path=organization#parameters
    */
   organization?: {
     /**
@@ -21,20 +25,24 @@ export interface SubmitParameters extends IdempotencyParameter {
      */
     registrationNumber?: string;
     /**
-     * The VAT number of the company, if based in the European Union. The VAT number will be checked with the VIES
-     * service by Mollie.
+     * The VAT number of the organization, if based in the European Union or in the United Kingdom. VAT numbers are
+     * verified against the international registry *VIES*.
+     *
+     * The field can be omitted for merchants residing in other countries.
      */
     vatNumber?: string;
     /**
-     * The organization's VAT regulation, if based in the European Union. Either `'shifted'` (VAT is shifted) or
-     * `'dutch'` (Dutch VAT rate) is accepted.
+     * The organization's VAT regulation. Mollie applies Dutch VAT for merchants based in the Netherlands, British VAT
+     * for merchants based in the United Kingdom, and shifted VAT for merchants in the European Union.
+     *
+     * The field can be omitted for merchants residing in other countries.
      */
-    vatRegulation?: 'shifted' | 'dutch';
+    vatRegulation?: 'dutch' | 'british' | 'shifted';
   };
   /**
    * Data of the payment profile you want to provide.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data?path=profile#parameters
+   * @see https://docs.mollie.com/reference/submit-onboarding-data?path=profile#parameters
    */
   profile?: {
     /**
@@ -49,6 +57,8 @@ export interface SubmitParameters extends IdempotencyParameter {
     url?: string;
     /**
      * The email address associated with the profile's tradename or brand.
+     *
+     * If the domain contains non-ASCII characters, encode it as Punycode per [RFC 3492](https://www.rfc-editor.org/rfc/rfc3492).
      */
     email?: string;
     /**
@@ -60,6 +70,13 @@ export interface SubmitParameters extends IdempotencyParameter {
      * `'+31208202070'`.
      */
     phone?: string;
+    /**
+     * The industry associated with the profile's tradename or brand. Refer to the business category list documentation
+     * for all accepted values.
+     *
+     * @see https://docs.mollie.com/reference/submit-onboarding-data?path=profile/businessCategory#parameters
+     */
+    businessCategory?: string;
     /**
      * The industry associated with the profile's tradename or brand.
      *
@@ -80,6 +97,8 @@ export interface SubmitParameters extends IdempotencyParameter {
      * * `7299` Personal services
      * * `7999` Events, festivals and recreation
      * * `8398` Charity and donations
+     *
+     * @deprecated Use {@link businessCategory} instead. The numeric category code is no longer part of the onboarding API.
      */
     categoryCode?: number;
   };

--- a/src/data/onboarding/data.ts
+++ b/src/data/onboarding/data.ts
@@ -4,19 +4,19 @@ import type Model from '../Model';
 /**
  * Get the status of onboarding of the authenticated organization.
  *
- * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status
+ * @see https://docs.mollie.com/reference/get-onboarding-status
  */
 export interface OnboardingData extends Model<'onboarding', undefined> {
   /**
    * The name of the organization.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=name#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=name#response
    */
   name: string;
   /**
-   * The sign up date and time of the organization.
+   * The sign up date and time of the organization in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=signedUpAt#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=signedUpAt#response
    */
   signedUpAt: string;
   /**
@@ -26,25 +26,25 @@ export interface OnboardingData extends Model<'onboarding', undefined> {
    * -   `in-review` The merchant provided all information and Mollie needs to check this
    * -   `completed` The onboarding is completed
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=status#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=status#response
    */
   status: OnboardingStatus;
   /**
    * Whether or not the organization can receive payments.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=canReceivePayments#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=canReceivePayments#response
    */
   canReceivePayments: boolean;
   /**
    * Whether or not the organization can receive settlements.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=canReceiveSettlements#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=canReceiveSettlements#response
    */
   canReceiveSettlements: boolean;
   /**
    * An object with several URL objects relevant to the onboarding status. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=_links#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=_links#response
    */
   _links: OnboardingLinks;
 }
@@ -53,13 +53,13 @@ export interface OnboardingLinks extends Links {
   /**
    * The URL of the onboarding process in Mollie Dashboard. You can redirect your customer to here for e.g. completing the onboarding process.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=_links/dashboard#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=_links/dashboard#response
    */
   dashboard: Url;
   /**
    * The API resource URL of the organization.
    *
-   * @see https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status?path=_links/organization#response
+   * @see https://docs.mollie.com/reference/get-onboarding-status?path=_links/organization#response
    */
   organization: Url;
 }


### PR DESCRIPTION
## Summary

Reconciles the `onboarding` resource types against Mollie's master OpenAPI spec (via `/sync-api onboarding`).

## Changes

**Types (non-breaking, additive)**
- Add `profile.businessCategory` (string). The spec replaced the numeric `categoryCode` with this string category; `categoryCode` is retained but marked `@deprecated` so existing integrations keep compiling.
- Add `'british'` to `vatRegulation` (`'dutch' | 'british' | 'shifted'`) — the UK is now a supported VAT regime.

**Deprecations**
- The `submit` method and `SubmitParameters` are marked `@deprecated`: Mollie no longer recommends the submit-onboarding-data endpoint and directs integrators to the Client Links API.

**Docs**
- Sync field descriptions: `signedUpAt` (ISO 8601), `vatNumber` (EU + UK, omittable elsewhere), `profile.email` (Punycode / RFC 3492).
- Migrate all `@see` links from the legacy `/reference/v2/onboarding-api/…` to the current `/reference/…` format.

## Reference

- https://docs.mollie.com/reference/get-onboarding-status
- https://docs.mollie.com/reference/submit-onboarding-data

## Verification

- `yarn build:declarations` (tsc over the full type graph) passes.
- ESLint clean; Prettier formatted.
- Post-apply spec diff reports zero drift on both the response and request mirrors.

> Note: deprecating `SubmitParameters` surfaces TS6385 "deprecated" _suggestion_ diagnostics (IDE strikethrough) at the binder's own usage — expected and benign, since the consuming `submit` method is itself deprecated. The build is unaffected.
