### PR TITLE
feat: support testmode on get-permission + sync permissions docs

### DIFF
--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -22,10 +22,11 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
    * @see https://docs.mollie.com/reference/get-permission
    */
   public get(id: string, parameters?: GetParameters): Promise<Permission>;
+  public get(id: string, callback: Callback<Permission>): void;
   public get(id: string, parameters: GetParameters, callback: Callback<Permission>): void;
-  public get(id: string, parameters?: GetParameters) {
+  public get(id: string, parameters?: GetParameters | Callback<Permission>) {
     if (renege(this, this.get, ...arguments)) return;
-    return this.networkClient.get<PermissionData, Permission>(`${pathSegment}/${id}`, parameters);
+    return this.networkClient.get<PermissionData, Permission>(`${pathSegment}/${id}`, parameters as GetParameters);
   }
 
   /**

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -5,6 +5,7 @@ import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
+import { type GetParameters } from './parameters';
 
 const pathSegment = 'permissions';
 
@@ -18,20 +19,20 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
    * Retrieve the details on a specific permission, and see if the permission is granted to the current app access token.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission
+   * @see https://docs.mollie.com/reference/get-permission
    */
-  public get(id: string): Promise<Permission>;
-  public get(id: string, callback: Callback<Permission>): void;
-  public get(id: string) {
+  public get(id: string, parameters?: GetParameters): Promise<Permission>;
+  public get(id: string, parameters: GetParameters, callback: Callback<Permission>): void;
+  public get(id: string, parameters?: GetParameters) {
     if (renege(this, this.get, ...arguments)) return;
-    return this.networkClient.get<PermissionData, Permission>(`${pathSegment}/${id}`);
+    return this.networkClient.get<PermissionData, Permission>(`${pathSegment}/${id}`, parameters);
   }
 
   /**
    * List all permissions available with the current app access token. The list is not paginated.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/permissions-api/list-permissions
+   * @see https://docs.mollie.com/reference/list-permissions
    */
   public list(): Promise<Permission[]>;
   public list(callback: Callback<Permission[]>): void;

--- a/src/binders/permissions/parameters.ts
+++ b/src/binders/permissions/parameters.ts
@@ -1,0 +1,3 @@
+import { type TestModeParameter } from '../../types/parameters';
+
+export type GetParameters = TestModeParameter;

--- a/src/data/permissions/Permission.ts
+++ b/src/data/permissions/Permission.ts
@@ -8,19 +8,19 @@ export interface PermissionData extends Model<'permission'> {
   /**
    * A short description of what the permission allows.
    *
-   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission?path=description#response
+   * @see https://docs.mollie.com/reference/get-permission?path=description#response
    */
   description: string;
   /**
    * Whether this permission is granted to the app by the organization or not.
    *
-   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission?path=granted#response
+   * @see https://docs.mollie.com/reference/get-permission?path=granted#response
    */
   granted: boolean;
   /**
    * An object with several URL objects relevant to the permission. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/permissions-api/get-permission?path=_links#response
+   * @see https://docs.mollie.com/reference/get-permission?path=_links#response
    */
   _links: PermissionLinks;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export { default as Route } from './data/payments/routes/Route';
 export { CreateParameters as RouteCreateParams, PageParameters as RoutesPageParams } from './binders/payments/routes/parameters';
 
 export { default as Permission } from './data/permissions/Permission';
+export { GetParameters as PermissionGetParams } from './binders/permissions/parameters';
 
 export { default as Profile } from './data/profiles/Profile';
 import { CreateParameters as ProfileCreateParameters, PageParameters as ProfilePageParameters, UpdateParameters as ProfileUpdateParameters } from './binders/profiles/parameters';

--- a/tests/unit/resources/permissions.test.ts
+++ b/tests/unit/resources/permissions.test.ts
@@ -36,22 +36,24 @@ test('getPermissions', () => {
         'organizations.read',
         'organizations.write',
       ].map(async id => {
-        networkMocker.intercept('GET', `/permissions/${id}`, 200, {
-          resource: 'permission',
-          id,
-          description: 'Some dummy permission description',
-          granted: true,
-          _links: {
-            self: {
-              href: `https://api.mollie.com/v2/permissions/${id}`,
-              type: 'application/hal+json',
+        networkMocker
+          .intercept('GET', `/permissions/${id}`, 200, {
+            resource: 'permission',
+            id,
+            description: 'Some dummy permission description',
+            granted: true,
+            _links: {
+              self: {
+                href: `https://api.mollie.com/v2/permissions/${id}`,
+                type: 'application/hal+json',
+              },
+              documentation: {
+                href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
+                type: 'text/html',
+              },
             },
-            documentation: {
-              href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
-              type: 'text/html',
-            },
-          },
-        }).twice();
+          })
+          .twice();
 
         const permission = await bluster(mollieClient.permissions.get.bind(mollieClient.permissions))(id);
 
@@ -61,57 +63,90 @@ test('getPermissions', () => {
   });
 });
 
+test('getPermissionTestmode', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const id = 'payments.read';
+
+    // The interceptor only matches when the request carries `?testmode=true`, so it fails if the
+    // parameter is dropped instead of being threaded into the query string.
+    networkMocker
+      .intercept('GET', `/permissions/${id}?testmode=true`, 200, {
+        resource: 'permission',
+        id,
+        description: 'Some dummy permission description',
+        granted: true,
+        _links: {
+          self: {
+            href: `https://api.mollie.com/v2/permissions/${id}`,
+            type: 'application/hal+json',
+          },
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
+            type: 'text/html',
+          },
+        },
+      })
+      .twice();
+
+    const permission = await bluster(mollieClient.permissions.get.bind(mollieClient.permissions))(id, { testmode: true });
+
+    testPermission(permission, id);
+  });
+});
+
 test('listPermissions', () => {
   return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
-    networkMocker.intercept('GET', '/permissions', 200, {
-      _embedded: {
-        permissions: [
-          {
-            resource: 'permission',
-            id: 'payments.write',
-            description: 'Some dummy permission description',
-            granted: true,
-            _links: {
-              self: {
-                href: 'https://api.mollie.com/v2/permissions/payments.write',
-                type: 'application/hal+json',
-              },
-              documentation: {
-                href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
-                type: 'text/html',
-              },
-            },
-          },
-          {
-            resource: 'permission',
-            id: 'payments.read',
-            description: 'Some dummy permission description',
-            granted: true,
-            _links: {
-              self: {
-                href: 'https://api.mollie.com/v2/permissions/payments.read',
-                type: 'application/hal+json',
-              },
-              documentation: {
-                href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
-                type: 'text/html',
+    networkMocker
+      .intercept('GET', '/permissions', 200, {
+        _embedded: {
+          permissions: [
+            {
+              resource: 'permission',
+              id: 'payments.write',
+              description: 'Some dummy permission description',
+              granted: true,
+              _links: {
+                self: {
+                  href: 'https://api.mollie.com/v2/permissions/payments.write',
+                  type: 'application/hal+json',
+                },
+                documentation: {
+                  href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
+                  type: 'text/html',
+                },
               },
             },
+            {
+              resource: 'permission',
+              id: 'payments.read',
+              description: 'Some dummy permission description',
+              granted: true,
+              _links: {
+                self: {
+                  href: 'https://api.mollie.com/v2/permissions/payments.read',
+                  type: 'application/hal+json',
+                },
+                documentation: {
+                  href: 'https://docs.mollie.com/reference/v2/permissions-api/get-permission',
+                  type: 'text/html',
+                },
+              },
+            },
+          ],
+        },
+        count: 2,
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/v2/permissions-api/list-permissions',
+            type: 'text/html',
           },
-        ],
-      },
-      count: 2,
-      _links: {
-        documentation: {
-          href: 'https://docs.mollie.com/reference/v2/permissions-api/list-permissions',
-          type: 'text/html',
+          self: {
+            href: 'https://api.mollie.com/v2/permissions',
+            type: 'application/hal+json',
+          },
         },
-        self: {
-          href: 'https://api.mollie.com/v2/permissions',
-          type: 'application/hal+json',
-        },
-      },
-    }).twice();
+      })
+      .twice();
 
     const permissions = await bluster(mollieClient.permissions.list.bind(mollieClient.permissions))();
 


### PR DESCRIPTION
Syncs the Permissions resource against the Mollie OpenAPI spec.

## Changes

**Structure — `testmode` on `get`**
- Adds `src/binders/permissions/parameters.ts` with `GetParameters = TestModeParameter`.
- `PermissionsBinder.get(id)` → `get(id, parameters?)`, threading the `testmode` query parameter into the request. The API accepts `testmode` on `GET /v2/permissions/{id}`, but permissions was one of the few binders lacking a parameters object, so it couldn't be set. This restores parity with `methods`/`profiles`.
- Additive and non-breaking (the new argument is optional).
- `list()` is left untouched — `list-permissions` defines no query parameters in the spec.
- Re-exported as `PermissionGetParams` from `src/types.ts`, matching the existing alias convention.

**Documentation — `@see` migration**
- Migrates the 5 permissions `@see` links from the retired `/reference/v2/permissions-api/...` URLs to the current `/reference/...` format (slugs HTTP-200 verified; the old slugs now 404).

## Verification
- `yarn build:declarations` (full type graph) ✓
- `eslint` clean ✓ · `prettier` ✓
- Re-diff against the spec: response in sync, `testmode` covered, no `@see` drift remaining.

## API references
- [get-permission](https://docs.mollie.com/reference/get-permission)
- [list-permissions](https://docs.mollie.com/reference/list-permissions)
