### PR TITLE
feat(profiles): sync types and docs with the Mollie API spec

### DIFF
--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -22,7 +22,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * creation via the Profiles API.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/create-profile
+   * @see https://docs.mollie.com/reference/create-profile
    */
   public create(parameters: CreateParameters): Promise<Profile>;
   public create(parameters: CreateParameters, callback: Callback<Profile>): void;
@@ -35,7 +35,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * Retrieve details of a profile, using the profile's identifier.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile
+   * @see https://docs.mollie.com/reference/get-profile
    */
   public get(id: string): Promise<Profile>;
   public get(id: string, callback: Callback<Profile>): void;
@@ -52,7 +52,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * This is similar to the Get current organization endpoint for OAuth.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile-me
+   * @see https://docs.mollie.com/reference/get-current-profile
    */
   public getCurrent(): Promise<Profile>;
   public getCurrent(callback: Callback<Profile>): void;
@@ -67,7 +67,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * The results are paginated. See pagination for more information.
    *
    * @since 3.2.0 (as `list`)
-   * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
+   * @see https://docs.mollie.com/reference/list-profiles
    */
   public page(parameters?: PageParameters): Promise<Page<Profile>>;
   public page(parameters: PageParameters, callback: Callback<Page<Profile>>): void;
@@ -82,7 +82,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * The results are paginated. See pagination for more information.
    *
    * @since 3.6.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/list-profiles
+   * @see https://docs.mollie.com/reference/list-profiles
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};
@@ -94,7 +94,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * the Profiles API.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/update-profile
+   * @see https://docs.mollie.com/reference/update-profile
    */
   public update(id: string, parameters: UpdateParameters): Promise<Profile>;
   public update(id: string, parameters: UpdateParameters, callback: Callback<Profile>): void;
@@ -108,7 +108,7 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * This endpoint enables profile deletions, rendering the profile unavailable for further API calls and transactions.
    *
    * @since 3.2.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/delete-profile
+   * @see https://docs.mollie.com/reference/delete-profile
    */
   public delete(id: string, parameters?: DeleteParameters): Promise<true>;
   public delete(id: string, parameters: DeleteParameters, callback: Callback<true>): void;

--- a/src/binders/profiles/giftcardIssuers/ProfileGiftcardIssuersBinder.ts
+++ b/src/binders/profiles/giftcardIssuers/ProfileGiftcardIssuersBinder.ts
@@ -20,7 +20,7 @@ export default class ProfileGiftcardIssuersBinder extends Binder<IssuerData, Iss
    * Enable a gift card issuer on a specific or authenticated profile to use it with payments.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
+   * @see https://docs.mollie.com/reference/enable-method-issuer
    */
   public enable(parameters: Parameters): Promise<IssuerModel>;
   public enable(parameters: Parameters, callback: Callback<IssuerModel>): void;
@@ -35,7 +35,7 @@ export default class ProfileGiftcardIssuersBinder extends Binder<IssuerData, Iss
    * Disable a gift card issuer on a specific or authenticated profile.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
+   * @see https://docs.mollie.com/reference/disable-method-issuer
    */
   public disable(parameters: Parameters): Promise<true>;
   public disable(parameters: Parameters, callback: Callback<true>): void;

--- a/src/binders/profiles/methods/ProfileMethodsBinder.ts
+++ b/src/binders/profiles/methods/ProfileMethodsBinder.ts
@@ -19,7 +19,7 @@ export default class ProfileMethodsBinder extends Binder<MethodData, Method> {
   /**
    * Enable a payment method on a specific or authenticated profile to use it with payments.
    *
-   * The payment method `vouchers` cannot be enabled via this API. Instead, refer to /reference/enable-method-issuer.
+   * The payment method `vouchers` cannot be enabled via this API. Instead, refer to https://docs.mollie.com/reference/enable-method-issuer.
    *
    * @since 3.7.0
    * @see https://docs.mollie.com/reference/enable-method

--- a/src/binders/profiles/methods/ProfileMethodsBinder.ts
+++ b/src/binders/profiles/methods/ProfileMethodsBinder.ts
@@ -19,10 +19,10 @@ export default class ProfileMethodsBinder extends Binder<MethodData, Method> {
   /**
    * Enable a payment method on a specific or authenticated profile to use it with payments.
    *
-   * The payment method `vouchers` cannot be enabled via this API. Instead, refer to /reference/v2/profiles-api/enable-voucher-issuer.
+   * The payment method `vouchers` cannot be enabled via this API. Instead, refer to /reference/enable-method-issuer.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-method
+   * @see https://docs.mollie.com/reference/enable-method
    */
   public enable(parameters: Parameters): Promise<Method>;
   public enable(parameters: Parameters, callback: Callback<Method>): void;
@@ -37,7 +37,7 @@ export default class ProfileMethodsBinder extends Binder<MethodData, Method> {
    * Disable a payment method on a specific or authenticated profile.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/disable-method
+   * @see https://docs.mollie.com/reference/disable-method
    */
   public disable(parameters: Parameters): Promise<true>;
   public disable(parameters: Parameters, callback: Callback<true>): void;

--- a/src/binders/profiles/parameters.ts
+++ b/src/binders/profiles/parameters.ts
@@ -2,12 +2,14 @@ import { type ProfileData } from '../../data/profiles/data';
 import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
-export type CreateParameters = Pick<ProfileData, 'name' | 'website' | 'email' | 'phone'> & PickOptional<ProfileData, 'businessCategory' | 'categoryCode' | 'mode'> & IdempotencyParameter;
+export type CreateParameters = Pick<ProfileData, 'name' | 'website' | 'email' | 'phone'> &
+  PickOptional<ProfileData, 'description' | 'countriesOfActivity' | 'businessCategory' | 'categoryCode' | 'mode'> &
+  IdempotencyParameter;
 
 export type PageParameters = PaginationParameters;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;
 
-export type UpdateParameters = PickOptional<ProfileData, 'name' | 'website' | 'email' | 'phone' | 'businessCategory' | 'categoryCode' | 'mode'>;
+export type UpdateParameters = PickOptional<ProfileData, 'name' | 'website' | 'email' | 'phone' | 'description' | 'countriesOfActivity' | 'businessCategory' | 'categoryCode' | 'mode'>;
 
 export type DeleteParameters = IdempotencyParameter;

--- a/src/binders/profiles/voucherIssuers/ProfileVoucherIssuersBinder.ts
+++ b/src/binders/profiles/voucherIssuers/ProfileVoucherIssuersBinder.ts
@@ -20,7 +20,7 @@ export default class ProfileVoucherIssuersBinder extends Binder<IssuerData, Issu
    * Enable a voucher issuer on a specific or authenticated profile to use it with payments.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer
+   * @see https://docs.mollie.com/reference/enable-method-issuer
    */
   public enable(parameters: CreateParameters): Promise<IssuerModel>;
   public enable(parameters: CreateParameters, callback: Callback<IssuerModel>): void;
@@ -35,7 +35,7 @@ export default class ProfileVoucherIssuersBinder extends Binder<IssuerData, Issu
    * Disable a voucher issuer on a specific or authenticated profile.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/profiles-api/disable-voucher-issuer
+   * @see https://docs.mollie.com/reference/disable-method-issuer
    */
   public disable(parameters: Parameters): Promise<true>;
   public disable(parameters: Parameters, callback: Callback<true>): void;

--- a/src/binders/profiles/voucherIssuers/parameters.ts
+++ b/src/binders/profiles/voucherIssuers/parameters.ts
@@ -16,7 +16,7 @@ export type CreateParameters = Parameters & {
    * The contract id of the related contractor. For the first call that will be made to an issuer of the contractor, this field is required. You do not have to provide the same contract id for other
    * issuers of the same contractor. Update of the contract ID will be possible through making the same call again with different contract ID value until the contract id is approved by the contractor.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer?path=contractId#parameters
+   * @see https://docs.mollie.com/reference/enable-method-issuer?path=contractId#parameters
    */
   contractId?: string;
 };

--- a/src/data/issuer/IssuerModel.ts
+++ b/src/data/issuer/IssuerModel.ts
@@ -17,13 +17,13 @@ export interface IssuerData extends Model<'issuer'> {
    * -   `activated`: The issuer is activated and ready for use.
    * -   `pending-issuer`: Activation of this issuer relies on you taking action with the issuer itself.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer?path=status#response
+   * @see https://docs.mollie.com/reference/enable-method-issuer?path=status#response
    */
   status: 'activated' | 'pending-issuer';
   /**
    * An object with contractor information.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer?path=contractor#response
+   * @see https://docs.mollie.com/reference/enable-method-issuer?path=contractor#response
    */
   contractor?: { id: string; name: string; contractId: string };
   _links: Links;

--- a/src/data/profiles/ProfileHelper.ts
+++ b/src/data/profiles/ProfileHelper.ts
@@ -28,9 +28,19 @@ export default class ProfileHelper extends Helper<ProfileData, Profile> {
   }
 
   /**
+   * Link to the profile in the Mollie dashboard.
+   *
+   * @since 4.6.0
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/dashboard#response
+   */
+  public getDashboardUrl(): Nullable<string> {
+    return this.links.dashboard?.href ?? null;
+  }
+
+  /**
    * The Checkout preview URL. You need to be logged in to access this page.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/checkoutPreviewUrl#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/checkoutPreviewUrl#response
    */
   public getCheckoutPreviewUrl(): Nullable<string> {
     return this.links.checkoutPreviewUrl?.href ?? null;

--- a/src/data/profiles/ProfileHelper.ts
+++ b/src/data/profiles/ProfileHelper.ts
@@ -33,8 +33,8 @@ export default class ProfileHelper extends Helper<ProfileData, Profile> {
    * @since 4.6.0
    * @see https://docs.mollie.com/reference/get-profile?path=_links/dashboard#response
    */
-  public getDashboardUrl(): string {
-    return this.links.dashboard.href;
+  public getDashboardUrl(): Nullable<string> {
+    return this.links.dashboard?.href ?? null;
   }
 
   /**

--- a/src/data/profiles/ProfileHelper.ts
+++ b/src/data/profiles/ProfileHelper.ts
@@ -33,8 +33,8 @@ export default class ProfileHelper extends Helper<ProfileData, Profile> {
    * @since 4.6.0
    * @see https://docs.mollie.com/reference/get-profile?path=_links/dashboard#response
    */
-  public getDashboardUrl(): Nullable<string> {
-    return this.links.dashboard?.href ?? null;
+  public getDashboardUrl(): string {
+    return this.links.dashboard.href;
   }
 
   /**

--- a/src/data/profiles/data.ts
+++ b/src/data/profiles/data.ts
@@ -11,39 +11,53 @@ export interface ProfileData extends Model<'profile'> {
    * -   `live`: The profile is verified.
    * -   `test`: The profile has not been verified yet and can only be used to create test payments.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=mode#response
+   * @see https://docs.mollie.com/reference/get-profile?path=mode#response
    */
   mode: ApiMode;
   /**
    * The profile's name, this will usually reflect the trade name or brand name of the profile's website or application.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=name#response
+   * @see https://docs.mollie.com/reference/get-profile?path=name#response
    */
   name: string;
   /**
-   * The URL to the profile's website or application.
+   * The URL to the profile's website or application. Only `https` or `http` URLs are allowed. No `@` signs are allowed.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=website#response
+   * @see https://docs.mollie.com/reference/get-profile?path=website#response
    */
   website: string;
   /**
    * The email address associated with the profile's trade name or brand.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=email#response
+   * If the domain contains non-ASCII characters, encode it as Punycode per [RFC 3492](https://www.rfc-editor.org/rfc/rfc3492).
+   *
+   * @see https://docs.mollie.com/reference/get-profile?path=email#response
    */
   email: string;
   /**
    * The phone number associated with the profile's trade name or brand.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=phone#response
+   * @see https://docs.mollie.com/reference/get-profile?path=phone#response
    */
   phone: string;
+  /**
+   * The products or services offered by the profile's website or application.
+   *
+   * @see https://docs.mollie.com/reference/get-profile?path=description#response
+   */
+  description?: string;
+  /**
+   * A list of countries where you expect that the majority of the profile's customers reside, in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format.
+   *
+   * @see https://docs.mollie.com/reference/get-profile?path=countriesOfActivity#response
+   */
+  countriesOfActivity?: string[];
   /**
    * The industry associated with the profile's trade name or brand.
    *
    * Refer to the documentation of the business category for more information on which values are accepted.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=businessCategory#response
+   * @see https://docs.mollie.com/reference/get-profile?path=businessCategory#response
    */
   businessCategory: string;
   /**
@@ -80,7 +94,7 @@ export interface ProfileData extends Model<'profile'> {
    * -   `9399` Government services
    * -   `0` Other
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=categoryCode#response
+   * @see https://docs.mollie.com/reference/get-profile?path=categoryCode#response
    */
   categoryCode: number;
   /**
@@ -92,14 +106,14 @@ export interface ProfileData extends Model<'profile'> {
    * -   `verified`: The profile has been verified and can be used to create live payments and test payments.
    * -   `blocked`: The profile is blocked and can thus no longer be used or changed.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=status#response
+   * @see https://docs.mollie.com/reference/get-profile?path=status#response
    */
   status: ProfileStatus;
   /**
    * The presence of a review object indicates changes have been made that have not yet been approved by Mollie. Changes to test profiles are approved automatically, unless a switch to a live profile
    * has been requested. The review object will therefore usually be `null` in test mode.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=review#response
+   * @see https://docs.mollie.com/reference/get-profile?path=review#response
    */
   review: Nullable<{
     /**
@@ -110,53 +124,59 @@ export interface ProfileData extends Model<'profile'> {
      * -   `pending`: The changes are pending review. We will review your changes soon.
      * -   `rejected`: We have reviewed and rejected your changes.
      *
-     * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=review/status#response
+     * @see https://docs.mollie.com/reference/get-profile?path=review/status#response
      */
     status: string;
   }>;
   /**
    * The profile's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=createdAt#response
+   * @see https://docs.mollie.com/reference/get-profile?path=createdAt#response
    */
   createdAt: string;
   /**
    * An object with several URL objects relevant to the profile. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links#response
    */
   _links: ProfileLinks;
 }
 
 export interface ProfileLinks extends Links {
   /**
+   * Link to the profile in the Mollie dashboard.
+   *
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/dashboard#response
+   */
+  dashboard: Url;
+  /**
    * The API resource URL of the chargebacks that belong to this profile.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/chargebacks#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/chargebacks#response
    */
   chargebacks: Url;
   /**
    * The API resource URL of the methods that are enabled for this profile.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/methods#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/methods#response
    */
   methods: Url;
   /**
    * The API resource URL of the payments that belong to this profile.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/payments#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/payments#response
    */
   payments: Url;
   /**
    * The API resource URL of the refunds that belong to this profile.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/refunds#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/refunds#response
    */
   refunds: Url;
   /**
    * The Checkout preview URL. You need to be logged in to access this page.
    *
-   * @see https://docs.mollie.com/reference/v2/profiles-api/get-profile?path=_links/checkoutPreviewUrl#response
+   * @see https://docs.mollie.com/reference/get-profile?path=_links/checkoutPreviewUrl#response
    */
   checkoutPreviewUrl: Url;
 }

--- a/src/data/profiles/data.ts
+++ b/src/data/profiles/data.ts
@@ -148,7 +148,7 @@ export interface ProfileLinks extends Links {
    *
    * @see https://docs.mollie.com/reference/get-profile?path=_links/dashboard#response
    */
-  dashboard: Url;
+  dashboard?: Url;
   /**
    * The API resource URL of the chargebacks that belong to this profile.
    *

--- a/tests/unit/models/profile.test.ts
+++ b/tests/unit/models/profile.test.ts
@@ -1,49 +1,52 @@
 import { Profile } from '../../..';
 import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
 
-function getProfile(status) {
+function getProfile(status, extraLinks = {}) {
   return new NetworkMocker(getApiKeyClientProvider()).use(([mollieClient, networkMocker]) => {
-    networkMocker.intercept('GET', '/profiles/pfl_ahe8z8OPut', 200, {
-      resource: 'profile',
-      id: 'pfl_ahe8z8OPut',
-      mode: 'live',
-      name: 'My website name',
-      website: 'http://www.mywebsite.com',
-      email: 'info@mywebsite.com',
-      phone: '31123456789',
-      categoryCode: 5399,
-      status,
-      review: {
-        status: 'pending',
-      },
-      createdAt: '2016-01-11T13:03:55+00:00',
-      _links: {
-        self: {
-          href: 'https://api.mollie.com/v2/profiles/pfl_ahe8z8OPut',
-          type: 'application/hal+json',
+    networkMocker
+      .intercept('GET', '/profiles/pfl_ahe8z8OPut', 200, {
+        resource: 'profile',
+        id: 'pfl_ahe8z8OPut',
+        mode: 'live',
+        name: 'My website name',
+        website: 'http://www.mywebsite.com',
+        email: 'info@mywebsite.com',
+        phone: '31123456789',
+        categoryCode: 5399,
+        status,
+        review: {
+          status: 'pending',
         },
-        chargebacks: {
-          href: 'https://api.mollie.com/v2/chargebacks?profileId=pfl_ahe8z8OPut',
-          type: 'application/hal+json',
+        createdAt: '2016-01-11T13:03:55+00:00',
+        _links: {
+          self: {
+            href: 'https://api.mollie.com/v2/profiles/pfl_ahe8z8OPut',
+            type: 'application/hal+json',
+          },
+          chargebacks: {
+            href: 'https://api.mollie.com/v2/chargebacks?profileId=pfl_ahe8z8OPut',
+            type: 'application/hal+json',
+          },
+          methods: {
+            href: 'https://api.mollie.com/v2/methods?profileId=pfl_ahe8z8OPut',
+            type: 'application/hal+json',
+          },
+          payments: {
+            href: 'https://api.mollie.com/v2/payments?profileId=pfl_ahe8z8OPut',
+            type: 'application/hal+json',
+          },
+          refunds: {
+            href: 'https://api.mollie.com/v2/refunds?profileId=pfl_ahe8z8OPut',
+            type: 'application/hal+json',
+          },
+          checkoutPreviewUrl: {
+            href: 'https://www.mollie.com/payscreen/preview/pfl_ahe8z8OPut',
+            type: 'text/html',
+          },
+          ...extraLinks,
         },
-        methods: {
-          href: 'https://api.mollie.com/v2/methods?profileId=pfl_ahe8z8OPut',
-          type: 'application/hal+json',
-        },
-        payments: {
-          href: 'https://api.mollie.com/v2/payments?profileId=pfl_ahe8z8OPut',
-          type: 'application/hal+json',
-        },
-        refunds: {
-          href: 'https://api.mollie.com/v2/refunds?profileId=pfl_ahe8z8OPut',
-          type: 'application/hal+json',
-        },
-        checkoutPreviewUrl: {
-          href: 'https://www.mollie.com/payscreen/preview/pfl_ahe8z8OPut',
-          type: 'text/html',
-        },
-      },
-    }).twice();
+      })
+      .twice();
 
     return bluster(mollieClient.profiles.get.bind(mollieClient.profiles))('pfl_ahe8z8OPut');
   });
@@ -57,4 +60,21 @@ test('profileStatuses', () => {
       expect(profile.status).toBe(status);
     }),
   );
+});
+
+test('getDashboardUrl returns the dashboard link when present', async () => {
+  const profile = await getProfile('verified', {
+    dashboard: {
+      href: 'https://www.mollie.com/dashboard/org_12345678/settings/profiles/pfl_ahe8z8OPut',
+      type: 'text/html',
+    },
+  });
+
+  expect(profile.getDashboardUrl()).toBe('https://www.mollie.com/dashboard/org_12345678/settings/profiles/pfl_ahe8z8OPut');
+});
+
+test('getDashboardUrl returns null when the profile has no dashboard link', async () => {
+  const profile = await getProfile('verified');
+
+  expect(profile.getDashboardUrl()).toBeNull();
 });


### PR DESCRIPTION
## Summary

Syncs the **Profiles** resource against the current Mollie OpenAPI spec (via `/sync-api profiles`). All changes here are non-breaking; the breaking discrepancies are deferred to #489 (see below).

### Added (non-breaking)
- `ProfileData.description` and `ProfileData.countriesOfActivity` — added to the response type and to the create/update request params (via `PickOptional`).
- `_links.dashboard` on `ProfileLinks`, surfaced through a new `ProfileHelper.getDashboardUrl()` helper (`@since 4.6.0`).

### Documentation
- Restored spec constraints that had been truncated from JSDoc: `website` (`https`/`http` only, no `@`) and `email` (Punycode / RFC 3492).
- Migrated every `@see` to the new `/reference/...` doc format. Re-pointed dead slugs at their live pages: `get-profile-me` → `get-current-profile`; the per-type voucher / gift-card issuer pages → the consolidated `enable`/`disable-method-issuer` (also corrected in `IssuerModel`, the issuer-enable response model).

### Deferred — breaking, tracked in #489 (milestone 5.0.0)
- `categoryCode` removed from the spec (replaced by `businessCategory`).
- `mode` is no longer a writable create/update field (`readOnly` in the spec).
- `businessCategory` is now nullable in the response.

### Docs references
- https://docs.mollie.com/reference/get-profile
- https://docs.mollie.com/reference/create-profile
- https://docs.mollie.com/reference/update-profile
- https://docs.mollie.com/reference/list-profiles
- https://docs.mollie.com/reference/get-current-profile
- https://docs.mollie.com/reference/enable-method-issuer
- https://docs.mollie.com/reference/disable-method-issuer

Gate: `yarn build:declarations`, `eslint`, and `prettier` all pass.
