### PR TITLE
feat: complete Routes API coverage (get endpoint + payment link)

### DIFF
--- a/src/binders/payments/routes/PaymentRoutesBinder.ts
+++ b/src/binders/payments/routes/PaymentRoutesBinder.ts
@@ -7,7 +7,7 @@ import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
-import { type CreateParameters, type IterateParameters, type PageParameters } from './parameters';
+import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
 
 function getPathSegments(paymentId: string) {
   return `payments/${paymentId}/routes`;
@@ -32,6 +32,22 @@ export default class PaymentRoutesBinder extends Binder<RouteData, Route> {
     const { paymentId, ...data } = parameters;
     assertWellFormedId(paymentId, 'payment');
     return this.networkClient.post<RouteData, Route>(getPathSegments(paymentId), data);
+  }
+
+  /**
+   * Retrieve a single route created for a specific payment.
+   *
+   * @since 4.6.0
+   * @see https://docs.mollie.com/reference/payment-get-route
+   */
+  public get(id: string, parameters: GetParameters): Promise<Route>;
+  public get(id: string, parameters: GetParameters, callback: Callback<Route>): void;
+  public get(id: string, parameters: GetParameters) {
+    if (renege(this, this.get, ...arguments)) return;
+    assertWellFormedId(id, 'route');
+    const { paymentId, ...query } = parameters;
+    assertWellFormedId(paymentId, 'payment');
+    return this.networkClient.get<RouteData, Route>(`${getPathSegments(paymentId)}/${id}`, query);
   }
 
   /**

--- a/src/binders/payments/routes/parameters.ts
+++ b/src/binders/payments/routes/parameters.ts
@@ -12,6 +12,8 @@ interface ContextParameters extends TestModeParameter {
 
 export type CreateParameters = ContextParameters & Pick<RouteData, 'amount' | 'description' | 'destination'> & IdempotencyParameter;
 
+export type GetParameters = ContextParameters;
+
 export type PageParameters = ContextParameters & PaginationParameters;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/data/payments/routes/RouteHelper.ts
+++ b/src/data/payments/routes/RouteHelper.ts
@@ -1,5 +1,10 @@
 import type TransformingNetworkClient from '../../../communication/TransformingNetworkClient';
+import breakUrl from '../../../communication/breakUrl';
+import renege from '../../../plumbing/renege';
+import type Callback from '../../../types/Callback';
 import Helper from '../../Helper';
+import type Payment from '../Payment';
+import { type PaymentData } from '../data';
 import type Route from './Route';
 import { type RouteData } from './data';
 
@@ -9,5 +14,17 @@ export default class RouteHelper extends Helper<RouteData, Route> {
     protected readonly links: RouteData['_links'],
   ) {
     super(networkClient, links);
+  }
+
+  /**
+   * Returns the payment this route belongs to.
+   *
+   * @since 4.6.0
+   */
+  public getPayment(): Promise<Payment>;
+  public getPayment(callback: Callback<Payment>): void;
+  public getPayment() {
+    if (renege(this, this.getPayment, ...arguments)) return;
+    return this.networkClient.get<PaymentData, Payment>(...breakUrl(this.links.payment.href));
   }
 }

--- a/src/data/payments/routes/data.ts
+++ b/src/data/payments/routes/data.ts
@@ -1,4 +1,4 @@
-import { type Amount, type Links } from '../../global';
+import { type Amount, type Links, type Url } from '../../global';
 import type Model from '../../Model';
 
 export interface RouteData extends Model<'route'> {
@@ -38,7 +38,16 @@ export interface RouteData extends Model<'route'> {
    *
    * @see https://docs.mollie.com/reference/payment-create-route?path=_links#response
    */
-  _links: Links;
+  _links: RouteLinks;
+}
+
+interface RouteLinks extends Links {
+  /**
+   * The API resource URL of the payment this route belongs to.
+   *
+   * @see https://docs.mollie.com/reference/payment-create-route?path=_links/payment#response
+   */
+  payment: Url;
 }
 
 export interface RouteDestination {

--- a/src/plumbing/assertWellFormedId.ts
+++ b/src/plumbing/assertWellFormedId.ts
@@ -15,6 +15,7 @@ const prefixes = {
   'payment-link': 'pl_',
   'profile': 'pfl_',
   'refund': 're_',
+  'route': 'crt_',
   'shipment': 'shp_',
   'subscription': 'sub_',
   'terminal': 'term_',

--- a/tests/unit/resources/payments/routes.test.ts
+++ b/tests/unit/resources/payments/routes.test.ts
@@ -20,6 +20,10 @@ function composeRouteResponse(paymentId = 'tr_5B8cwPMGnU6qLbRvo7qEZo', routeId =
         href: `https://api.mollie.com/v2/payments/${paymentId}/routes/${routeId}`,
         type: 'application/hal+json',
       },
+      payment: {
+        href: `https://api.mollie.com/v2/payments/${paymentId}`,
+        type: 'application/hal+json',
+      },
       documentation: {
         href: 'https://docs.mollie.com/reference/payment-create-route',
         type: 'text/html',
@@ -45,6 +49,11 @@ function testRoute(route, paymentId = 'tr_5B8cwPMGnU6qLbRvo7qEZo', routeId = 'cr
 
   expect(route._links.self).toEqual({
     href: `https://api.mollie.com/v2/payments/${paymentId}/routes/${routeId}`,
+    type: 'application/hal+json',
+  });
+
+  expect(route._links.payment).toEqual({
+    href: `https://api.mollie.com/v2/payments/${paymentId}`,
     type: 'application/hal+json',
   });
 
@@ -76,6 +85,18 @@ test('createRoute', () => {
     const { createdAt: _expectedCreatedAt, ...expectedWithoutCreatedAt } = composeRouteResponse('tr_5B8cwPMGnU6qLbRvo7qEZo', 'crt_dyARQ3JzCgtPDhU2Pbq3J');
 
     expect(routeWithoutCreatedAt).toMatchObject(expectedWithoutCreatedAt);
+  });
+});
+
+test('getRoute', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/payments/tr_5B8cwPMGnU6qLbRvo7qEZo/routes/crt_dyARQ3JzCgtPDhU2Pbq3J', 200, composeRouteResponse('tr_5B8cwPMGnU6qLbRvo7qEZo', 'crt_dyARQ3JzCgtPDhU2Pbq3J')).twice();
+
+    const route = await bluster(mollieClient.paymentRoutes.get.bind(mollieClient.paymentRoutes))('crt_dyARQ3JzCgtPDhU2Pbq3J', { paymentId: 'tr_5B8cwPMGnU6qLbRvo7qEZo' });
+
+    expect(typeof route.getPayment).toBe('function');
+
+    testRoute(route);
   });
 });
 


### PR DESCRIPTION
## What

Completes the Routes API coverage, which shipped in 4.4.0 missing two things the API actually provides.

### Single-route retrieval (`get`)
Adds `paymentRoutes.get(id, parameters)` for [`payment-get-route`](https://docs.mollie.com/reference/payment-get-route). The binder previously exposed only `create`/`page`/`iterate`, so a route could be created and listed but never fetched by id. Registers the `crt_` id prefix in `assertWellFormedId` so the route id is validated like every other resource.

### Payment link + helper
The API returns a `payment` link on every route (on [create](https://docs.mollie.com/reference/payment-create-route), [get](https://docs.mollie.com/reference/payment-get-route), and each [list](https://docs.mollie.com/reference/payment-list-routes) item), but `RouteData._links` was typed as the generic `Links` (`self` + `documentation` only), so consumers couldn't reach it. Adds `RouteLinks.payment` and a `getPayment()` helper so a route can resolve back to its payment without touching the private `_links` object.

## Tests
- New `getRoute` test exercises the `get` method end-to-end (promise + callback via `bluster`).
- `_links.payment` added to the shared route mock and asserted in `testRoute`, so `createRoute`/`getRoute`/`listRoutes` all validate it.
- Full unit suite green (41 suites / 124 tests).

## Notes
- Non-breaking: both additions widen the public surface (new method, new link/helper); nothing is removed or narrowed.
- `@since 4.6.0` on the new method and helper.
