### PR TITLE
feat: add Invoices API support

### DIFF
--- a/src/binders/invoices/InvoicesBinder.ts
+++ b/src/binders/invoices/InvoicesBinder.ts
@@ -1,0 +1,61 @@
+import { type InvoiceData } from '../../data/invoices/data';
+import type Invoice from '../../data/invoices/Invoice';
+import type Page from '../../data/page/Page';
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import alias from '../../plumbing/alias';
+import assertWellFormedId from '../../plumbing/assertWellFormedId';
+import renege from '../../plumbing/renege';
+import type Callback from '../../types/Callback';
+import Binder from '../Binder';
+import { type IterateParameters, type PageParameters } from './parameters';
+
+const pathSegment = 'invoices';
+
+export default class InvoicesBinder extends Binder<InvoiceData, Invoice> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+    alias(this, { page: ['all', 'list'] });
+  }
+
+  /**
+   * Retrieve a single invoice by its ID.
+   *
+   * @since 4.6.0
+   * @see https://docs.mollie.com/reference/get-invoice
+   */
+  public get(id: string): Promise<Invoice>;
+  public get(id: string, callback: Callback<Invoice>): void;
+  public get(id: string) {
+    if (renege(this, this.get, ...arguments)) return;
+    assertWellFormedId(id, 'invoice');
+    return this.networkClient.get<InvoiceData, Invoice>(`${pathSegment}/${id}`);
+  }
+
+  /**
+   * Retrieve all invoices on the organization, ordered from newest to oldest.
+   *
+   * The results are paginated.
+   *
+   * @since 4.6.0
+   * @see https://docs.mollie.com/reference/list-invoices
+   */
+  public page(parameters?: PageParameters): Promise<Page<Invoice>>;
+  public page(parameters: PageParameters, callback: Callback<Page<Invoice>>): void;
+  public page(parameters: PageParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient.page<InvoiceData, Invoice>(pathSegment, 'invoices', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Retrieve all invoices on the organization, ordered from newest to oldest.
+   *
+   * The results are paginated.
+   *
+   * @since 4.6.0
+   * @see https://docs.mollie.com/reference/list-invoices
+   */
+  public iterate(parameters?: IterateParameters) {
+    const { valuesPerMinute, ...query } = parameters ?? {};
+    return this.networkClient.iterate<InvoiceData, Invoice>(pathSegment, 'invoices', query, valuesPerMinute);
+  }
+}

--- a/src/binders/invoices/parameters.ts
+++ b/src/binders/invoices/parameters.ts
@@ -1,0 +1,15 @@
+import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../types/parameters';
+
+export type PageParameters = PaginationParameters &
+  SortParameter & {
+    /**
+     * Use this parameter to filter for invoices with a specific invoice reference, for example `2024.10000`.
+     */
+    reference?: string;
+    /**
+     * Use this parameter to filter for invoices from a specific year, for example `2024`.
+     */
+    year?: string;
+  };
+
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -32,6 +32,7 @@ import { transform as transformRoute } from './data/payments/routes/Route';
 import { transform as transformBalanceTransfer } from './data/balance-transfers/BalanceTransfer';
 import { transform as transformClient } from './data/clients/Client';
 import { transform as transformClientLink } from './data/client-links/ClientLink';
+import { transform as transformInvoice } from './data/invoices/Invoice';
 
 // Binders
 import ApplePayBinder from './binders/applePay/ApplePayBinder';
@@ -73,6 +74,7 @@ import CapabilitiesBinder from './binders/capabilities/CapabilitiesBinder';
 import ClientsBinder from './binders/clients/ClientsBinder';
 import OAuthBinder from './binders/oauth/OAuthBinder';
 import ClientLinksBinder from './binders/client-links/ClientLinksBinder';
+import InvoicesBinder from './binders/invoices/InvoicesBinder';
 
 /**
  * Returns whether the code appears to be running in a browser-like environment, where shipping credentials would expose
@@ -133,7 +135,8 @@ export default function createMollieClient(options: Options) {
       .add('route', transformRoute)
       .add('connect-balance-transfer', transformBalanceTransfer)
       .add('client', transformClient)
-      .add('client-link', transformClientLink),
+      .add('client-link', transformClientLink)
+      .add('invoice', transformInvoice),
   );
 
   return apply(
@@ -224,6 +227,9 @@ export default function createMollieClient(options: Options) {
 
       // Client Links
       clientLinks: new ClientLinksBinder(transformingNetworkClient),
+
+      // Invoices
+      invoices: new InvoicesBinder(transformingNetworkClient),
     },
     client =>
       alias(client, {
@@ -260,5 +266,6 @@ export { OnboardingStatus } from './data/onboarding/data';
 export { TerminalStatus } from './data/terminals/data';
 export { CapabilityStatus, CapabilityStatusReason, RequirementStatus } from './data/capabilities/data';
 export { ClientEmbed } from './data/clients/data';
+export { InvoiceStatus } from './data/invoices/data';
 export { GrantType as OAuthGrantType, TokenType as OAuthTokenType } from './data/oauth/data';
 export { default as MollieApiError } from './errors/ApiError';

--- a/src/data/invoices/Invoice.ts
+++ b/src/data/invoices/Invoice.ts
@@ -1,0 +1,12 @@
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import type Seal from '../../types/Seal';
+import { type InvoiceData } from './data';
+import InvoiceHelper from './InvoiceHelper';
+
+type Invoice = Seal<Omit<InvoiceData, '_links'>, InvoiceHelper>;
+
+export default Invoice;
+
+export function transform(networkClient: TransformingNetworkClient, input: InvoiceData): Invoice {
+  return Object.assign(Object.create(new InvoiceHelper(networkClient, input._links)), input);
+}

--- a/src/data/invoices/InvoiceHelper.ts
+++ b/src/data/invoices/InvoiceHelper.ts
@@ -1,0 +1,23 @@
+import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import type Nullable from '../../types/Nullable';
+import Helper from '../Helper';
+import { type InvoiceData } from './data';
+import type Invoice from './Invoice';
+
+export default class InvoiceHelper extends Helper<InvoiceData, Invoice> {
+  constructor(
+    networkClient: TransformingNetworkClient,
+    protected readonly links: InvoiceData['_links'],
+  ) {
+    super(networkClient, links);
+  }
+
+  /**
+   * Returns the URL to the PDF version of the invoice, or `null` if it is not available.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=_links/pdf#response
+   */
+  public getPdfUrl(): Nullable<string> {
+    return this.links.pdf?.href ?? null;
+  }
+}

--- a/src/data/invoices/data.ts
+++ b/src/data/invoices/data.ts
@@ -1,9 +1,10 @@
+import type Nullable from '../../types/Nullable';
 import { type Amount, type Links, type Url } from '../global';
 import type Model from '../Model';
 
 export interface InvoiceData extends Model<'invoice'> {
   /**
-   * The reference number of the invoice. An example value would be `2018.10000`.
+   * The reference number of the invoice. An example value would be: `2024.10000`.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=reference#response
    */
@@ -13,29 +14,31 @@ export interface InvoiceData extends Model<'invoice'> {
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=vatNumber#response
    */
-  vatNumber?: string;
+  vatNumber?: Nullable<string>;
   /**
    * Status of the invoice.
+   *
+   * Possible values: `open` `paid` `overdue`
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=status#response
    */
   status: InvoiceStatus;
   /**
-   * The total amount of the invoice excluding VAT, e.g. `100.00`.
+   * Total amount of the invoice, excluding VAT.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=netAmount#response
    */
   netAmount: Amount;
   /**
-   * The VAT amount of the invoice. Only applicable for merchants registered in the Netherlands. For EU merchants, VAT
-   * will be shifted to recipient; article 44 and 196 EU VAT Directive 2006/112. For merchants outside the EU, no VAT
-   * will be charged.
+   * VAT amount of the invoice. Only applicable to merchants registered in the Netherlands. For EU merchants, VAT will be
+   * shifted to the recipient (as per article 44 and 196 in the EU VAT Directive 2006/112). For merchants outside the EU,
+   * no VAT will be charged.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=vatAmount#response
    */
   vatAmount: Amount;
   /**
-   * The total amount of the invoice including VAT.
+   * Total amount of the invoice, including VAT.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=grossAmount#response
    */
@@ -47,23 +50,23 @@ export interface InvoiceData extends Model<'invoice'> {
    */
   lines: InvoiceLine[];
   /**
-   * The date on which the invoice was issued, in `YYYY-MM-DD` format.
+   * The invoice date in `YYYY-MM-DD` format.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=issuedAt#response
    */
   issuedAt: string;
   /**
-   * The date on which the invoice was paid, in `YYYY-MM-DD` format. Only available if the invoice is `paid`.
+   * The date on which the invoice was paid, if applicable, in `YYYY-MM-DD` format.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=paidAt#response
    */
-  paidAt?: string;
+  paidAt?: Nullable<string>;
   /**
-   * The date on which the invoice is due, in `YYYY-MM-DD` format. Only available if the invoice is not `paid` yet.
+   * The date on which the invoice is due, if applicable, in `YYYY-MM-DD` format.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=dueAt#response
    */
-  dueAt?: string;
+  dueAt?: Nullable<string>;
   /**
    * An object with several relevant URLs. Every URL object will contain an `href` and a `type` field.
    *
@@ -80,25 +83,25 @@ export interface InvoiceLine {
    */
   period: string;
   /**
-   * A description of the product, for example `iDEAL transaction costs`.
+   * Description of the product.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=lines/description#response
    */
   description: string;
   /**
-   * The number of products invoiced, for example the number of payments in case of transaction costs.
+   * Number of products invoiced. For example, the number of payments.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=lines/count#response
    */
   count: number;
   /**
-   * The VAT percentage rate that applies to this product.
+   * VAT percentage rate that applies to this product.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=lines/vatPercentage#response
    */
   vatPercentage: number;
   /**
-   * The price of a single product, excluding VAT.
+   * Line item amount excluding VAT.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=lines/amount#response
    */
@@ -107,7 +110,7 @@ export interface InvoiceLine {
 
 export interface InvoiceLinks extends Links {
   /**
-   * The URL to the PDF version of the invoice. Only available if the invoice has been generated.
+   * URL to a downloadable PDF of the invoice.
    *
    * @see https://docs.mollie.com/reference/get-invoice?path=_links/pdf#response
    */

--- a/src/data/invoices/data.ts
+++ b/src/data/invoices/data.ts
@@ -1,0 +1,121 @@
+import { type Amount, type Links, type Url } from '../global';
+import type Model from '../Model';
+
+export interface InvoiceData extends Model<'invoice'> {
+  /**
+   * The reference number of the invoice. An example value would be `2018.10000`.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=reference#response
+   */
+  reference: string;
+  /**
+   * The VAT number to which the invoice was issued to, if applicable.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=vatNumber#response
+   */
+  vatNumber?: string;
+  /**
+   * Status of the invoice.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=status#response
+   */
+  status: InvoiceStatus;
+  /**
+   * The total amount of the invoice excluding VAT, e.g. `100.00`.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=netAmount#response
+   */
+  netAmount: Amount;
+  /**
+   * The VAT amount of the invoice. Only applicable for merchants registered in the Netherlands. For EU merchants, VAT
+   * will be shifted to recipient; article 44 and 196 EU VAT Directive 2006/112. For merchants outside the EU, no VAT
+   * will be charged.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=vatAmount#response
+   */
+  vatAmount: Amount;
+  /**
+   * The total amount of the invoice including VAT.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=grossAmount#response
+   */
+  grossAmount: Amount;
+  /**
+   * The collection of products which make up the invoice.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=lines#response
+   */
+  lines: InvoiceLine[];
+  /**
+   * The date on which the invoice was issued, in `YYYY-MM-DD` format.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=issuedAt#response
+   */
+  issuedAt: string;
+  /**
+   * The date on which the invoice was paid, in `YYYY-MM-DD` format. Only available if the invoice is `paid`.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=paidAt#response
+   */
+  paidAt?: string;
+  /**
+   * The date on which the invoice is due, in `YYYY-MM-DD` format. Only available if the invoice is not `paid` yet.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=dueAt#response
+   */
+  dueAt?: string;
+  /**
+   * An object with several relevant URLs. Every URL object will contain an `href` and a `type` field.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=_links#response
+   */
+  _links: InvoiceLinks;
+}
+
+export interface InvoiceLine {
+  /**
+   * The administrative period in `YYYY-MM` on which the line should be booked.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=lines/period#response
+   */
+  period: string;
+  /**
+   * A description of the product, for example `iDEAL transaction costs`.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=lines/description#response
+   */
+  description: string;
+  /**
+   * The number of products invoiced, for example the number of payments in case of transaction costs.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=lines/count#response
+   */
+  count: number;
+  /**
+   * The VAT percentage rate that applies to this product.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=lines/vatPercentage#response
+   */
+  vatPercentage: number;
+  /**
+   * The price of a single product, excluding VAT.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=lines/amount#response
+   */
+  amount: Amount;
+}
+
+export interface InvoiceLinks extends Links {
+  /**
+   * The URL to the PDF version of the invoice. Only available if the invoice has been generated.
+   *
+   * @see https://docs.mollie.com/reference/get-invoice?path=_links/pdf#response
+   */
+  pdf?: Url;
+}
+
+export enum InvoiceStatus {
+  open = 'open',
+  paid = 'paid',
+  overdue = 'overdue',
+}

--- a/src/plumbing/assertWellFormedId.ts
+++ b/src/plumbing/assertWellFormedId.ts
@@ -6,6 +6,7 @@ const prefixes = {
   'capture': 'cpt_',
   'chargeback': 'chb_',
   'customer': 'cst_',
+  'invoice': 'inv_',
   'mandate': 'mdt_',
   'order': 'ord_',
   'orderline': 'odl_',

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,9 @@ export { GetParameters as ClientGetParams, PageParameters as ClientsListParams }
 export { default as ClientLink } from './data/client-links/ClientLink';
 export { CreateParameters as ClientLinkCreateParams } from './binders/client-links/parameters';
 
+export { default as Invoice } from './data/invoices/Invoice';
+export { PageParameters as InvoicePageParams } from './binders/invoices/parameters';
+
 export { default as Capture } from './data/payments/captures/Capture';
 import { GetParameters as CapturesGetParameters, PageParameters as CapturesPageParameters } from './binders/payments/captures/parameters';
 export { CapturesGetParameters, CapturesPageParameters };

--- a/tests/unit/resources/invoices.test.ts
+++ b/tests/unit/resources/invoices.test.ts
@@ -1,0 +1,128 @@
+import { InvoiceStatus } from '../../..';
+import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
+
+function composeInvoiceResponse(id = 'inv_xBEbP9rvAq', status = InvoiceStatus.paid) {
+  return {
+    resource: 'invoice',
+    id,
+    reference: '2024.10000',
+    vatNumber: 'NL001234567B01',
+    status,
+    netAmount: { value: '45.00', currency: 'EUR' },
+    vatAmount: { value: '9.45', currency: 'EUR' },
+    grossAmount: { value: '54.45', currency: 'EUR' },
+    lines: [
+      {
+        period: '2024-09',
+        description: 'iDEAL transaction costs',
+        count: 100,
+        vatPercentage: 21,
+        amount: { value: '45.00', currency: 'EUR' },
+      },
+    ],
+    issuedAt: '2024-09-01',
+    paidAt: '2024-09-14',
+    _links: {
+      self: {
+        href: `https://api.mollie.com/v2/invoices/${id}`,
+        type: 'application/hal+json',
+      },
+      pdf: {
+        href: `https://www.mollie.com/merchant/download/invoice/${id}/2ab44d60b35b1d06090bba955fa2c602`,
+        type: 'application/pdf',
+      },
+      documentation: {
+        href: 'https://docs.mollie.com/reference/get-invoice',
+        type: 'text/html',
+      },
+    },
+  };
+}
+
+function testInvoice(invoice, id = 'inv_xBEbP9rvAq') {
+  expect(invoice.resource).toBe('invoice');
+  expect(invoice.id).toBe(id);
+  expect(invoice.reference).toBe('2024.10000');
+  expect(invoice.vatNumber).toBe('NL001234567B01');
+  expect(invoice.status).toBe('paid');
+  expect(invoice.netAmount).toEqual({ value: '45.00', currency: 'EUR' });
+  expect(invoice.vatAmount).toEqual({ value: '9.45', currency: 'EUR' });
+  expect(invoice.grossAmount).toEqual({ value: '54.45', currency: 'EUR' });
+  expect(invoice.lines).toEqual([
+    {
+      period: '2024-09',
+      description: 'iDEAL transaction costs',
+      count: 100,
+      vatPercentage: 21,
+      amount: { value: '45.00', currency: 'EUR' },
+    },
+  ]);
+  expect(invoice.issuedAt).toBe('2024-09-01');
+  expect(invoice.paidAt).toBe('2024-09-14');
+  expect(invoice.getPdfUrl()).toBe(`https://www.mollie.com/merchant/download/invoice/${id}/2ab44d60b35b1d06090bba955fa2c602`);
+}
+
+test('getInvoice', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/invoices/inv_xBEbP9rvAq', 200, composeInvoiceResponse('inv_xBEbP9rvAq')).twice();
+
+    const invoice = await bluster(mollieClient.invoices.get.bind(mollieClient.invoices))('inv_xBEbP9rvAq');
+
+    testInvoice(invoice, 'inv_xBEbP9rvAq');
+  });
+});
+
+test('getInvoiceWithoutPdf', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const response = composeInvoiceResponse('inv_open', InvoiceStatus.open);
+    delete (response._links as { pdf?: unknown }).pdf;
+    networkMocker.intercept('GET', '/invoices/inv_open', 200, response).twice();
+
+    const invoice = await bluster(mollieClient.invoices.get.bind(mollieClient.invoices))('inv_open');
+
+    expect(invoice.status).toBe('open');
+    expect(invoice.getPdfUrl()).toBeNull();
+  });
+});
+
+test('listInvoices', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker
+      .intercept('GET', '/invoices', 200, {
+        count: 2,
+        _embedded: {
+          invoices: [composeInvoiceResponse('inv_1'), composeInvoiceResponse('inv_2')],
+        },
+        _links: {
+          documentation: {
+            href: 'https://docs.mollie.com/reference/list-invoices',
+            type: 'text/html',
+          },
+          self: {
+            href: 'https://api.mollie.com/v2/invoices?limit=50',
+            type: 'application/hal+json',
+          },
+          previous: null,
+          next: null,
+        },
+      })
+      .twice();
+
+    const invoices = await bluster(mollieClient.invoices.page.bind(mollieClient.invoices))();
+
+    expect(invoices.length).toBe(2);
+    expect(invoices.links.documentation).toEqual({
+      href: 'https://docs.mollie.com/reference/list-invoices',
+      type: 'text/html',
+    });
+    expect(invoices.links.self).toEqual({
+      href: 'https://api.mollie.com/v2/invoices?limit=50',
+      type: 'application/hal+json',
+    });
+    expect(invoices.links.previous).toBeNull();
+    expect(invoices.links.next).toBeNull();
+
+    testInvoice(invoices[0], 'inv_1');
+    testInvoice(invoices[1], 'inv_2');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **Invoices API** as a new read-only resource, so consumers can list and retrieve the invoices Mollie issues for an organization's fees without hand-rolling the requests.

Exposed on the client as `mollieClient.invoices`:

- `invoices.get(id)` — retrieve a single invoice
- `invoices.page(params)` — list invoices (aliased as `all` / `list`), with `reference` / `year` filters plus pagination and `sort`
- `invoices.iterate(params)` — async iteration over all invoices

The `Invoice` model exposes `getPdfUrl()` so callers get the PDF download link without reaching into `_links`.

## Mollie API reference

- Overview: https://docs.mollie.com/reference/invoices-api
- List invoices: https://docs.mollie.com/reference/list-invoices
- Get invoice: https://docs.mollie.com/reference/get-invoice

## Implementation notes

- Follows the established data/binder split: `InvoiceData` (response shape) + `InvoiceLine` + `InvoiceStatus` enum in `data/invoices/`, with `get`/`page`/`iterate` in the binder.
- Registered the `inv_` ID prefix in `assertWellFormedId`, the `invoice` transformer in `createMollieClient`, and the `Invoice` / `InvoicePageParams` / `InvoiceStatus` public exports.

## Decisions worth a reviewer's eye

- **No `testmode` parameter.** Both endpoints document none, and invoices are real billing documents with no test-mode variant — consistent with how the settlements family is modelled. Trivial to add if the team confirms otherwise.
- **`vatNumber`, `paidAt`, `dueAt` typed optional (`?`)** rather than `Nullable`, per our default-to-optional policy (presence is status-dependent).
- **`pdf` link modelled optional** (`pdf?: Url`) — it's absent on invoices that haven't been generated yet.

## Test plan

- `tests/unit/resources/invoices.test.ts` covers get, get-without-pdf (asserts `getPdfUrl()` returns `null`), and list.
- `yarn test:unit` — 42 suites / 126 tests pass.
- `yarn build` clean (bundle + declarations); ESLint + Prettier clean.