### PR TITLE
feat(organizations): sync resource with the Mollie API spec

### DIFF
--- a/src/binders/organizations/OrganizationsBinder.ts
+++ b/src/binders/organizations/OrganizationsBinder.ts
@@ -7,6 +7,7 @@ import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
+import { type GetParameters } from './parameters';
 
 const pathSegment = 'organizations';
 
@@ -19,21 +20,21 @@ export default class OrganizationsBinder extends Binder<OrganizationData, Organi
    * Retrieve an organization by its ID.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization
+   * @see https://docs.mollie.com/reference/get-organization
    */
-  public get(id: string): Promise<Organization>;
-  public get(id: string, callback: Callback<Organization>): void;
-  public get(id: string) {
+  public get(id: string, parameters?: GetParameters): Promise<Organization>;
+  public get(id: string, parameters: GetParameters, callback: Callback<Organization>): void;
+  public get(id: string, parameters?: GetParameters) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'organization');
-    return this.networkClient.get<OrganizationData, Organization>(`${pathSegment}/${id}`);
+    return this.networkClient.get<OrganizationData, Organization>(`${pathSegment}/${id}`, parameters);
   }
 
   /**
    * Retrieve the currently authenticated organization.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/organizations-api/current-organization
+   * @see https://docs.mollie.com/reference/get-current-organization
    */
   public getCurrent(): Promise<Organization>;
   public getCurrent(callback: Callback<Organization>): void;

--- a/src/binders/organizations/OrganizationsBinder.ts
+++ b/src/binders/organizations/OrganizationsBinder.ts
@@ -22,12 +22,16 @@ export default class OrganizationsBinder extends Binder<OrganizationData, Organi
    * @since 3.2.0
    * @see https://docs.mollie.com/reference/get-organization
    */
-  public get(id: string, parameters?: GetParameters): Promise<Organization>;
+  // Four overloads (rather than the params-only pair used by other binders) so the released
+  // `get(id, callback)` signature keeps compiling while `testmode` is also accepted.
+  public get(id: string): Promise<Organization>;
+  public get(id: string, callback: Callback<Organization>): void;
+  public get(id: string, parameters: GetParameters): Promise<Organization>;
   public get(id: string, parameters: GetParameters, callback: Callback<Organization>): void;
-  public get(id: string, parameters?: GetParameters) {
+  public get(id: string, parameters?: GetParameters | Callback<Organization>) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'organization');
-    return this.networkClient.get<OrganizationData, Organization>(`${pathSegment}/${id}`, parameters);
+    return this.networkClient.get<OrganizationData, Organization>(`${pathSegment}/${id}`, parameters as GetParameters | undefined);
   }
 
   /**

--- a/src/binders/organizations/parameters.ts
+++ b/src/binders/organizations/parameters.ts
@@ -1,0 +1,3 @@
+import { type TestModeParameter } from '../../types/parameters';
+
+export type GetParameters = TestModeParameter;

--- a/src/data/organizations/OrganizationHelper.ts
+++ b/src/data/organizations/OrganizationHelper.ts
@@ -1,0 +1,23 @@
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import type Nullable from '../../types/Nullable';
+import Helper from '../Helper';
+import type Organization from './Organizations';
+import { type OrganizationData } from './Organizations';
+
+export default class OrganizationHelper extends Helper<OrganizationData, Organization> {
+  constructor(
+    networkClient: TransformingNetworkClient,
+    protected readonly links: OrganizationData['_links'],
+  ) {
+    super(networkClient, links);
+  }
+
+  /**
+   * Returns the direct link to the organization in the Mollie Dashboard.
+   *
+   * @see https://docs.mollie.com/reference/get-organization?path=_links/dashboard#response
+   */
+  public getDashboardUrl(): Nullable<string> {
+    return this.links.dashboard?.href ?? null;
+  }
+}

--- a/src/data/organizations/Organizations.ts
+++ b/src/data/organizations/Organizations.ts
@@ -1,62 +1,81 @@
 import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
 import type Seal from '../../types/Seal';
-import { type Address, type Links, type Locale } from '../global';
-import Helper from '../Helper';
+import { type Address, type Links, type Locale, type Url } from '../global';
 import type Model from '../Model';
+import OrganizationHelper from './OrganizationHelper';
 
 export interface OrganizationData extends Model<'organization'> {
   /**
    * The name of the organization.
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=name#response
+   * @see https://docs.mollie.com/reference/get-organization?path=name#response
    */
   name: string;
   /**
+   * The email address associated with the organization.
+   *
+   * If the domain contains non-ASCII characters, encode it as Punycode per [RFC 3492](https://www.rfc-editor.org/rfc/rfc3492).
+   *
+   * @see https://docs.mollie.com/reference/get-organization?path=email#response
+   */
+  email: string;
+  /**
    * The preferred locale of the merchant which has been set in Mollie Dashboard.
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=locale#response
+   * @see https://docs.mollie.com/reference/get-organization?path=locale#response
    */
   locale: Locale;
   /**
    * The address of the organization.
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=address#response
+   * @see https://docs.mollie.com/reference/get-organization?path=address#response
    */
   address: OrganizationAdress;
   /**
    * The registration number of the organization at the (local) chamber of commerce.
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=registrationNumber#response
+   * @see https://docs.mollie.com/reference/get-organization?path=registrationNumber#response
    */
   registrationNumber: string;
   /**
-   * The VAT number of the organization, if based in the European Union. The VAT number has been checked with the [VIES](http://ec.europa.eu/taxation_customs/vies/) service by Mollie.
+   * The VAT number of the organization, if based in the European Union or in the United Kingdom. The VAT number has been checked with the [VIES](http://ec.europa.eu/taxation_customs/vies/) service by Mollie.
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=vatNumber#response
+   * The field is not present for merchants residing in other countries.
+   *
+   * @see https://docs.mollie.com/reference/get-organization?path=vatNumber#response
    */
   vatNumber: string;
   /**
-   * The organization's VAT regulation, if based in the European Union. Either `shifted` (VAT is shifted) or `dutch` (Dutch VAT rate).
+   * The organization's VAT regulation. Either `dutch` (Dutch VAT, for merchants based in The Netherlands), `british` (British VAT, for merchants based in the United Kingdom), or `shifted` (shifted VAT, for merchants in the European Union).
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=vatRegulation#response
+   * The field is not present for merchants residing in other countries.
+   *
+   * @see https://docs.mollie.com/reference/get-organization?path=vatRegulation#response
    */
   vatRegulation: string;
   /**
    * An object with several URL objects relevant to the organization. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/organizations-api/get-organization?path=_links#response
+   * @see https://docs.mollie.com/reference/get-organization?path=_links#response
    */
   _links: OrganizationLinks;
 }
 
 export type OrganizationAdress = Pick<Address, 'streetAndNumber' | 'postalCode' | 'city' | 'country'>;
 
-type Organization = Seal<OrganizationData, Helper<OrganizationData, Organization>>;
+type Organization = Seal<OrganizationData, OrganizationHelper>;
 
 export default Organization;
 
-export type OrganizationLinks = Links;
+export interface OrganizationLinks extends Links {
+  /**
+   * Direct link to the organization's Mollie dashboard.
+   *
+   * @see https://docs.mollie.com/reference/get-organization?path=_links/dashboard#response
+   */
+  dashboard?: Url;
+}
 
 export function transform(networkClient: TransformingNetworkClient, input: OrganizationData): Organization {
-  return Object.assign(Object.create(new Helper<OrganizationData, Organization>(networkClient, input._links)), input);
+  return Object.assign(Object.create(new OrganizationHelper(networkClient, input._links)), input);
 }

--- a/src/data/organizations/partner/data.ts
+++ b/src/data/organizations/partner/data.ts
@@ -58,7 +58,7 @@ export interface PartnerStatusData extends Model<'partner'> {
    */
   partnerContractExpiresAt?: string;
   /**
-   * An object with several URL objects relevant to the partner status.
+   * An object with several URL objects relevant to the partner status. Every URL object will contain an `href` and a `type` field.
    *
    * @see https://docs.mollie.com/reference/get-partner-status
    */

--- a/tests/unit/resources/organizations.test.ts
+++ b/tests/unit/resources/organizations.test.ts
@@ -23,6 +23,10 @@ const response = {
       href: 'https://docs.mollie.com/reference/v2/organizations-api/get-organization',
       type: 'text/html',
     },
+    dashboard: {
+      href: 'https://www.mollie.com/dashboard/org_12345678',
+      type: 'text/html',
+    },
   },
 };
 
@@ -47,6 +51,7 @@ function testOrganization(organization) {
     href: 'https://docs.mollie.com/reference/v2/organizations-api/get-organization',
     type: 'text/html',
   });
+  expect(organization.getDashboardUrl()).toBe('https://www.mollie.com/dashboard/org_12345678');
 }
 
 test('getOrganization', () => {
@@ -66,6 +71,20 @@ test('getCurrentOrganization', () => {
     const organization = await bluster(mollieClient.organizations.getCurrent.bind(mollieClient.organizations))();
 
     testOrganization(organization);
+  });
+});
+
+test('getDashboardUrl returns null when the organization has no dashboard link', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const responseWithoutDashboard = {
+      ...response,
+      _links: { self: response._links.self, documentation: response._links.documentation },
+    };
+    networkMocker.intercept('GET', '/organizations/org_12345678', 200, responseWithoutDashboard).twice();
+
+    const organization = await bluster(mollieClient.organizations.get.bind(mollieClient.organizations))('org_12345678');
+
+    expect(organization.getDashboardUrl()).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Syncs the **organizations** resource against the master Mollie OpenAPI spec (via `/sync-api organizations`). All changes are non-breaking; breaking corrections are deferred to v5 (#489).

## Changes

### Added
- `email` response field on `OrganizationData`.
- `_links.dashboard` URL, exposed through a new `getDashboardUrl()` helper (`OrganizationHelper`), consistent with the payments and orders resources.
- `testmode` query parameter on `organizations.get(id)` — relevant for organization-level (OAuth) credentials.

### Docs
- `vatRegulation` JSDoc now documents all three values (`dutch` / `british` / `shifted`); `vatNumber` notes UK applicability and absence for non-EU/UK merchants.
- `@see` links migrated to the modern `/reference/<slug>` format (including the stale `current-organization` → `get-current-organization`).

### Deferred (breaking → #489)
- Response-level optionality of `vatNumber` / `vatRegulation` / `locale`.
- Partner-status spurious `id` (would become `Model<'partner', undefined>`).

## Verification
- `yarn build:declarations`, ESLint and Prettier all clean.
- `tests/unit/resources/organizations.test.ts` → 3/3 pass.

## References
- https://docs.mollie.com/reference/get-organization
- https://docs.mollie.com/reference/get-current-organization
- https://docs.mollie.com/reference/get-partner-status
