### PR TITLE
fix: align terminal response type with the API

### DIFF
--- a/src/binders/terminals/TerminalsBinder.ts
+++ b/src/binders/terminals/TerminalsBinder.ts
@@ -21,7 +21,7 @@ export default class TerminalsBinder extends Binder<TerminalData, Terminal> {
    * For more information on accepting point-of-sale payments, please refer to the [point-of-sale guide](https://docs.mollie.com/point-of-sale/overview).
    *
    * @since 4.3.0
-   * @see https://docs.mollie.com/reference/v2/terminals-api/get-terminal
+   * @see https://docs.mollie.com/reference/get-terminal
    */
   public get(id: string): Promise<Terminal>;
   public get(id: string, callback: Callback<Terminal>): void;
@@ -37,7 +37,7 @@ export default class TerminalsBinder extends Binder<TerminalData, Terminal> {
    * The results are paginated. See pagination for more information.
    *
    * @since 4.3.0
-   * @see https://docs.mollie.com/reference/v2/terminals-api/list-terminals
+   * @see https://docs.mollie.com/reference/list-terminals
    */
   public page(parameters?: PageParameters): Promise<Page<Terminal>>;
   public page(parameters: PageParameters, callback: Callback<Page<Terminal>>): void;
@@ -52,7 +52,7 @@ export default class TerminalsBinder extends Binder<TerminalData, Terminal> {
    * The results are paginated. See pagination for more information.
    *
    * @since 4.3.0
-   * @see https://docs.mollie.com/reference/v2/terminals-api/list-terminals
+   * @see https://docs.mollie.com/reference/list-terminals
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};

--- a/src/data/terminals/data.ts
+++ b/src/data/terminals/data.ts
@@ -1,5 +1,5 @@
 import type Model from '../Model';
-import { ApiMode, Links } from '../global';
+import { type ApiMode, type Links } from '../global';
 
 export interface TerminalData extends Model<'terminal'> {
   /**

--- a/src/data/terminals/data.ts
+++ b/src/data/terminals/data.ts
@@ -1,7 +1,15 @@
 import type Model from '../Model';
-import { Links } from '../global';
+import { ApiMode, Links } from '../global';
 
 export interface TerminalData extends Model<'terminal'> {
+  /**
+   * Whether this entity was created in live mode or in test mode.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/get-terminal?path=mode#response
+   */
+  mode: ApiMode;
   /**
    * A short description of the terminal. The description can be used as an identifier for the terminal. Currently, the description is set when the terminal is initially configured. It will be visible in the Mollie Dashboard, and it may be visible on the device itself depending on the device.
    */
@@ -9,7 +17,7 @@ export interface TerminalData extends Model<'terminal'> {
   /**
    * The terminal's status. Refer to the documentation regarding statuses for more info about which statuses occur at what point.
    *
-   * @see https://docs.mollie.com/reference/v2/terminals-api/get-terminal#response
+   * @see https://docs.mollie.com/reference/get-terminal?path=status#response
    */
   status: TerminalStatus;
   /**
@@ -29,13 +37,21 @@ export interface TerminalData extends Model<'terminal'> {
    */
   currency?: string;
   /**
-   * The identifier used for referring to the profile the terminal was created on. For example, pfl_QkEhN94Ba.
+   * The identifier used for referring to the profile the terminal was created on. For example, `pfl_QkEhN94Ba`.
+   *
+   * Most API credentials are linked to a single profile. In these cases the profileId can be omitted in the creation request. For organization-level credentials such as OAuth access tokens however, the profileId parameter is required.
+   *
+   * @see https://docs.mollie.com/reference/get-terminal?path=profileId#response
    */
   profileId?: string;
   /**
    * The date and time the terminal was created, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    */
   createdAt: string;
+  /**
+   * The date and time the terminal was last updated, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   */
+  updatedAt: string;
   _links: Links;
 }
 


### PR DESCRIPTION
## What

Aligns the `Terminal` response type (`TerminalData`) with the current Mollie API, surfaced by a `sync-api` run against the master OpenAPI spec.

- **Add `mode`** (`live` | `test`) and **`updatedAt`** — response fields the API returns but the type omitted.
- **Enrich the `profileId` JSDoc** with the OAuth/organization-credentials note.
- **Migrate `@see` links** from the stale `/reference/v2/terminals-api/...` form to the current `/reference/...` form — on the `status` field and the binder's `get` / `page` / `iterate` methods.

Additive fields and documentation only — no breaking changes.

## Docs

- https://docs.mollie.com/reference/get-terminal
- https://docs.mollie.com/reference/list-terminals

## Notes

Deferred (breaking) terminal corrections — `brand` / `model` / `serialNumber` nullability and a `brand` / `model` enum-narrowing question — are tracked in #489 for v5, intentionally out of scope here.
