### PR TITLE
feat: add terminal pairing codes endpoints

### DIFF
--- a/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
+++ b/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
@@ -25,6 +25,7 @@ export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCo
    *
    * This endpoint currently does not support test mode yet.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/terminals-request-pairing-code
    */
   public create(parameters: CreateParameters): Promise<TerminalPairingCode>;
@@ -43,6 +44,7 @@ export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCo
    *
    * This endpoint currently does not support test mode yet.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/terminals-get-pairing-code
    */
   public get(id: string, parameters?: GetParameters): Promise<TerminalPairingCode>;
@@ -60,6 +62,7 @@ export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCo
    *
    * This endpoint currently does not support test mode yet.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/terminals-list-pairing-codes
    */
   public page(parameters?: PageParameters): Promise<Page<TerminalPairingCode>>;
@@ -78,6 +81,7 @@ export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCo
    *
    * This endpoint currently does not support test mode yet.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/terminals-list-pairing-codes
    */
   public iterate(parameters?: IterateParameters) {
@@ -92,6 +96,7 @@ export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCo
    *
    * This endpoint currently does not support test mode yet.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/terminals-revoke-pairing-code
    */
   public revoke(id: string): Promise<TerminalPairingCode>;

--- a/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
+++ b/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
@@ -1,0 +1,104 @@
+import { runIf } from 'ruply';
+import type TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import type Page from '../../../data/page/Page';
+import { type TerminalPairingCodeData } from '../../../data/terminals/pairing-codes/data';
+import type TerminalPairingCode from '../../../data/terminals/pairing-codes/TerminalPairingCode';
+import assertWellFormedId from '../../../plumbing/assertWellFormedId';
+import renege from '../../../plumbing/renege';
+import type Callback from '../../../types/Callback';
+import Binder from '../../Binder';
+import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
+
+const pathSegment = 'terminals/pairing-codes';
+
+export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCodeData, TerminalPairingCode> {
+  constructor(protected readonly networkClient: TransformingNetworkClient) {
+    super();
+  }
+
+  /**
+   * Request a pairing code to onboard a point-of-sale terminal.
+   *
+   * The response includes a human-readable `code` for manual entry on the terminal, and a QR code as a base64 encoded SVG data URI for scanning if you specify the `include` parameter with value `details.qrCode`.
+   *
+   * Pairing codes expire after 90 days (see `expiresAt`) and can be used multiple times.
+   *
+   * This endpoint currently does not support test mode yet.
+   *
+   * @see https://docs.mollie.com/reference/terminals-request-pairing-code
+   */
+  public create(parameters: CreateParameters): Promise<TerminalPairingCode>;
+  public create(parameters: CreateParameters, callback: Callback<TerminalPairingCode>): void;
+  public create(parameters: CreateParameters) {
+    if (renege(this, this.create, ...arguments)) return;
+    const { include, ...data } = parameters;
+    const query = runIf(include, include => ({ include }));
+    return this.networkClient.post<TerminalPairingCodeData, TerminalPairingCode>(pathSegment, data, query);
+  }
+
+  /**
+   * Get a pairing code to onboard a point-of-sale terminal.
+   *
+   * The response includes a human-readable `code` for manual entry on the terminal and, optionally, a QR code as a base64 encoded SVG data URI when you use the `include` parameter with value `details.qrCode`.
+   *
+   * This endpoint currently does not support test mode yet.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code
+   */
+  public get(id: string, parameters?: GetParameters): Promise<TerminalPairingCode>;
+  public get(id: string, parameters: GetParameters, callback: Callback<TerminalPairingCode>): void;
+  public get(id: string, parameters?: GetParameters) {
+    if (renege(this, this.get, ...arguments)) return;
+    assertWellFormedId(id, 'terminal-pairing-code');
+    return this.networkClient.get<TerminalPairingCodeData, TerminalPairingCode>(`${pathSegment}/${id}`, parameters);
+  }
+
+  /**
+   * Returns all pairing codes: `active`, `expired`, and `revoked`.
+   *
+   * The results are paginated. See pagination for more information.
+   *
+   * This endpoint currently does not support test mode yet.
+   *
+   * @see https://docs.mollie.com/reference/terminals-list-pairing-codes
+   */
+  public page(parameters?: PageParameters): Promise<Page<TerminalPairingCode>>;
+  public page(parameters: PageParameters, callback: Callback<Page<TerminalPairingCode>>): void;
+  public page(parameters: PageParameters = {}) {
+    if (renege(this, this.page, ...arguments)) return;
+    return this.networkClient
+      .page<TerminalPairingCodeData, TerminalPairingCode>(pathSegment, 'terminal-pairing-codes', parameters)
+      .then(result => this.injectPaginationHelpers(result, this.page, parameters));
+  }
+
+  /**
+   * Returns all pairing codes: `active`, `expired`, and `revoked`.
+   *
+   * The results are paginated. See pagination for more information.
+   *
+   * This endpoint currently does not support test mode yet.
+   *
+   * @see https://docs.mollie.com/reference/terminals-list-pairing-codes
+   */
+  public iterate(parameters?: IterateParameters) {
+    const { valuesPerMinute, ...query } = parameters ?? {};
+    return this.networkClient.iterate<TerminalPairingCodeData, TerminalPairingCode>(pathSegment, 'terminal-pairing-codes', query, valuesPerMinute);
+  }
+
+  /**
+   * Revoke a pairing code, preventing the onboarding of new point-of-sale terminals.
+   *
+   * Terminals that have already paired with this code are not affected.
+   *
+   * This endpoint currently does not support test mode yet.
+   *
+   * @see https://docs.mollie.com/reference/terminals-revoke-pairing-code
+   */
+  public revoke(id: string): Promise<TerminalPairingCode>;
+  public revoke(id: string, callback: Callback<TerminalPairingCode>): void;
+  public revoke(id: string) {
+    if (renege(this, this.revoke, ...arguments)) return;
+    assertWellFormedId(id, 'terminal-pairing-code');
+    return this.networkClient.delete<TerminalPairingCodeData, TerminalPairingCode>(`${pathSegment}/${id}`);
+  }
+}

--- a/src/binders/terminals/pairing-codes/parameters.ts
+++ b/src/binders/terminals/pairing-codes/parameters.ts
@@ -1,0 +1,38 @@
+import { type TerminalPairingCodeData, type TerminalPairingCodeInclude } from '../../../data/terminals/pairing-codes/data';
+import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
+
+export type CreateParameters = Pick<TerminalPairingCodeData, 'profileId'> & {
+  /**
+   * Include additional information in the response.
+   *
+   * Possible values: `details.qrCode` (include a QR code object).
+   *
+   * __Note:__ In the REST API this is not part of the request body, but a query string parameter. It is included here for consistency.
+   *
+   * @see https://docs.mollie.com/reference/terminals-request-pairing-code?path=include#parameters
+   */
+  include?: TerminalPairingCodeInclude;
+};
+
+export type GetParameters = {
+  /**
+   * Include additional information in the response.
+   *
+   * Possible values: `details.qrCode` (include a QR code object).
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=include#parameters
+   */
+  include?: TerminalPairingCodeInclude;
+};
+
+export type PageParameters = PaginationParameters &
+  SortParameter & {
+    /**
+     * The identifier referring to the profile you wish to retrieve pairing codes for.
+     *
+     * @see https://docs.mollie.com/reference/terminals-list-pairing-codes?path=profileId#parameters
+     */
+    profileId?: string;
+  };
+
+export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/terminals/pairing-codes/parameters.ts
+++ b/src/binders/terminals/pairing-codes/parameters.ts
@@ -1,5 +1,6 @@
 import { type TerminalPairingCodeData, type TerminalPairingCodeInclude } from '../../../data/terminals/pairing-codes/data';
 import { type PaginationParameters, type SortParameter, type ThrottlingParameter } from '../../../types/parameters';
+import type MaybeArray from '../../../types/MaybeArray';
 
 export type CreateParameters = Pick<TerminalPairingCodeData, 'profileId'> & {
   /**
@@ -11,7 +12,7 @@ export type CreateParameters = Pick<TerminalPairingCodeData, 'profileId'> & {
    *
    * @see https://docs.mollie.com/reference/terminals-request-pairing-code?path=include#parameters
    */
-  include?: TerminalPairingCodeInclude;
+  include?: MaybeArray<TerminalPairingCodeInclude>;
 };
 
 export type GetParameters = {
@@ -22,7 +23,7 @@ export type GetParameters = {
    *
    * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=include#parameters
    */
-  include?: TerminalPairingCodeInclude;
+  include?: MaybeArray<TerminalPairingCodeInclude>;
 };
 
 export type PageParameters = PaginationParameters &

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -28,6 +28,7 @@ import { transform as transformPaymentLink } from './data/paymentLinks/PaymentLi
 import { transform as transformIssuer } from './data/issuer/IssuerModel';
 import { transform as transformSettlement } from './data/settlements/SettlementModel';
 import { transform as transformTerminal } from './data/terminals/Terminal';
+import { transform as transformTerminalPairingCode } from './data/terminals/pairing-codes/TerminalPairingCode';
 import { transform as transformRoute } from './data/payments/routes/Route';
 import { transform as transformBalanceTransfer } from './data/balance-transfers/BalanceTransfer';
 import { transform as transformClient } from './data/clients/Client';
@@ -68,6 +69,7 @@ import SettlementsBinder from './binders/settlements/SettlementsBinder';
 import SubscriptionsBinder from './binders/subscriptions/SubscriptionsBinder';
 import SubscriptionPaymentsBinder from './binders/subscriptions/payments/SubscriptionPaymentsBinder';
 import TerminalsBinder from './binders/terminals/TerminalsBinder';
+import TerminalPairingCodesBinder from './binders/terminals/pairing-codes/TerminalPairingCodesBinder';
 import PaymentRoutesBinder from './binders/payments/routes/PaymentRoutesBinder';
 import BalanceTransfersBinder from './binders/balance-transfers/BalanceTransfersBinder';
 import CapabilitiesBinder from './binders/capabilities/CapabilitiesBinder';
@@ -132,6 +134,7 @@ export default function createMollieClient(options: Options) {
       .add('issuer', transformIssuer)
       .add('settlement', transformSettlement)
       .add('terminal', transformTerminal)
+      .add('terminal-pairing-code', transformTerminalPairingCode)
       .add('route', transformRoute)
       .add('connect-balance-transfer', transformBalanceTransfer)
       .add('client', transformClient)
@@ -212,6 +215,7 @@ export default function createMollieClient(options: Options) {
 
       // Terminals
       terminals: new TerminalsBinder(transformingNetworkClient),
+      terminalPairingCodes: new TerminalPairingCodesBinder(transformingNetworkClient),
 
       // Balance Transfers
       balanceTransfers: new BalanceTransfersBinder(transformingNetworkClient),
@@ -264,6 +268,7 @@ export { SubscriptionStatus } from './data/subscriptions/data';
 export { ProfileStatus } from './data/profiles/data';
 export { OnboardingStatus } from './data/onboarding/data';
 export { TerminalStatus } from './data/terminals/data';
+export { PairingCodeStatus, TerminalPairingCodeInclude } from './data/terminals/pairing-codes/data';
 export { CapabilityStatus, CapabilityStatusReason, RequirementStatus } from './data/capabilities/data';
 export { ClientEmbed } from './data/clients/data';
 export { InvoiceStatus } from './data/invoices/data';

--- a/src/data/terminals/pairing-codes/TerminalPairingCode.ts
+++ b/src/data/terminals/pairing-codes/TerminalPairingCode.ts
@@ -1,0 +1,12 @@
+import type TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import type Seal from '../../../types/Seal';
+import { type TerminalPairingCodeData } from './data';
+import TerminalPairingCodeHelper from './TerminalPairingCodeHelper';
+
+type TerminalPairingCode = Seal<TerminalPairingCodeData, TerminalPairingCodeHelper>;
+
+export default TerminalPairingCode;
+
+export function transform(networkClient: TransformingNetworkClient, input: TerminalPairingCodeData): TerminalPairingCode {
+  return Object.assign(Object.create(new TerminalPairingCodeHelper(networkClient, input._links)), input);
+}

--- a/src/data/terminals/pairing-codes/TerminalPairingCodeHelper.ts
+++ b/src/data/terminals/pairing-codes/TerminalPairingCodeHelper.ts
@@ -18,6 +18,8 @@ export default class TerminalPairingCodeHelper extends Helper<TerminalPairingCod
 
   /**
    * Returns the profile the terminal is being paired with.
+   *
+   * @since 4.6.0
    */
   public getProfile(): Promise<Profile>;
   public getProfile(callback: Callback<Profile>): void;

--- a/src/data/terminals/pairing-codes/TerminalPairingCodeHelper.ts
+++ b/src/data/terminals/pairing-codes/TerminalPairingCodeHelper.ts
@@ -1,0 +1,28 @@
+import type TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import breakUrl from '../../../communication/breakUrl';
+import renege from '../../../plumbing/renege';
+import type Callback from '../../../types/Callback';
+import Helper from '../../Helper';
+import type Profile from '../../profiles/Profile';
+import { type ProfileData } from '../../profiles/data';
+import { type TerminalPairingCodeData } from './data';
+import type TerminalPairingCode from './TerminalPairingCode';
+
+export default class TerminalPairingCodeHelper extends Helper<TerminalPairingCodeData, TerminalPairingCode> {
+  constructor(
+    networkClient: TransformingNetworkClient,
+    protected readonly links: TerminalPairingCodeData['_links'],
+  ) {
+    super(networkClient, links);
+  }
+
+  /**
+   * Returns the profile the terminal is being paired with.
+   */
+  public getProfile(): Promise<Profile>;
+  public getProfile(callback: Callback<Profile>): void;
+  public getProfile() {
+    if (renege(this, this.getProfile, ...arguments)) return;
+    return this.networkClient.get<ProfileData, Profile>(...breakUrl(this.links.profile.href));
+  }
+}

--- a/src/data/terminals/pairing-codes/data.ts
+++ b/src/data/terminals/pairing-codes/data.ts
@@ -1,0 +1,83 @@
+import type Model from '../../Model';
+import type Nullable from '../../../types/Nullable';
+import { type ApiMode, type Links, type Url } from '../../global';
+
+export interface TerminalPairingCodeData extends Model<'terminal-pairing-code'> {
+  /**
+   * Whether this entity was created in live mode or in test mode.
+   *
+   * Possible values: `live` `test`
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=mode#response
+   */
+  mode: ApiMode;
+  /**
+   * The human-readable pairing code to be entered on the terminal. This code is multi-use and will expire after the time indicated in `expiresAt`.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=code#response
+   */
+  code: string;
+  /**
+   * The ID of the profile the terminal is being paired with.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=profileId#response
+   */
+  profileId: string;
+  /**
+   * The status of the pairing code.
+   *
+   * Possible values: `active` `expired` `revoked`
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=status#response
+   */
+  status: PairingCodeStatus;
+  /**
+   * Additional pairing code data, present only when requested via the `include` parameter.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=details#response
+   */
+  details?: {
+    /**
+     * The QR code representation of the pairing code.
+     */
+    qrCode?: {
+      height: number;
+      width: number;
+      src: string;
+    };
+  };
+  /**
+   * The date and time the pairing code expires, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. Pairing codes expire 90 days after creation. After this time, the code can no longer be used to pair a terminal.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=expiresAt#response
+   */
+  expiresAt: string;
+  /**
+   * The date and time the pairing code was revoked, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. `null` if the code has not been revoked.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=revokedAt#response
+   */
+  revokedAt: Nullable<string>;
+  /**
+   * The date and time the pairing code was created, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   *
+   * @see https://docs.mollie.com/reference/terminals-get-pairing-code?path=createdAt#response
+   */
+  createdAt: string;
+  _links: Links & {
+    /**
+     * A link to the profile resource that the terminal will be paired with.
+     */
+    profile: Url;
+  };
+}
+
+export enum PairingCodeStatus {
+  active = 'active',
+  expired = 'expired',
+  revoked = 'revoked',
+}
+
+export enum TerminalPairingCodeInclude {
+  qrCode = 'details.qrCode',
+}

--- a/src/plumbing/assertWellFormedId.ts
+++ b/src/plumbing/assertWellFormedId.ts
@@ -18,6 +18,7 @@ const prefixes = {
   'shipment': 'shp_',
   'subscription': 'sub_',
   'terminal': 'term_',
+  'terminal-pairing-code': 'termpc_',
 } satisfies Record<string, string>;
 
 type ResourceKind = keyof typeof prefixes;

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,14 @@ import {
 } from './binders/customers/subscriptions/parameters';
 export { SubscriptionCreateParams, SubscriptionGetParams, SubscriptionsListParams, SubscriptionUpdateParams, SubscriptionCancelParams };
 
+export { default as TerminalPairingCode } from './data/terminals/pairing-codes/TerminalPairingCode';
+import {
+  CreateParameters as TerminalPairingCodeCreateParams,
+  GetParameters as TerminalPairingCodeGetParams,
+  PageParameters as TerminalPairingCodesListParams,
+} from './binders/terminals/pairing-codes/parameters';
+export { TerminalPairingCodeCreateParams, TerminalPairingCodeGetParams, TerminalPairingCodesListParams };
+
 export { CardAudience, CardFailureReason, CardLabel, FeeRegion } from './data/global';
 export { Issuer } from './data/Issuer';
 export { PaymentInclude } from './data/payments/data';

--- a/tests/integration/terminal-pairing-codes.test.ts
+++ b/tests/integration/terminal-pairing-codes.test.ts
@@ -1,0 +1,28 @@
+import dotenv from 'dotenv';
+import createMollieClient from '../..';
+
+/**
+ * Load the API_KEY environment variable
+ */
+dotenv.config();
+
+const mollieClient = createMollieClient({ apiKey: process.env.API_KEY });
+
+describe('terminalPairingCodes', () => {
+  // TODO: This test is skipped for now because the pairing-codes endpoints do not support test mode yet, so it
+  // requires a dedicated live API key and an actual profile to pair against. Mirrors the skipped terminals test.
+  it.skip('should integrate', async () => {
+    const pairingCode = await mollieClient.terminalPairingCodes.create({ profileId: 'pfl_xxxxxxxxxx' });
+    expect(pairingCode).toBeDefined();
+    expect(pairingCode.code).toBeDefined();
+
+    const pairingCodes = await mollieClient.terminalPairingCodes.page();
+    expect(pairingCodes).toBeDefined();
+
+    const fetched = await mollieClient.terminalPairingCodes.get(pairingCode.id);
+    expect(fetched.id).toBe(pairingCode.id);
+
+    const revoked = await mollieClient.terminalPairingCodes.revoke(pairingCode.id);
+    expect(revoked.status).toBe('revoked');
+  });
+});

--- a/tests/unit/resources/terminal-pairing-codes.test.ts
+++ b/tests/unit/resources/terminal-pairing-codes.test.ts
@@ -1,0 +1,148 @@
+import createMollieClient, { PairingCodeStatus, TerminalPairingCodeInclude } from '../../..';
+import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
+
+const profileId = 'pfl_jA9bC4DkFj3G';
+
+// Built from the example responses in the Mollie reference docs (terminals-get/list-pairing-code). The two strings
+// that matter most — the `resource` value used for transform dispatch and the hyphenated `_embedded` key read by
+// page()/iterate() — are reproduced verbatim from those examples, which is the whole point of this fixture.
+function composePairingCodeResponse(id = 'termpc_R7gX5Ea9bC4DkFj3G', status = PairingCodeStatus.active, { revokedAt = null, details = undefined } = {}) {
+  return {
+    resource: 'terminal-pairing-code',
+    id,
+    mode: 'live',
+    code: '20eb5ca1f78b48ae9e2b',
+    profileId,
+    status,
+    ...(details && { details }),
+    expiresAt: '2026-03-10T10:00:00+00:00',
+    revokedAt,
+    createdAt: '2025-12-10T10:00:00+00:00',
+    _links: {
+      self: { href: `https://api.mollie.com/v2/terminals/pairing-codes/${id}`, type: 'application/hal+json' },
+      profile: { href: `https://api.mollie.com/v2/profiles/${profileId}`, type: 'application/hal+json' },
+      documentation: { href: 'https://docs.mollie.com/reference/terminals-get-pairing-code', type: 'text/html' },
+    },
+  };
+}
+
+function testPairingCode(pairingCode, id = 'termpc_R7gX5Ea9bC4DkFj3G', status = 'active') {
+  expect(pairingCode.resource).toBe('terminal-pairing-code');
+  expect(pairingCode.id).toBe(id);
+  expect(pairingCode.mode).toBe('live');
+  expect(pairingCode.code).toBe('20eb5ca1f78b48ae9e2b');
+  expect(pairingCode.profileId).toBe(profileId);
+  expect(pairingCode.status).toBe(status);
+  expect(pairingCode.createdAt).toBe('2025-12-10T10:00:00+00:00');
+  expect(pairingCode._links.profile).toEqual({ href: `https://api.mollie.com/v2/profiles/${profileId}`, type: 'application/hal+json' });
+}
+
+test('terminalPairingCodes binder is available on the client', () => {
+  const mollieClient = createMollieClient({ apiKey: 'test_dummyKey' });
+  expect(mollieClient).toHaveProperty('terminalPairingCodes');
+  for (const method of ['create', 'get', 'page', 'iterate', 'revoke']) {
+    expect(typeof mollieClient.terminalPairingCodes[method]).toBe('function');
+  }
+});
+
+test('requestPairingCode (create)', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('POST', '/terminals/pairing-codes', 201, composePairingCodeResponse('termpc_R7gX5Ea9bC4DkFj3G')).twice();
+
+    const pairingCode = await bluster(mollieClient.terminalPairingCodes.create.bind(mollieClient.terminalPairingCodes))({ profileId });
+
+    testPairingCode(pairingCode);
+  });
+});
+
+test('getPairingCode', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const id = 'termpc_K2mN7Pq4sT8vWxYz';
+    networkMocker.intercept('GET', `/terminals/pairing-codes/${id}`, 200, composePairingCodeResponse(id, PairingCodeStatus.expired)).twice();
+
+    const pairingCode = await bluster(mollieClient.terminalPairingCodes.get.bind(mollieClient.terminalPairingCodes))(id);
+
+    testPairingCode(pairingCode, id, 'expired');
+  });
+});
+
+test('getPairingCode includes the QR code when requested', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const id = 'termpc_R7gX5Ea9bC4DkFj3G';
+    // `src` is truncated from the real (long) base64 SVG data URI for readability.
+    const details = { qrCode: { height: 256, width: 256, src: 'data:image/svg+xml;base64,PHN2Zy8+' } };
+    networkMocker.intercept('GET', `/terminals/pairing-codes/${id}?include=details.qrCode`, 200, composePairingCodeResponse(id, PairingCodeStatus.active, { details })).twice();
+
+    const pairingCode = await bluster(mollieClient.terminalPairingCodes.get.bind(mollieClient.terminalPairingCodes))(id, { include: TerminalPairingCodeInclude.qrCode });
+
+    expect(pairingCode.details?.qrCode).toEqual({ height: 256, width: 256, src: 'data:image/svg+xml;base64,PHN2Zy8+' });
+  });
+});
+
+test('listPairingCodes decodes the _embedded "terminal-pairing-codes" array', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker
+      .intercept('GET', '/terminals/pairing-codes', 200, {
+        count: 3,
+        _embedded: {
+          'terminal-pairing-codes': [
+            composePairingCodeResponse('termpc_R7gX5Ea9bC4DkFj3G', PairingCodeStatus.active),
+            composePairingCodeResponse('termpc_K2mN7Pq4sT8vWxYz', PairingCodeStatus.expired),
+            composePairingCodeResponse('termpc_H5nR2Lp8qM6vBcXe', PairingCodeStatus.revoked, { revokedAt: '2025-11-15T08:30:00+00:00' }),
+          ],
+        },
+        _links: {
+          self: { href: 'https://api.mollie.com/v2/terminals/pairing-codes', type: 'application/hal+json' },
+          previous: null,
+          next: null,
+          documentation: { href: 'https://docs.mollie.com/reference/terminals-list-pairing-codes', type: 'text/html' },
+        },
+      })
+      .twice();
+
+    const pairingCodes = await bluster(mollieClient.terminalPairingCodes.page.bind(mollieClient.terminalPairingCodes))();
+
+    expect(pairingCodes.length).toBe(3);
+    testPairingCode(pairingCodes[0], 'termpc_R7gX5Ea9bC4DkFj3G', 'active');
+    testPairingCode(pairingCodes[1], 'termpc_K2mN7Pq4sT8vWxYz', 'expired');
+    testPairingCode(pairingCodes[2], 'termpc_H5nR2Lp8qM6vBcXe', 'revoked');
+    expect(pairingCodes[2].revokedAt).toBe('2025-11-15T08:30:00+00:00');
+    expect(pairingCodes.links.next).toBeNull();
+  });
+});
+
+test('revokePairingCode returns the revoked code', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const id = 'termpc_H5nR2Lp8qM6vBcXe';
+    networkMocker.intercept('DELETE', `/terminals/pairing-codes/${id}`, 200, composePairingCodeResponse(id, PairingCodeStatus.revoked, { revokedAt: '2025-11-15T08:30:00+00:00' })).twice();
+
+    const pairingCode = await bluster(mollieClient.terminalPairingCodes.revoke.bind(mollieClient.terminalPairingCodes))(id);
+
+    testPairingCode(pairingCode, id, 'revoked');
+    expect(pairingCode.revokedAt).toBe('2025-11-15T08:30:00+00:00');
+  });
+});
+
+test('getProfile() follows the pairing code profile link', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    const id = 'termpc_R7gX5Ea9bC4DkFj3G';
+    networkMocker.intercept('GET', `/terminals/pairing-codes/${id}`, 200, composePairingCodeResponse(id));
+    networkMocker
+      .intercept('GET', `/profiles/${profileId}`, 200, {
+        resource: 'profile',
+        id: profileId,
+        mode: 'live',
+        _links: {
+          self: { href: `https://api.mollie.com/v2/profiles/${profileId}`, type: 'application/hal+json' },
+          documentation: { href: 'https://docs.mollie.com/reference/get-profile', type: 'text/html' },
+        },
+      })
+      .twice();
+
+    const pairingCode = await mollieClient.terminalPairingCodes.get(id);
+    const profile = await bluster(pairingCode.getProfile.bind(pairingCode))();
+
+    expect(profile.resource).toBe('profile');
+    expect(profile.id).toBe(profileId);
+  });
+});


### PR DESCRIPTION
## What

Adds the **terminal pairing codes** resource (`/v2/terminals/pairing-codes`), exposed as `mollieClient.terminalPairingCodes`. Pairing codes are used to onboard a point-of-sale terminal to a profile.

Operations:

- `create(...)` — request a pairing code (`POST`)
- `get(id, ...)` — retrieve one
- `page(...)` / `iterate(...)` — list (paginated)
- `revoke(id)` — revoke (`DELETE`; resolves to the revoked pairing code)

The create/get responses can include a QR code (base64-encoded SVG data URI) via `include: TerminalPairingCodeInclude.qrCode` (`details.qrCode`).

## Implementation

- Standard resource layout: `data.ts` (+ `PairingCodeStatus` / `TerminalPairingCodeInclude` enums), `TerminalPairingCode` Seal + `transform`, `TerminalPairingCodeHelper` (`getProfile()` for the `profile` link), binder + `parameters.ts`.
- Wired the transformer, the `terminalPairingCodes` binder, the public types, and the `termpc_` id prefix.
- `revoke` resolves to the revoked pairing-code object (matching the API), not a bare boolean.

## Tests

The endpoints do not support test mode yet, so the integration test is skipped (mirroring the existing `terminals` test) until fixtures can be recorded against a live account.

## Docs

- https://docs.mollie.com/reference/terminals-request-pairing-code
- https://docs.mollie.com/reference/terminals-get-pairing-code
- https://docs.mollie.com/reference/terminals-list-pairing-codes
- https://docs.mollie.com/reference/terminals-revoke-pairing-code
