### PR TITLE
feat: sync settlements with the Mollie API spec

### DIFF
--- a/src/binders/settlements/SettlementsBinder.ts
+++ b/src/binders/settlements/SettlementsBinder.ts
@@ -21,7 +21,7 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
    * Beside payments, settlements can be composed of other entities such as refunds, chargebacks or captures.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement
+   * @see https://docs.mollie.com/reference/get-settlement
    */
   public get(id: string): Promise<SettlementModel>;
   public get(id: string, callback: Callback<SettlementModel>): void;
@@ -35,7 +35,7 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
    * Retrieve the details of the current settlement that has not yet been paid out.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement
+   * @see https://docs.mollie.com/reference/get-next-settlement
    */
   public getNext(): Promise<SettlementModel>;
   public getNext(callback: Callback<SettlementModel>): void;
@@ -48,7 +48,7 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
    * Retrieve the details of the open balance of the organization. This will return a settlement object representing your organization's balance.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-open-settlement
+   * @see https://docs.mollie.com/reference/get-open-settlement
    */
   public getOpen(): Promise<SettlementModel>;
   public getOpen(callback: Callback<SettlementModel>): void;
@@ -58,12 +58,12 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
   }
 
   /**
-   * Retrieve all payments links created with the current website profile, ordered from newest to oldest.
+   * Retrieve a list of all your settlements.
    *
    * The results are paginated. See pagination for more information.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
+   * @see https://docs.mollie.com/reference/list-settlements
    */
   public page(parameters?: PageParameters): Promise<Page<SettlementModel>>;
   public page(parameters: PageParameters, callback: Callback<Page<SettlementModel>>): void;
@@ -73,10 +73,10 @@ export default class SettlementsBinder extends Binder<SettlementData, Settlement
   }
 
   /**
-   * Retrieve a single payment link object by its token.
+   * Retrieve a list of all your settlements, iterating over the paginated result set.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+   * @see https://docs.mollie.com/reference/list-settlements
    */
   public iterate(parameters?: IterateParameters) {
     const { valuesPerMinute, ...query } = parameters ?? {};

--- a/src/binders/settlements/payments/SettlementPaymentsBinder.ts
+++ b/src/binders/settlements/payments/SettlementPaymentsBinder.ts
@@ -22,7 +22,7 @@ export default class SettlementPaymentsBinder extends Binder<PaymentData, Paymen
    * Note that payments for Klarna payment methods are not listed in here. These payment methods are settled using captures. To retrieve the captures, use the List settlement captures endpoint.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
+   * @see https://docs.mollie.com/reference/list-settlement-payments
    */
   public page(parameters: PageParameters): Promise<Page<Payment>>;
   public page(parameters: PageParameters, callback: Callback<Page<Payment>>): void;
@@ -38,7 +38,7 @@ export default class SettlementPaymentsBinder extends Binder<PaymentData, Paymen
    * Note that payments for Klarna payment methods are not listed in here. These payment methods are settled using captures. To retrieve the captures, use the List settlement captures endpoint.
    *
    * @since 3.7.0
-   * @see https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
+   * @see https://docs.mollie.com/reference/list-settlement-payments
    */
   public iterate(parameters: IterateParameters) {
     const { settlementId, valuesPerMinute, ...query } = parameters;

--- a/src/createMollieClient.ts
+++ b/src/createMollieClient.ts
@@ -267,5 +267,6 @@ export { TerminalStatus } from './data/terminals/data';
 export { CapabilityStatus, CapabilityStatusReason, RequirementStatus } from './data/capabilities/data';
 export { ClientEmbed } from './data/clients/data';
 export { InvoiceStatus } from './data/invoices/data';
+export { SettlementStatus } from './data/settlements/data';
 export { GrantType as OAuthGrantType, TokenType as OAuthTokenType } from './data/oauth/data';
 export { default as MollieApiError } from './errors/ApiError';

--- a/src/data/settlements/SettlementHelper.ts
+++ b/src/data/settlements/SettlementHelper.ts
@@ -1,10 +1,17 @@
+import { runIf } from 'ruply';
 import breakUrl from '../../communication/breakUrl';
 import type TransformingNetworkClient from '../../communication/TransformingNetworkClient';
+import renege from '../../plumbing/renege';
+import undefinedPromise from '../../plumbing/undefinedPromise';
 import { type Capture } from '../../types';
+import type Callback from '../../types/Callback';
+import type Maybe from '../../types/Maybe';
 import { type ThrottlingParameter } from '../../types/parameters';
 import type Chargeback from '../chargebacks/Chargeback';
 import { type ChargebackData } from '../chargebacks/Chargeback';
 import Helper from '../Helper';
+import { type InvoiceData } from '../invoices/data';
+import type Invoice from '../invoices/Invoice';
 import { type CaptureData } from '../payments/captures/data';
 import { type PaymentData } from '../payments/data';
 import type Payment from '../payments/Payment';
@@ -59,5 +66,23 @@ export default class SettlementHelper extends Helper<SettlementData, SettlementM
   public getCaptures(parameters?: ThrottlingParameter) {
     const [pathname, query] = breakUrl(this.links.captures.href);
     return this.networkClient.iterate<CaptureData, Capture>(pathname, 'captures', query, parameters?.valuesPerMinute);
+  }
+
+  /**
+   * Returns the invoice that contains this settlement, if an invoice has been created for it.
+   *
+   * @since 4.6.0
+   */
+  public getInvoice(): Promise<Invoice> | Promise<undefined>;
+  public getInvoice(callback: Callback<Maybe<Invoice>>): void;
+  public getInvoice() {
+    if (renege(this, this.getInvoice, ...arguments)) return;
+    return (
+      runIf(
+        this.links.invoice,
+        ({ href }) => breakUrl(href),
+        ([pathname, query]) => this.networkClient.get<InvoiceData, Invoice>(pathname, query),
+      ) ?? undefinedPromise
+    );
   }
 }

--- a/src/data/settlements/data.ts
+++ b/src/data/settlements/data.ts
@@ -8,50 +8,61 @@ export interface SettlementData extends Model<'settlement'> {
   /**
    * The settlement's bank reference, as found in your Mollie account and on your bank statement.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=reference#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=reference#response
    */
   reference: string;
   /**
    * The date on which the settlement was created, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=createdAt#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=createdAt#response
    */
   createdAt: string;
   /**
    * The date on which the settlement was settled, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format. When requesting the open settlement or next settlement the return value is `null`.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=settledAt#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=settledAt#response
    */
   settledAt: Nullable<string>;
   /**
    * The status of the settlement.
    *
-   * Possible values:
-   *
-   * -   `open` The settlement has not been closed yet.
-   * -   `pending` The settlement has been closed and is being processed.
-   * -   `paidout` The settlement has been paid out.
-   * -   `failed` The settlement could not be paid out.
-   *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=status#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=status#response
    */
-  status: 'open' | 'pending' | 'paidout' | 'failed';
+  status: SettlementStatus;
   /**
    * The total amount paid out with this settlement.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=amount#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=amount#response
    */
   amount: Amount;
   /**
-   * The total amount paid out with this settlement.
+   * The balance token that the settlement was settled to.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=amount#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=balanceId#response
+   */
+  balanceId: string;
+  /**
+   * The ID of the oldest invoice created for all the periods, if the invoice has been created yet.
+   *
+   * @see https://docs.mollie.com/reference/get-settlement?path=invoiceId#response
+   */
+  invoiceId?: string;
+  /**
+   * For bookkeeping purposes, the settlement includes an overview of transactions included in the settlement. These transactions are grouped into 'period' objects — one for each calendar month.
+   *
+   * For example, if a settlement includes funds from 15 April until 4 May, it will include two period objects. One for all transactions processed between 15 April and 30 April, and one for all transactions between 1 May and 4 May.
+   *
+   * Period objects are grouped by year, and then by month. So in the above example, the full `periods` collection will look as follows: `{"2024": {"04": {...}, "05": {...}}}`. The year and month in this documentation are referred as `<year>` and `<month>`.
+   *
+   * The example response should give a good idea of what this looks like in practise.
+   *
+   * @see https://docs.mollie.com/reference/get-settlement?path=periods#response
    */
   periods: Record<string, Record<string, Period>>;
   /**
    * An object with several URL objects relevant to the settlement. Every URL object will contain an `href` and a `type` field.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=_links#response
    */
   _links: SettlementLinks;
 }
@@ -62,13 +73,13 @@ interface Period {
   /**
    * An array of revenue objects containing the total revenue for each payment method during this period. Each object has the following fields.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=periods/revenue#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=periods/revenue#response
    */
   revenue: Array<{ description: string; method: string; count: number; amountNet: Amount; amountVat: Amount; amountGross: Amount }>;
   /**
    * An array of Cost objects, describing the fees withheld for each payment method during this period. Each object has the following fields.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=periods/costs#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=periods/costs#response
    */
   costs: Array<{ description: string; method: string; count: number; rate: { fixed: Amount; variable: string }; amountNet: Amount; amountVat: Amount; amountGross: Amount }>;
   /**
@@ -76,40 +87,69 @@ interface Period {
    *
    * If an individual month/period has not been invoiced yet, then this field will not be present until that invoice is created.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=periods/invoiceId#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=periods/invoiceId#response
    */
   invoiceId: string;
+  /**
+   * The invoice reference, if the invoice has been created already.
+   *
+   * @see https://docs.mollie.com/reference/get-settlement?path=periods/invoiceReference#response
+   */
+  invoiceReference?: string;
 }
 
 interface SettlementLinks extends Links {
   /**
    * The API resource URL of the payments that are included in this settlement.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/payments#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=_links/payments#response
    */
   payments: Url;
   /**
    * The API resource URL of the refunds that are included in this settlement.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/refunds#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=_links/refunds#response
    */
   refunds: Url;
   /**
    * The API resource URL of the chargebacks that are included in this settlement.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/chargebacks#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=_links/chargebacks#response
    */
   chargebacks: Url;
   /**
    * The API resource URL of the captures that are included in this settlement.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/captures#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=_links/captures#response
    */
   captures: Url;
   /**
-   * The API resource URL of the invoice that contains this settlement.
+   * The API resource URL of the invoice that contains this settlement, if an invoice has been created for it. Omitted for the open and next settlements.
    *
-   * @see https://docs.mollie.com/reference/v2/settlements-api/get-settlement?path=_links/invoice#response
+   * @see https://docs.mollie.com/reference/get-settlement?path=_links/invoice#response
    */
-  invoice: Url;
+  invoice?: Url;
+}
+
+export enum SettlementStatus {
+  /**
+   * The settlement has not been closed yet.
+   */
+  open = 'open',
+  /**
+   * The settlement has been closed and is being processed.
+   */
+  pending = 'pending',
+  /**
+   * The settlement is being processed by the bank.
+   */
+  processingAtBank = 'processing-at-bank',
+  /**
+   * The settlement has been paid out.
+   */
+  paidout = 'paidout',
+  /**
+   * The settlement could not be paid out.
+   */
+  failed = 'failed',
 }

--- a/tests/scenarios/settlements.test.ts
+++ b/tests/scenarios/settlements.test.ts
@@ -109,6 +109,7 @@ describe('settlements', () => {
             },
           },
         },
+        balanceId: 'bal_gVMhHKqSSRYJyPsuoPNFH',
         invoiceId: 'inv_FrvewDA3Pr',
         _links: {
           self: {
@@ -147,9 +148,95 @@ describe('settlements', () => {
   test('settlements', async () => {
     let settlement = await mollieClient.settlements.get('stl_jDk30akdN');
     expect(settlement.id).toBe('stl_jDk30akdN');
+    expect(settlement.balanceId).toBe('bal_gVMhHKqSSRYJyPsuoPNFH');
 
     settlement = await mollieClient.settlements.get('1234567.1804.03');
     expect(settlement.reference).toBe('1234567.1804.03');
+  });
+
+  test('settlementInvoice', async () => {
+    networkMocker
+      .intercept('GET', '/invoices/inv_FrvewDA3Pr', 200, {
+        resource: 'invoice',
+        id: 'inv_FrvewDA3Pr',
+        reference: '2018.10000',
+        vatNumber: 'NL001234567B01',
+        status: 'paid',
+        netAmount: { value: '35.07', currency: 'EUR' },
+        vatAmount: { value: '7.36', currency: 'EUR' },
+        grossAmount: { value: '42.43', currency: 'EUR' },
+        lines: [
+          {
+            period: '2018-04',
+            description: 'iDEAL transaction costs',
+            count: 6,
+            vatPercentage: 21,
+            amount: { value: '2.10', currency: 'EUR' },
+          },
+        ],
+        issuedAt: '2018-05-01',
+        paidAt: '2018-05-14',
+        _links: {
+          self: {
+            href: 'https://api.mollie.com/v2/invoices/inv_FrvewDA3Pr',
+            type: 'application/hal+json',
+          },
+          documentation: {
+            href: 'https://docs.mollie.com/reference/get-invoice',
+            type: 'text/html',
+          },
+        },
+      })
+      .once();
+
+    const settlement = await mollieClient.settlements.get('stl_jDk30akdN');
+    const invoice = await settlement.getInvoice();
+    expect(invoice?.id).toBe('inv_FrvewDA3Pr');
+    expect(invoice?.status).toBe('paid');
+
+    // The open settlement has no invoice link, so getInvoice() resolves to undefined.
+    networkMocker
+      .intercept('GET', '/settlements/open', 200, {
+        resource: 'settlement',
+        id: 'stl_open',
+        reference: '1234567.1805.03',
+        createdAt: '2018-05-01T06:00:01.0Z',
+        settledAt: null,
+        status: 'open',
+        amount: { value: '0.00', currency: 'EUR' },
+        balanceId: 'bal_gVMhHKqSSRYJyPsuoPNFH',
+        periods: {},
+        _links: {
+          self: {
+            href: 'https://api.mollie.com/v2/settlements/open',
+            type: 'application/hal+json',
+          },
+          payments: {
+            href: 'https://api.mollie.com/v2/settlements/open/payments',
+            type: 'application/hal+json',
+          },
+          refunds: {
+            href: 'https://api.mollie.com/v2/settlements/open/refunds',
+            type: 'application/hal+json',
+          },
+          chargebacks: {
+            href: 'https://api.mollie.com/v2/settlements/open/chargebacks',
+            type: 'application/hal+json',
+          },
+          captures: {
+            href: 'https://api.mollie.com/v2/settlements/open/captures',
+            type: 'application/hal+json',
+          },
+          documentation: {
+            href: 'https://docs.mollie.com/reference/get-open-settlement',
+            type: 'text/html',
+          },
+        },
+      })
+      .once();
+
+    const open = await mollieClient.settlements.getOpen();
+    expect(await open.getInvoice()).toBeUndefined();
   });
 
   test('settlementPayments', async () => {


### PR DESCRIPTION
> **Stacked on #506 (Invoices API).** The `getInvoice()` helper depends on the `Invoice` resource that PR adds, so this branch is based on `feat/invoices-api`. Review/merge #506 first; rebase onto `master` once it lands.

Syncs the settlements resource against the master OpenAPI spec (`/sync-api settlements`).

## Structure
- Add `SettlementData.balanceId` (required), top-level `invoiceId?`, and `Period.invoiceReference?`.
- Add `SettlementHelper.getInvoice()` — fetches the typed `Invoice` (from #506) via `_links.invoice`, resolving to `undefined` when no invoice has been created.

## Types
- `status` is now an exported `SettlementStatus` enum (was an inline union) — aligns settlements with every other resource and the new `InvoiceStatus`, and adds the `processing-at-bank` status.
- `_links.invoice` is now optional (`invoice?: Url`) — it is absent on the open and next settlements.

Both are **minor** type changes, effectively non-breaking for read-consumers: enum comparisons / `switch` / assignment to the old union still type-check, and `_links` is helper-abstracted. Only *constructing* a settlement object with a string-literal status, or reaching into `_links.invoice` directly, is affected.

## Docs
- Fix copy-pasted JSDoc on `periods` (was duplicated from `amount`) and on `SettlementsBinder.page()` / `iterate()` (was payment-links text).
- Modernise all `@see` links to the `/reference/<slug>` format.

## Deferred (breaking → #489)
- `Period.costs[].rate.variable` → spec `percentage` (rename).
- `Period.invoiceId` required → optional.

## Docs reference
- https://docs.mollie.com/reference/get-settlement
- https://docs.mollie.com/reference/list-settlements
- https://docs.mollie.com/reference/get-next-settlement
- https://docs.mollie.com/reference/get-open-settlement
- https://docs.mollie.com/reference/get-invoice
