### PR TITLE
feat(applePay): add profileId to payment session request

### DIFF
--- a/src/binders/applePay/ApplePayBinder.ts
+++ b/src/binders/applePay/ApplePayBinder.ts
@@ -30,7 +30,7 @@ export default class ApplePayBinder {
    * For the full documentation, see the official [Apple Pay JS API](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api) documentation.
    *
    * @since 3.5.0
-   * @see https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session
+   * @see https://docs.mollie.com/reference/request-apple-pay-payment-session
    */
   public requestPaymentSession(parameters: RequestPaymentSessionParameters): Promise<ApplePaySession>;
   public requestPaymentSession(parameters: RequestPaymentSessionParameters, callback: Callback<ApplePaySession>): void;

--- a/src/binders/applePay/parameters.ts
+++ b/src/binders/applePay/parameters.ts
@@ -7,13 +7,22 @@ export interface RequestPaymentSessionParameters extends IdempotencyParameter {
    * A [list of all valid host names](https://developer.apple.com/documentation/apple_pay_on_the_web/setting_up_your_server#3172427) for merchant validation is available. You should white list these
    * in your application and reject any `validationUrl` that have a host name not in the list.
    *
-   * @see https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session?path=validationUrl#parameters
+   * @see https://docs.mollie.com/reference/request-apple-pay-payment-session?path=validationUrl#parameters
    */
   validationUrl: string;
   /**
    * The domain of your web shop, that is visible in the browser's location bar. For example `pay.myshop.com`.
    *
-   * @see https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session?path=domain#parameters
+   * @see https://docs.mollie.com/reference/request-apple-pay-payment-session?path=domain#parameters
    */
   domain: string;
+  /**
+   * The identifier referring to the [profile](https://docs.mollie.com/reference/get-profile) this entity belongs to.
+   *
+   * Most API credentials are linked to a single profile. In these cases the `profileId` must not be sent in the creation request. For organization-level credentials such as OAuth access tokens however, the
+   * `profileId` parameter is required.
+   *
+   * @see https://docs.mollie.com/reference/request-apple-pay-payment-session?path=profileId#parameters
+   */
+  profileId?: string;
 }


### PR DESCRIPTION
## Summary

Syncs the Apple Pay wallet types against the Mollie OpenAPI spec (`request-apple-pay-payment-session`).

- Add `profileId?: string` to `RequestPaymentSessionParameters`. Required for organization-level credentials (e.g. OAuth access tokens), omitted for single-profile API keys. Modeled inline (request-only here — the response is the opaque Apple Pay session object), consistent with how the other binders expose `profileId`.
- Refresh three `@see` links from the legacy `/reference/v2/wallets-api/...` format to the current `/reference/...` format — the `validationUrl` and `domain` params plus the `requestPaymentSession` binder method.

All non-breaking: one added optional field plus doc-link updates.

## Docs reference

https://docs.mollie.com/reference/request-apple-pay-payment-session

## Verification

- `yarn build:declarations` ✓ (tsc over the full type graph)
- `eslint` ✓
- `prettier` ✓