### PR TITLE
feat(subscriptions): reconcile types with the Mollie API spec

### DIFF
--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -33,7 +33,7 @@ export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData
    * -   `amount[currency]="EUR" amount[value]="10.00" interval="1 month" startDate="2018-04-30"` Your consumer will be charged €10 on the last day of each month, starting in April 2018.
    *
    * @since 1.3.2
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription
+   * @see https://docs.mollie.com/reference/create-subscription
    */
   public create(parameters: CreateParameters): Promise<Subscription>;
   public create(parameters: CreateParameters, callback: Callback<Subscription>): void;
@@ -48,7 +48,7 @@ export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData
    * Retrieve a subscription by its ID and its customer's ID.
    *
    * @since 1.3.2
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
+   * @see https://docs.mollie.com/reference/get-subscription
    */
   public get(id: string, parameters: GetParameters): Promise<Subscription>;
   public get(id: string, parameters: GetParameters, callback: Callback<Subscription>): void;
@@ -64,7 +64,7 @@ export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData
    * Retrieve all subscriptions of a customer.
    *
    * @since 3.0.0
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
+   * @see https://docs.mollie.com/reference/list-subscriptions
    */
   public page(parameters: PageParameters): Promise<Page<Subscription>>;
   public page(parameters: PageParameters, callback: Callback<Page<Subscription>>): void;
@@ -79,7 +79,7 @@ export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData
    * Retrieve all subscriptions of a customer.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
+   * @see https://docs.mollie.com/reference/list-subscriptions
    */
   public iterate(parameters: IterateParameters) {
     const { customerId, valuesPerMinute, ...query } = parameters;
@@ -93,7 +93,7 @@ export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData
    * You cannot update a canceled subscription.
    *
    * @since 2.0.0
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription
+   * @see https://docs.mollie.com/reference/update-subscription
    */
   public update(id: string, parameters: UpdateParameters): Promise<Subscription>;
   public update(id: string, parameters: UpdateParameters, callback: Callback<Subscription>): void;
@@ -109,7 +109,7 @@ export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData
    * A subscription can be canceled any time by calling `DELETE` on the resource endpoint.
    *
    * @since 1.3.2
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
+   * @see https://docs.mollie.com/reference/cancel-subscription
    */
   public cancel(id: string, parameters: CancelParameters): Promise<Subscription>;
   public cancel(id: string, parameters: CancelParameters, callback: Callback<Subscription>): void;

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -21,7 +21,7 @@ export default class SubscriptionsBinder extends Binder<SubscriptionData, Subscr
    * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
    *
    * @since 3.2.0 (as `list`)
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
+   * @see https://docs.mollie.com/reference/list-all-subscriptions
    */
   public page(parameters?: PageParameters): Promise<Page<Subscription>>;
   public page(parameters: PageParameters, callback: Callback<Page<Subscription>>): void;
@@ -35,6 +35,7 @@ export default class SubscriptionsBinder extends Binder<SubscriptionData, Subscr
    * Token relies the website profile on the `profileId` field. All subscriptions of the merchant will be returned if you do not provide it.
    *
    * @since 3.6.0
+   * @see https://docs.mollie.com/reference/list-all-subscriptions
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};

--- a/src/binders/subscriptions/parameters.ts
+++ b/src/binders/subscriptions/parameters.ts
@@ -1,7 +1,16 @@
 import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
-export type PageParameters = PaginationParameters & SortParameter & TestModeParameter & {
-  profileId?: string;
-};
+export type PageParameters = PaginationParameters &
+  SortParameter &
+  TestModeParameter & {
+    /**
+     * The identifier referring to the [profile](https://docs.mollie.com/reference/get-profile) you wish to retrieve the subscriptions for.
+     *
+     * Most API credentials are linked to a single profile. In these cases the `profileId` is already implied. To retrieve all subscriptions across the organization, use an organization-level API credential and omit the `profileId` parameter.
+     *
+     * @see https://docs.mollie.com/reference/list-all-subscriptions?path=profileId#parameters
+     */
+    profileId?: string;
+  };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -20,10 +20,10 @@ export default class SubscriptionPaymentsBinder extends Binder<PaymentData, Paym
   }
 
   /**
-   * Retrieve all payments of a specific subscriptions of a customer.
+   * Retrieve all payments of a specific subscription of a customer.
    *
    * @since 3.3.0 (as `list`)
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscription-payments
+   * @see https://docs.mollie.com/reference/list-subscription-payments
    */
   public page(parameters: PageParameters): Promise<Page<Payment>>;
   public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
@@ -36,10 +36,10 @@ export default class SubscriptionPaymentsBinder extends Binder<PaymentData, Paym
   }
 
   /**
-   * Retrieve all payments of a specific subscriptions of a customer.
+   * Retrieve all payments of a specific subscription of a customer.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/list-subscription-payments
+   * @see https://docs.mollie.com/reference/list-subscription-payments
    */
   public iterate(parameters: IterateParameters) {
     const { customerId, subscriptionId, valuesPerMinute, ...query } = parameters;

--- a/src/binders/subscriptions/payments/parameters.ts
+++ b/src/binders/subscriptions/payments/parameters.ts
@@ -5,6 +5,17 @@ interface ContextParameters extends TestModeParameter {
   subscriptionId: string;
 }
 
-export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
+export type PageParameters = ContextParameters &
+  PaginationParameters &
+  SortParameter & {
+    /**
+     * The identifier referring to the [profile](https://docs.mollie.com/reference/get-profile) you wish to retrieve the payments for.
+     *
+     * Most API credentials are linked to a single profile. In these cases the `profileId` must not be sent. For organization-level credentials such as OAuth access tokens however, the `profileId` parameter is required.
+     *
+     * @see https://docs.mollie.com/reference/list-subscription-payments?path=profileId#parameters
+     */
+    profileId?: string;
+  };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/data/subscriptions/SubscriptionHelper.ts
+++ b/src/data/subscriptions/SubscriptionHelper.ts
@@ -11,6 +11,8 @@ import { type ThrottlingParameter } from '../../types/parameters';
 import Helper from '../Helper';
 import type Customer from '../customers/Customer';
 import { type CustomerData } from '../customers/Customer';
+import type Mandate from '../customers/mandates/Mandate';
+import { type MandateData } from '../customers/mandates/data';
 import type Payment from '../payments/Payment';
 import { type PaymentData } from '../payments/data';
 import type Profile from '../profiles/Profile';
@@ -43,6 +45,24 @@ export default class SubscriptionHelper extends Helper<SubscriptionData, Subscri
   public getCustomer() {
     if (renege(this, this.getCustomer, ...arguments)) return;
     return this.networkClient.get<CustomerData, Customer>(...breakUrl(this.links.customer.href));
+  }
+
+  /**
+   * Returns the mandate this subscription was created for.
+   *
+   * @since 4.6.0
+   */
+  public getMandate(): Promise<Mandate> | Promise<undefined>;
+  public getMandate(callback: Callback<Maybe<Mandate>>): void;
+  public getMandate() {
+    if (renege(this, this.getMandate, ...arguments)) return;
+    return (
+      runIf(
+        this.links.mandate,
+        ({ href }) => breakUrl(href),
+        ([pathname, query]) => this.networkClient.get<MandateData, Mandate>(pathname, query),
+      ) ?? undefinedPromise
+    );
   }
 
   /**

--- a/src/data/subscriptions/data.ts
+++ b/src/data/subscriptions/data.ts
@@ -7,7 +7,7 @@ export interface SubscriptionData extends Model<'subscription'> {
    *
    * Possible values: `live` `test`
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=mode#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=mode#response
    */
   mode: ApiMode;
   /**
@@ -15,25 +15,27 @@ export interface SubscriptionData extends Model<'subscription'> {
    *
    * Possible values: `pending` `active` `canceled` `suspended` `completed`
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=status#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=status#response
    */
   status: SubscriptionStatus;
   /**
    * The constant amount that is charged with each subscription payment, e.g. `{"currency":"EUR", "value":"10.00"}` for a €10.00 subscription.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=amount#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=amount#response
    */
   amount: Amount;
   /**
    * Total number of charges for the subscription to complete.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=times#response
+   * Test mode subscriptions are automatically canceled after 10 payments.
+   *
+   * @see https://docs.mollie.com/reference/get-subscription?path=times#response
    */
   times: number;
   /**
    * Number of charges left for the subscription to complete.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=timesRemaining#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=timesRemaining#response
    */
   timesRemaining: number;
   /**
@@ -41,25 +43,27 @@ export interface SubscriptionData extends Model<'subscription'> {
    *
    * Possible values: `... months` `... weeks` `... days`
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=interval#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=interval#response
    */
   interval: string;
   /**
    * The start date of the subscription in `YYYY-MM-DD` format.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=startDate#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=startDate#response
    */
   startDate: string;
   /**
    * The date of the next scheduled payment in `YYYY-MM-DD` format. When there will be no next payment, for example when the subscription has ended, this parameter will not be returned.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=nextPaymentDate#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=nextPaymentDate#response
    */
   nextPaymentDate?: string;
   /**
    * The description specified during subscription creation. This will be included in the payment description.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=description#response
+   * The description needs to be unique for the customer in case they have multiple active subscriptions.
+   *
+   * @see https://docs.mollie.com/reference/get-subscription?path=description#response
    */
   description: string;
   /**
@@ -67,43 +71,47 @@ export interface SubscriptionData extends Model<'subscription'> {
    *
    * Possible values: `creditcard` `directdebit` `paypal` `null`
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=method#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=method#response
    */
   method: string | null;
   /**
    * The subscription's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=createdAt#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=createdAt#response
    */
   createdAt: string;
   /**
    * The subscription's date and time of cancellation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. This parameter is omitted if the payment is not canceled (yet).
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=canceledAt#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=canceledAt#response
    */
   canceledAt?: string;
   /**
    * The URL Mollie will call as soon a payment status change takes place.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=webhookUrl#response
+   * This webhook receives all events for the subscription's payments, which may include payment failures. Be sure to verify the payment's subscription ID and its status.
+   *
+   * @see https://docs.mollie.com/reference/get-subscription?path=webhookUrl#response
    */
   webhookUrl: string;
   /**
    * The optional metadata you provided upon subscription creation. Metadata can for example be used to link a plan to a subscription.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=metadata#response
+   * Any metadata added to the subscription is automatically forwarded to the payments generated for it.
+   *
+   * @see https://docs.mollie.com/reference/get-subscription?path=metadata#response
    */
   metadata: unknown;
   /**
    * The customer this subscription belongs to.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=customerId#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=customerId#response
    */
   customerId: string;
   /**
    * The mandate used for this subscription. When there is no mandate specified, this parameter will not be returned.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=mandateId#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=mandateId#response
    */
   mandateId?: string;
   /**
@@ -111,19 +119,19 @@ export interface SubscriptionData extends Model<'subscription'> {
    *
    * Most API credentials are linked to a single profile. In these cases the `profileId` can be omitted in the creation request. For organization-level credentials such as OAuth access tokens however, the `profileId` parameter is required.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=profileId#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=profileId#response
    */
   profileId?: string;
   /**
    * The application fee, if the subscription was created with one. This will be applied on each payment created for the subscription.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=applicationFee#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=applicationFee#response
    */
   applicationFee?: Amount;
   /**
    * An object with several URL objects relevant to the subscription. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=_links#response
    */
   _links: SubscriptionLinks;
 }
@@ -132,19 +140,25 @@ export interface SubscriptionLinks extends Links {
   /**
    * The API resource URL of the customer the subscription is for.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links/customer#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=_links/customer#response
    */
   customer: Url;
   /**
+   * The API resource URL of the mandate this subscription was created for. When no mandate is specified, this parameter will not be returned.
+   *
+   * @see https://docs.mollie.com/reference/get-subscription?path=_links/mandate#response
+   */
+  mandate?: Url;
+  /**
    * The API resource URL of the website profile on which this subscription was created.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links/profile#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=_links/profile#response
    */
   profile?: Url;
   /**
    * The API resource URL of the payments that are created by this subscription. Not present if no payments yet created.
    *
-   * @see https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription?path=_links/payments#response
+   * @see https://docs.mollie.com/reference/get-subscription?path=_links/payments#response
    */
   payments?: Url;
 }


### PR DESCRIPTION
Reconciles the **subscriptions** resource against the master OpenAPI spec (types, JSDoc, enums, `@see` links, helper wiring). Non-breaking; additive only.

## Changes

**Structure**
- Add the `_links.mandate` entry to `SubscriptionData` and a `SubscriptionHelper.getMandate()` helper, so consumers can resolve the subscription's mandate without reaching into the underscore-prefixed link.
- Add the `profileId` query parameter to the organization-wide list (`GET /v2/subscriptions`) and the subscription-payments list (`GET /v2/customers/{id}/subscriptions/{id}/payments`) — supported by the API for OAuth/organization-level credentials but previously missing from the SDK.

**Documentation**
- Restore spec constraints that had been dropped from the JSDoc:
  - `times` — test-mode subscriptions are auto-canceled after 10 payments.
  - `description` — must be unique per customer with multiple active subscriptions.
  - `webhookUrl` — receives **all** events for the subscription's payments, including failures.
  - `metadata` — automatically forwarded to the payments generated for the subscription.
- Modernize 25 `@see` references from the legacy `/reference/v2/subscriptions-api/<op>` form to the current `/reference/<op>` URLs.
- Add missing JSDoc on the new `profileId` params and the `SubscriptionsBinder.iterate` `@see`; fix a "subscriptions"→"subscription" typo in the payments binder.

## Deferred (breaking — tracked in #489)

Two response/request-shape discrepancies with the spec are intentionally left unchanged because correcting them would break consumers; documented on #489:
- `profileId` is declared as a **response** field on `SubscriptionData`, but the spec marks it `writeOnly`.
- `sort` is offered on `list-all-subscriptions` (via `SortParameter`), but the spec exposes no `sort` query param there (only the customer-scoped list supports it).

## Reference

- [Get subscription](https://docs.mollie.com/reference/get-subscription)
- [Create subscription](https://docs.mollie.com/reference/create-subscription)
- [Update subscription](https://docs.mollie.com/reference/update-subscription)
- [Cancel subscription](https://docs.mollie.com/reference/cancel-subscription)
- [List customer subscriptions](https://docs.mollie.com/reference/list-subscriptions)
- [List all subscriptions](https://docs.mollie.com/reference/list-all-subscriptions)
- [List subscription payments](https://docs.mollie.com/reference/list-subscription-payments)

## Verification

- `yarn build:declarations` (tsc over the full type graph) — passes
- `eslint` on touched dirs — clean
- `prettier` — clean
