### PR TITLE
chore: add sync-api skill for reconciling the SDK with the Mollie API

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Resource Architecture
+
+Each API resource (payments, refunds, customers, etc.) is composed of up to four parts:
+
+```
+src/
+├── data/<resource>/
+│   ├── data.ts              # Response type + enums
+│   ├── <Resource>.ts        # Sealed public type + transform()
+│   └── <Resource>Helper.ts  # Instance methods (optional)
+│
+└── binders/<resource>/
+    ├── <Resource>Binder.ts  # Endpoint methods (create, get, page, ...)
+    └── parameters.ts        # Request types per operation
+```
+
+## `data.ts` — Response shape
+
+- Defines `*Data` interface extending `Model<'resource-name'>` — the raw API response
+- Contains enums (statuses, embed/include options) and `*Links` interfaces
+- Source of truth for field names and types; `parameters.ts` reuses fields from here via `Pick`
+
+## `<Resource>.ts` — Sealed type + transform
+
+- Defines `type Resource = Seal<ResourceData, ResourceHelper>`
+- `Seal<M, H>` = `Readonly<M> & H` — frozen data properties merged with helper methods
+- `transform()` creates the sealed object and recursively transforms embedded sub-resources
+- This is what SDK consumers interact with
+
+## `<Resource>Helper.ts` — Instance methods
+
+- Extends `Helper<Data, Resource>` base class (provides `refresh()`, toString, inspect)
+- Adds convenience methods for navigating related resources (e.g. `getRefunds()`, `getPayment()`)
+- Not every resource needs a custom helper — simple resources use the base `Helper` directly
+- Wired to the sealed type via `Object.assign(Object.create(new Helper(...)), data)`
+
+## `<Resource>Binder.ts` — Endpoint methods
+
+- Extends `Binder<ResourceData, Resource>`
+- One public method per API operation: `create`, `get`, `page`, `iterate`, `update`, `cancel`/`delete`
+- Delegates to `TransformingNetworkClient`, which auto-applies `transform()` to responses
+
+## `parameters.ts` — Request types
+
+- One type per operation (`CreateParameters`, `GetParameters`, `PageParameters`, etc.)
+- Composed from the Data interface via `Pick` (preserves optionality) and `PickOptional` (forces optional)
+- Request-only fields (not in response) are defined inline here
+- Shared mixins (from `src/types/parameters.ts`): `IdempotencyParameter`, `PaginationParameters`, `SortParameter`, `ThrottlingParameter`, `TestModeParameter`
+- Nested resources include context params (e.g. `paymentId: string`)
+
+## Wiring
+
+New resources must be registered in `createMollieClient.ts`:
+1. Import and register the transformer: `.add('resource-name', transformResource)`
+2. Instantiate and expose the binder: `resourceName: new ResourceBinder(transformingNetworkClient)`
+
+Public types are exported from `src/types.ts` (sealed types, parameter type aliases, enums).
+`*Data` interfaces and helpers are internal — not exported to consumers.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,56 @@
+# Mollie API Node.js SDK
+
+Official Node.js client (`@mollie/api-client`) for the Mollie Payment API v2.
+
+Resource layer structure (data, binders, helpers, parameters) is documented in `.claude/ARCHITECTURE.md`.
+
+## Commands
+
+```bash
+yarn build          # Rollup bundle (CJS + ESM) + TypeScript declarations
+yarn test           # Jest tests
+yarn test:watch     # Jest watch mode
+yarn test:cov       # Coverage report
+yarn lint           # ESLint fix + Prettier
+```
+
+## Type System — Request vs Response
+
+IMPORTANT: `data.ts` and `parameters.ts` are **not** two views of the same type. They are separate concerns:
+
+- `data/<resource>/data.ts` → **response** shape (what the API returns). This is the source of truth for field names and types.
+- `binders/<resource>/parameters.ts` → **request** shape (what the consumer sends). Built by `Pick`/`PickOptional` from the Data interface, plus request-only fields that don't appear in responses (e.g. `applePayPaymentToken`, `cardToken`).
+
+`Pick<Data, ...>` preserves optionality from the response type. `PickOptional<Data, ...>` forces fields optional ("exists on response, but optional to send").
+
+Do NOT add request-only fields to `data.ts` — they belong in `parameters.ts`.
+
+## Helpers and underscore-prefixed fields
+
+Consumers should never access underscore-prefixed properties directly (the `_` prefix denotes private/internal, e.g. `_links`, `_embedded`). Helper methods (e.g. `payment.getRefunds()`) abstract these away — they transparently return embedded data if available, or fetch via the API link if not. This is why helpers exist: a single entry point regardless of whether data was embedded or needs fetching.
+
+## Conventions
+
+- Conventional commits for all commit messages.
+- `prefer-rest-params` is intentionally off — the `arguments` object is used deliberately in the renege (promise↔callback) pattern. Don't refactor these to rest params.
+- New transformers must be registered in `createMollieClient.ts` alongside the binder wiring.
+- Enums and public types are exported from `src/createMollieClient.ts` and `src/types.ts`.
+
+## Release Process
+
+Publishing is automated via `.github/workflows/publish.yml` (npm Trusted Publishing / OIDC) — it runs when a GitHub Release is published. There is **no manual `npm publish`** and no npm token.
+
+1. Update `CHANGELOG.md`
+2. `npm version <major|minor|patch>` (bumps `package.json`, commits, creates the `vX.Y.Z` tag)
+3. `git push --follow-tags`
+4. Publish a GitHub Release for the tag → the workflow verifies the tag matches `package.json`, builds, runs unit tests, and publishes with provenance (prereleases like `-rc.N` go to their own dist-tag, not `latest`).
+
+See `CONTRIBUTING.md` for the maintainer-facing version of this.
+
+## Gotchas
+
+- **Mollie API docs are unreliable for optionality/nullability.** Fields marked `required` may work fine without sending them (e.g. `redirectUrl`). Fields typed as `object` (not nullable) may actually be optional (e.g. `billingAddress`). Fields typed as `string | null` are likely optional too (absent from responses despite not being marked optional). Never auto-apply optionality from the docs — flag discrepancies for manual review instead.
+- **Nullable vs optional convention**: `Nullable<T>` (`T | null`) = always present, sometimes null. `T?` = sometimes absent. `?: Nullable<T>` = both. Default to `?` (optional) when uncertain, upgrade to `Nullable<T>` only when confirmed via actual API behavior.
+- **Mollie docs .md trick** — append `.md` to any reference page URL (e.g. `https://docs.mollie.com/reference/create-payment.md`) to get plain-text markdown with fully resolved OpenAPI JSON. No browser automation needed. The GitHub repo `mollie/openapi` (`specs.yaml`) has the full spec but uses `$ref`s.
+- **node-fetch v2** (CommonJS) is the HTTP client, not native fetch.
+- **Node version: README says 14+, `engines` says `>=8` — this mismatch is intentional, do not "fix" it.** The SDK's *code* is expected to run on Node 8+, hence `engines.node: ">=8"`. But the *test environment* won't run on anything older than Node 14, so 14 is the lowest version we can actually verify. The policy: we guarantee it works on 14, and it *probably* works on older versions down to 8 — we just can't prove it. README states 14 (the supported/tested floor); `engines` states 8 (the believed-actual floor). Aligning the two numbers would either drop unverified-but-likely support or claim guarantees we can't back.

--- a/.claude/skills/sync-api/SKILL.md
+++ b/.claude/skills/sync-api/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: sync-api
+description: Reconcile the SDK against the Mollie API spec — checks and optionally fixes types, JSDoc, enums, deprecations, endpoint coverage, and helper wiring. Use when verifying or syncing the SDK with the official API for a single endpoint, a resource, or the whole SDK.
+---
+
+# Sync Types with Mollie API
+
+Compare the SDK's TypeScript types against Mollie's master OpenAPI spec and optionally apply fixes. A bundled toolchain does the **deterministic** work (fetch, resolve, flatten, diff); you apply the **judgment** (Pick-vs-inline, nullability, breaking changes, deprecation, JSDoc). Spend your tokens on judgment, not on parsing JSON.
+
+## Usage
+
+`/sync-api <target> [--only structure,docs,wiring]`
+
+`<target>` is a **single token** — one of:
+
+- **operationId** (e.g. `get-payment`, `create-refund`) — one endpoint
+- **resource** (e.g. `refunds`, `payments`) — every endpoint of that resource
+- **all** — every resource (parallel agents, one per resource)
+
+`--only` scopes which phases run (default: all three). "just sync the docs" → `--only docs`. If the target doesn't match a known operationId (via `extract-spec.mjs --index`) or resource directory, ask rather than guessing.
+
+## Source of truth
+
+The master spec `mollie/openapi:specs.yaml` (operationId **is** the endpoint key, complete, all `$ref`s local). The toolchain fetches and caches it (ETag-validated) under `.tmp/sync-api/`.
+
+**Do NOT hand-fetch doc pages to read schemas.** Doc-site slugs are inconsistent with operationIds (e.g. spec `list-chargebacks` = doc `list-payment-chargebacks`; `create-payment-refund.md` 404s — it's `create-refund`) and a wrong slug returns a 200-status 404 page that parses as an empty "in sync" result. Doc pages are only used for `@see` URLs, always HTTP-200-verified before writing (see `references/apply.md`).
+
+## Toolchain (`scripts/`, run via Bash)
+
+Run from the **repo root** (paths below are repo-root-relative; the scripts resolve the repo root themselves, so the working directory only matters for locating the script file).
+
+| Command | Output |
+|---|---|
+| `node .claude/skills/sync-api/scripts/extract-spec.mjs --index` | every operation: `METHOD path -> operationId` |
+| `node .claude/skills/sync-api/scripts/extract-spec.mjs <operationId> [--side response\|request\|params] [--show\|--json]` | bare: summary + self-check status. `--show`: rendered digest. `--json`: digest rows. Default side: `response` (GET) / `request` (POST/PATCH/PUT). |
+| `node .claude/skills/sync-api/scripts/extract-spec.mjs <operationId> --meta [--json]` | the **operation's** own `summary` / `description` / `deprecated` — the anchor for the binder-method JSDoc check (Phase 2) |
+| `node .claude/skills/sync-api/scripts/extract-sdk.mjs <file.ts> [--json]` | SDK structural map: `Pick`/`PickOptional`/inline/heritage, JSDoc, `@see`, **duplicate fields**; for a binder, also `.methods[]` (method name + JSDoc + `@see`) |
+| `node .claude/skills/sync-api/scripts/diff.mjs <operationId> <file.ts> <TypeName>` | deterministic field delta: missing / extra / type+doc drift. Side is chosen from the SDK type (see below); `readOnly`/`writeOnly` filtered accordingly; bases resolved (incl. cross-file). Field-level only — method JSDoc is Phase 2. |
+
+The digest preserves every description **verbatim** — that prose (deprecations, constraints, access restrictions, method-specific relevance) is the core value and the scripts never summarize it. If `extract-spec.mjs` exits **non-zero on a digest**, a description was dropped — treat as a bug, do not proceed on partial data. (A missing *side* — e.g. a `204 No Content` response, or a GET with no query params — is a clean exit 0 with empty output, not an error.) The spec is fetched once and cached; a recent cache is reused without a network call. Offline → it warns once and uses the cache; pass `--refresh` to force a re-fetch.
+
+## Step 1 — Analyze
+
+For each operation in scope:
+
+1. **Discover** the SDK side. Glob the resource's files (`src/data/**/<resource>/*.ts`, `src/binders/**/<resource>/*.ts`); run `extract-sdk.mjs <data.ts> --json` and `extract-sdk.mjs <parameters.ts> --json` to see the exported types.
+2. **Run `diff.mjs`** for each operation against its SDK mirror(s). An operation has up to **two** mirrors, and `diff.mjs` picks the comparison side automatically from the SDK type you pass:
+   - **Response** ↔ the resource's `Data` interface — `diff <op> <data.ts> <ResourceData>` (every GET/POST/PATCH that returns a body).
+   - **Request body + query params** ↔ the operation's `*Parameters` type — `diff <op> <parameters.ts> <OpParameters>` (`Create*`/`Update*` for body; `Get*`/`Page*`/`Iterate*` for query params; `Cancel*`/`Delete*` for `testmode`-only bodies).
+
+   Run both where both exist. The diff is the mechanical delta; spend judgment on it, not on re-deriving it.
+3. **Apply judgment** over the delta + the verbatim descriptions, across three phases **in order** (each depends on the previous being resolved):
+
+### Phase 1 — Structure
+
+Resolve the `diff` "MISSING" / "IN SDK not in spec" / type findings:
+
+- **Missing fields** — add with `?` optional by default, always with JSDoc (the spec description, verbatim) and an `@see` link.
+- **Where a request field lives — `Pick` vs inline (the hardest call):** a field belongs **inline** in `parameters.ts` ONLY if (a) it exists on no `Data` interface anywhere in `src/data/` (request-only / `writeOnly`, e.g. `cardToken`, `dueDate`), OR (b) the spec genuinely differs between request and response for that field (different description, constraints, or type — compare both). Otherwise use `Pick`/`PickOptional` from the owning `Data` interface. `extract-sdk.mjs` flags fields defined via `Pick` **and** inline (`⚠️ DUPLICATES`) — those must be deduplicated to `Pick`/`PickOptional` (verify the `Data` interface's JSDoc is complete first, since it becomes canonical).
+- **Always `Pick`, never `Omit`** — `Omit` silently leaks newly-added source fields.
+- **"IN SDK, not in spec" — never auto-remove; judge over-declaration vs spec-incompleteness.** Param-absence is a *proxy*, not proof. When the spec's operation description explains the absence, `diff.mjs` appends it as `— spec note: "…"` — that prose is authoritative (e.g. `testmode` on the terminals pairing endpoints: *"does not support test mode yet"* → a real over-declaration; mind the **"yet"** — the answer may be "keep, support is imminent"). With **no** spec note (e.g. `testmode` on the live-only settlement endpoints), it's a softer call — genuinely unsupported, or just unlisted by Mollie? Flag under "Needs attention" either way.
+- **`_links` / `_embedded` entries are structure too** — `diff.mjs` flags a missing link/embed property as `[P1] _links.<name>: in spec, not on <Links interface>`. Add the property (e.g. to the `*Links` interface) with JSDoc, exactly like any other field. (The *helper* for it is a separate concern — Phase 3.)
+- **Response-only (`readOnly`) fields on shared interfaces** stay **required** on the `Data` interface (matching the response); the request strips them via `Pick`. Never weaken a response type because a field isn't sent in requests.
+- **Enums / types** — add missing enum values; fix genuine type mismatches.
+
+**Nullable vs optional (see CLAUDE.md for the project convention):**
+- On **request** fields, spec `type: [..,'null']` does **NOT** mean `T | null`. Sending `null` to clear a field is a distinct semantic most Mollie fields don't support — default to `T` unless the description explicitly says `null` clears the value.
+- Never downgrade an existing `Nullable<T>` (confirmed behavior). Don't auto-flip optionality from the spec — the docs are unreliable here.
+
+**⚠️ BREAKING CHANGES — warn loudly, never auto-apply.** Removing/renaming a field/type/enum/method; optional→required on a request param; **required→optional on a response field** (breaks consumers doing `obj.field.prop`, even if the spec says optional — the SDK may keep it required based on observed behavior); type changes. Prefix with `⚠️ BREAKING:` under "Needs attention", explain why, and prefer non-breaking alternatives (add alongside, `@deprecated` the old, union types). Response optionality changes require explicit user confirmation.
+
+### Phase 2 — Documentation
+
+On the **final** field locations (after Phase 1):
+
+- **Deprecation** — check the digest's `deprecated` flag, `xDeprecatedEnum`, AND the description prose ("will be ignored", "no longer supported", "use X instead"). Any deprecation → `@deprecated` JSDoc tag on the SDK field/method.
+- **JSDoc drift / content loss** — `diff.mjs` flags `no-JSDoc` and `JSDoc may drop N spec sentence(s)` (the SDK JSDoc lost content the spec has). This is **coverage, not verbatim** — the goal is that the spec's information is *reflected* in the code, not copied word-for-word. Apply judgment:
+  - **Intentional drift is fine** — SDK-specific notes, or corrections where the docs are wrong (e.g. docs say a field is required but it isn't). Keep these; a flag here just means "confirm it's deliberate".
+  - **Accidental truncation is not** — a dropped sentence with no reason (constraints, possible values, method-specific relevance) should be restored from the spec description.
+  - **Ignore the shared `Amount`/`URL` boilerplate** ("In v2 endpoints, monetary amounts/URLs are represented as objects…") — it lives on the shared `Amount`/`Url` type, not repeated per field; its absence is not a gap.
+- **`@see` format** — `diff.mjs` flags `old-@see-format` (`/reference/v2/<api>/...` → `/reference/...`). For bulk, state the count.
+- **Binder method JSDoc** — `diff.mjs` does NOT cover this (it's method-level, not field-level), so it must be done explicitly. Run `extract-spec.mjs <op> --meta` (the operation's `summary`/`description`/`deprecated`) and `extract-sdk.mjs <binder> --json` (`.methods[]` with JSDoc + `@see`); map each method to its operation via its `@see` slug. Then flag:
+  - **`@deprecated` mismatch** (mechanical) — operation `deprecated: true` but the method JSDoc lacks `@deprecated`, or vice versa.
+  - **Factual drift** (judgment) — product claims, supported-method lists, or legacy-flow references in the method JSDoc that the operation `description` contradicts or no longer mentions (e.g. "supports Cards and Klarna", an Orders-shipment flow). Ignore mere wording differences.
+
+### Phase 3 — Wiring (helper coverage)
+
+An **invariant over the current state**: every `_links` / `_embedded` entry the SDK declares should have a corresponding helper — *regardless of whether the entry was just added (Phase 1) or has been there all along*. (Existence + correctness of the entry itself is Phase 1/2; this phase only asks "is there a helper for it?")
+
+`diff.mjs` flags `[P3] _links.<name>: no helper (expected get/has<Name>[Url]) — Helper class: <file | NONE — must be created>`. For each, add the helper using the right pattern (list→`HelpfulIterator` + `hasX`; single resource→`getX`; URL-only→`getXUrl`), creating the resource's `*Helper.ts` if none exists. **See `references/wiring.md`** for the patterns and the 4-file `_embedded` procedure. Base `self`/`documentation` are never helper-exposed and aren't flagged.
+
+4. **Report** — issues only, grouped by phase; omit empty phases; counts for bulk items; field path + what differs + `file:line` for individual ones. Never auto-remove SDK fields absent from the spec — flag under "Needs attention". Then a **Summary**: **Doc-synced** (no type change), **Added**, **Needs attention** (omit empty categories).
+
+## Step 2 — Apply
+
+1. **Ask which phases/categories to apply.** If the user selects nothing to change, stop here — there are no edits to make, so the working tree is never touched.
+2. **Only if changes will be made, check the working tree is clean** (do this *after* the selection, *before* the first edit). Run `git status --porcelain --untracked-files=no` (the gitignored `.tmp/` cache and untracked files are correctly excluded). If it shows **uncommitted changes to tracked files**, STOP and ask the user — sync edits would interleave with their existing work, muddying the diff. Lead with the safer option (the tree is already dirty, which is the only reason this prompt appears): (a) **isolate in a fresh worktree (recommended/default)** — `git worktree add ../mollie-api-node-sync-<target> -b sync/<target>` (clean checkout of the current commit; their WIP stays put); or (b) apply here anyway (sync edits interleave with the existing changes). Do not proceed until they choose.
+3. **Read `references/apply.md`** (Pick/PickOptional mechanics + the mandatory pre-check, `@see` format + verify-before-write, intersection/empty-interface style) and apply edits **in phase order**.
+
+**Post-apply gate (MANDATORY):** after edits, run `yarn build:declarations` (typechecks the whole graph via `src/types.ts`, ~2s) and `npx eslint --ext .ts src/<touched dirs>`, then `npx prettier --write <touched files only>` (NOT `yarn lint` — it reformats the whole tree). Fix any diagnostics before reporting done. The gate proves edits are type-valid; it does **not** validate optionality/breaking-change judgment — those stay under "Needs attention".
+
+**Post-apply description-coverage review:** re-run `diff.mjs` on each edited `(op, type)` pair and look at the `JSDoc may drop …` flags. This catches the common failure where the apply step **shortened a description while writing JSDoc** — especially on **newly-added fields**, where a coverage gap is almost certainly accidental truncation (you just added it from the spec — restore the dropped content). For pre-existing fields, judge intentional drift vs accidental per the Phase 2 rules. This is a **review, not a hard gate** — fix accidental loss, keep deliberate deviations.
+
+## Parallelization
+
+For a resource or `all`, fan out **one agent per resource** (never per endpoint — the request-vs-response `Pick` decision needs both specs in one context; never per check — the phases are dependency-ordered). Each agent runs the full analyze step for its resource and writes verbatim findings to `.tmp/sync-api/report-<resource>.json` (apply reads these, immune to context summarization). Use the contract in **`references/agent-prompt.md`**. `--only` scopes each agent's phases.

--- a/.claude/skills/sync-api/references/agent-prompt.md
+++ b/.claude/skills/sync-api/references/agent-prompt.md
@@ -1,0 +1,31 @@
+# Per-resource agent contract
+
+When `<target>` is a resource or `all`, fan out **one agent per resource** (never per endpoint — the request-vs-response `Pick` decision needs both specs in one context; never per check — phases are dependency-ordered). Each agent runs the full analyze step for its resource. Build each agent's prompt from this self-contained contract (the agent does NOT inherit SKILL.md):
+
+---
+
+You are syncing the SDK types for the **`<resource>`** resource against Mollie's master OpenAPI spec. Work from the repo root.
+
+**Toolchain (run via Bash, paths relative to repo root):**
+- `node .claude/skills/sync-api/scripts/extract-spec.mjs --index` — all operations; filter to this resource's paths.
+- `node .claude/skills/sync-api/scripts/extract-sdk.mjs <file.ts> --json` — SDK structural map.
+- `node .claude/skills/sync-api/scripts/diff.mjs <operationId> <file.ts> <TypeName>` — deterministic delta per operation. If `extract-spec` exits non-zero, a description was dropped — report it as a tool bug, do not proceed on partial data.
+
+**Steps:**
+1. Glob this resource's files (`src/data/**/<resource>/*.ts`, `src/binders/**/<resource>/*.ts`). Run `extract-sdk` on `data.ts` and `parameters.ts` to list exported types.
+2. Run `diff.mjs` for each operation against its mirror(s). `diff.mjs` picks the side from the SDK type: a `Data` interface → response body; a `*Parameters` type → request body + query params. Run both where both exist: `diff <op> <data.ts> <ResourceData>` AND `diff <op> <parameters.ts> <OpParameters>`.
+3. For every delta entry, **read the field's full `description` from the `extract-spec` digest** and apply judgment per the phase rules below.
+4. **Binder method JSDoc** (not covered by `diff.mjs`): run `extract-spec <op> --meta` and `extract-sdk <binder> --json` (`.methods[]`); map each method to its operation via its `@see` slug; flag `@deprecated` mismatches (mechanical) and factual drift — stale product claims / supported-method lists / legacy-flow references the operation `description` no longer supports (judgment; ignore wording).
+
+**Non-negotiable judgment rules:**
+1. **Read every field's full description prose** — deprecations, constraints, access restrictions ("only available to marketplace operators"), and method-specific relevance live in TEXT, not structured fields. Carry the **full content** into JSDoc — don't drop sentences. This is coverage, not verbatim: you MAY reword or add SDK-specific notes/corrections, but never *silently shorten*. After applying, re-run `diff.mjs` and resolve `JSDoc may drop …` flags (on a field you just added, that's almost always accidental truncation — restore it; ignore the shared `Amount`/`URL` boilerplate).
+2. **Request `type: [..,'null']` ≠ `T | null`** — default to `T` unless the description explicitly says `null` clears the value.
+3. **`Pick` vs inline:** a request field goes inline ONLY if it exists on no `Data` interface in `src/data/`, OR the spec genuinely differs between request and response. Otherwise `Pick`/`PickOptional`. State, for each field, whether it exists on a `Data` interface and justify any inline choice.
+4. **Deprecation** — check the `deprecated` flag, `xDeprecatedEnum`, AND prose ("will be ignored", "no longer supported", "use X instead"); also the endpoint-level `deprecated`/intro text.
+5. **Never** recommend changing a response field required→optional — that's breaking even if the spec marks it optional. Categorize as "Needs attention" with `⚠️ BREAKING`.
+
+**Output:** write verbatim findings to `.tmp/sync-api/report-<resource>.json` — per finding: `{operationId, phase (1|2|3), category (doc-synced|added|needs-attention), field path, file:line, current vs spec, full verbatim description, breaking (bool)}`. The apply step reads this file (immune to context-window summarization), so it must contain the full description text, not a summary. Also return a concise issues-only summary to the orchestrator.
+
+---
+
+The orchestrator collects the per-resource reports into one combined report (grouped by phase, then the Summary). Apply reads the `.tmp/sync-api/report-*.json` files as the source of truth.

--- a/.claude/skills/sync-api/references/apply.md
+++ b/.claude/skills/sync-api/references/apply.md
@@ -1,0 +1,72 @@
+# Apply mechanics
+
+Read this before writing ANY edit. Apply edits in phase order (Phase 1 structure → 2 docs → 3 wiring): JSDoc lands on final field locations, and wiring depends on settled structure.
+
+## 🚫 Working-tree check (before the FIRST edit)
+
+Once the user has chosen what to apply (SKILL.md Step 2.1) and there *are* changes to make — but before writing the first edit:
+
+```bash
+git status --porcelain --untracked-files=no
+```
+Empty → proceed. Non-empty → there are uncommitted changes to tracked files; the sync edits would mix into the user's existing work. **STOP and ask the user** before editing, leading with the safer option (a dirty tree is the only reason you're asking):
+- **(a) isolate in a worktree — recommended/default** — `git worktree add ../mollie-api-node-sync-<target> -b sync/<target>` gives a clean checkout of the current commit; their WIP stays in the main tree, and the sync's diff is reviewable on its own branch.
+- **(b) apply here** — sync edits interleave with their current changes (only when those are related/throwaway).
+
+Present (a) first as the default; don't pick for them, but lead with the worktree. (The gitignored `.tmp/` cache and untracked files are excluded by `--untracked-files=no`, so they never trip this.)
+
+## 🚫 MANDATORY pre-check before writing a field to `parameters.ts`
+
+Before defining a field **inline** in `parameters.ts`, `Grep src/data/` for that field name to confirm it does not exist on any `Data` interface. (`extract-sdk.mjs` also reports duplicates, but re-confirm at apply time — the per-resource analysis can be provisional, and only the whole-`src/data/` grep has the global view.)
+
+- If it exists on a `Data` interface → use `Pick<Data, 'field'>` (preserves the response's optionality) or `PickOptional<Data, 'field'>` (forces optional) — UNLESS the spec genuinely differs between request and response for that field (compare both schemas: different description, constraints, or a narrower request type). Optionality-only differences use `PickOptional`, not inline duplication.
+- Only define inline when the grep confirms it is request-only (`writeOnly`, e.g. `dueDate`, `cardToken`, `applePayPaymentToken`), or the request/response semantics genuinely differ.
+- When moving inline → `Pick`/`PickOptional`, first ensure the `Data` interface's JSDoc is complete (enrich from the spec — it becomes the canonical source for both request and response consumers).
+
+Always `Pick`, never `Omit` (see CLAUDE.md / ARCHITECTURE.md for the `Pick`/`PickOptional` pattern).
+
+## Style
+
+**Intersection ordering** — `Pick`/`PickOptional` and named bases first, inline `{ }` block always last:
+```ts
+export type CreateParameters = Pick<Data, 'a' | 'b'> &
+  PickOptional<Data, 'c'> &
+  IdempotencyParameter &
+  TestModeParameter & {
+    inlineField?: string;
+  };
+```
+
+**No empty interfaces** — use a `type` alias with intersections, not an empty `interface`:
+```ts
+export type CancelParameters = IdempotencyParameter & TestModeParameter;
+```
+
+## `@see` links
+
+Format: `https://docs.mollie.com/reference/<slug>?path=<fieldPath>#<section>`. Keep `?path=` even though the new docs ignore it (future compatibility). Update old `/reference/v2/<api-name>/...` → new `/reference/...` in `data.ts`, `parameters.ts`, AND the binder.
+
+**🚫 Verify every new/changed `@see` slug returns HTTP 200 before writing** — slugs are inconsistent (`get-chargeback` works, `list-chargebacks` does not — it's `list-payment-chargebacks`). Batch-verify with a labelled loop so each result maps to its slug:
+```bash
+for s in slug-a slug-b; do printf '%s %s\n' "$s" "$(curl -s -L -o /dev/null -w '%{http_code}' "https://docs.mollie.com/reference/$s.md")"; done
+```
+Any non-200 blocks that specific edit → re-resolve the slug (the operationId is a starting guess, not guaranteed equal to the doc slug).
+
+## Post-apply gate (run before reporting done)
+
+```bash
+yarn build:declarations                         # tsc over the whole type graph (~2s); MUST pass
+npx eslint --ext .ts src/<dirs you touched>      # clean today; catches lint regressions
+npx prettier --write <the files you edited>      # scoped — NOT `yarn lint` (it rewrites the whole tree)
+```
+A green gate means edits are type-valid and lint-clean. It does **NOT** validate optionality/required↔optional/breaking-change judgment — those remain under "Needs attention" with user confirmation. The repair step fixes only structural breakage the apply introduced; never revert an intentional, user-approved "Needs attention" change.
+
+**Then re-run `diff.mjs` on each edited `(op, type)` to catch description truncation:**
+```bash
+node .claude/skills/sync-api/scripts/diff.mjs <op> <edited-file.ts> <Type>   # look at "JSDoc may drop …" flags
+```
+The apply step often shortens a description while writing JSDoc — worst on **newly-added fields** (pure transcription). For an added field, a `JSDoc may drop …` flag is almost certainly accidental truncation → restore the dropped sentence(s) from the spec digest. For pre-existing fields it may be deliberate (SDK note / doc correction) → keep. This is a **review, not a hard gate**; do not enforce verbatim, and ignore the shared `Amount`/`URL` boilerplate.
+
+## Re-run safety
+
+Re-running on an already-synced target must be a no-op: before each edit confirm the target state isn't already present (`Edit` no-ops/fails on unchanged strings); never duplicate a field or re-rewrite a correct `@see`.

--- a/.claude/skills/sync-api/references/wiring.md
+++ b/.claude/skills/sync-api/references/wiring.md
@@ -1,0 +1,24 @@
+# Phase 3 — Wiring (helper coverage)
+
+Consumers never access `_links`/`_embedded` directly — helper methods abstract them (see CLAUDE.md). Phase 3 is a **coverage invariant**: every link/embed the SDK declares should have a helper, *whether the entry was just added in Phase 1 or already existed*. The entry's existence + JSDoc are Phase 1/2; here you only add the missing **helper**. `diff.mjs` lists each as `[P3] _links.<name>: no helper …`. See ARCHITECTURE.md for the Seal-type / `transform` background.
+
+Discover the Helper and Model via `Glob src/data/**/<resource>/*Helper.ts` and `*.ts` (the Model file, e.g. `Payment.ts`). If no `*Helper.ts` exists for the resource (the diff says `Helper class: NONE`), create one.
+
+## Helper for `_links.<name>`
+
+Add a helper method (the property itself is Phase 1). Choose the pattern by what the link points to:
+
+1. **List of sub-resources** (`refunds`, `chargebacks`, `captures`): helper returns `HelpfulIterator<T>` — checks `_embedded` first, falls back to fetching the link URL. Add a `hasX(): boolean` checking `this.links.x != undefined`. E.g. `getRefunds()` / `hasRefunds()`.
+2. **Single related resource** (`order`, `customer`, `mandate`): helper returns `Promise<T> | Promise<undefined>` with a callback overload; uses `breakUrl` + `networkClient.get()`. E.g. `getOrder()`.
+3. **URL-only** (`checkout`, `dashboard`): helper returns `Nullable<string>` — `return this.links.x?.href ?? null`. E.g. `getCheckoutUrl()`.
+
+A fetch-style helper (1–2) may need the target resource's Data + Model types imported. If the target resource has no transformer registered in `createMollieClient.ts`, flag it to the user.
+
+## Missing `_embedded.<name>` → four files
+
+1. **`data.ts`** — add to `_embedded` on the Data interface: `captures?: Omit<CaptureData, '_embedded'>[]`.
+2. **Model file** (e.g. `Payment.ts`) — add the *transformed* type to the `_embedded` override in the Seal type: `captures?: Capture[]`.
+3. **`transform` function** (same file) — map each embedded item through the sub-resource's transform: `_embedded.x = input._embedded.x.map(transformX.bind(undefined, networkClient))`.
+4. **Helper** — `getX()` checks `this.embedded?.x` first (no network call), falls back to fetching via `_links.x`. Add the helper if missing (patterns above).
+
+A new embed almost always pairs with a new `_links` entry + helper — flag all together in the report.

--- a/.claude/skills/sync-api/scripts/diff.mjs
+++ b/.claude/skills/sync-api/scripts/diff.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * diff.mjs — deterministic structural delta between the master-spec digest and
+ * the SDK's declared shape for one operation. Emits mechanical facts; the agent
+ * applies judgment (Pick-vs-inline, breaking-change, nullable, JSDoc).
+ *
+ * The comparison side is chosen from the SDK TYPE, not the HTTP method:
+ *   - a Data interface   → compared against the RESPONSE body (writeOnly filtered)
+ *   - a *Parameters type  → compared against the REQUEST body (readOnly filtered)
+ *                           UNION the query parameters
+ * so `diff get-capture …/data.ts CaptureData` checks the response and
+ * `diff get-capture …/parameters.ts GetParameters` checks the query params —
+ * no more diffing query params against the response schema.
+ *
+ * Base mixins (TestModeParameter, IdempotencyParameter, Pagination, Sort,
+ * Throttling) and Model/Links heritage are expanded; transport-only params
+ * (idempotencyKey, valuesPerMinute) are ignored. Unknown bases are annotated.
+ *
+ * Usage: node diff.mjs <operationId> <sdkFile.ts> <SdkTypeName>
+ */
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { existsSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd: HERE }).toString().trim();
+// Suppressed from "IN SDK, not in spec" — but only where the diff structurally CAN'T compare:
+//  - idempotencyKey: the `Idempotency-Key` HEADER (diff compares query+body, not headers); universal on writes.
+//  - valuesPerMinute: ThrottlingParameter — a client-side pagination throttle, never an API field in any spec.
+// NOT testmode: the spec reliably lists it where supported and omits it on live-only endpoints (settlements),
+// so an SDK type that declares testmode where the spec omits it is a genuine over-declaration → must surface.
+const IGNORE_EXTRA = new Set(['idempotencyKey', 'valuesPerMinute']);
+
+function run(script, args) {
+  try {
+    return JSON.parse(execFileSync('node', [`${HERE}/${script}`, ...args], { maxBuffer: 1 << 28 }).toString());
+  } catch (e) {
+    const last = ((e.stderr ?? Buffer.from('')).toString().trim().split('\n').pop()) || (e.message || '').split('\n')[0];
+    const err = new Error(`${script} ${args.filter(a => a !== '--json').join(' ')} — ${last}`);
+    err.clean = true;
+    throw err;
+  }
+}
+
+const sdkCache = new Map();
+const loadSdk = (file) => { if (!sdkCache.has(file)) sdkCache.set(file, run('extract-sdk.mjs', [file, '--json'])); return sdkCache.get(file); };
+function resolveModule(fromFile, spec) {            // relative import → actual .ts file
+  if (!spec.startsWith('.')) return null;
+  const base = resolve(dirname(fromFile), spec);
+  for (const c of [`${base}.ts`, `${base}/index.ts`]) if (existsSync(c)) return c;
+  return null;
+}
+// member names of a *Links interface/alias, following `extends`/`= Base` across files
+function linkMembers(file, typeName, seen = new Set()) {
+  const names = new Set();
+  const key = `${file}#${typeName}`;
+  if (seen.has(key)) return names; seen.add(key);
+  const sdk = loadSdk(file);
+  const resolveBaseName = (base) => {
+    const b = base.replace(/<.*/, '').trim();
+    const imp = sdk.imports.find(i => i.local === b);
+    const target = imp ? [resolveModule(file, imp.module), imp.imported] : [file, b];
+    if (target[0]) for (const n of linkMembers(target[0], target[1], seen)) names.add(n);
+  };
+  const it = sdk.interfaces.find(i => i.name === typeName);
+  const ta = sdk.types.find(t => t.name === typeName);
+  if (it) { for (const f of it.fields) names.add(f.name); for (const e of it.extends ?? []) resolveBaseName(e); }
+  else if (ta) { for (const f of ta.inline) names.add(f.name); for (const b of ta.bases) resolveBaseName(b); }
+  return names;
+}
+
+function topLevel(rows, { dropReadOnly = false, dropWriteOnly = false } = {}) {
+  // First pass: which top-level fields to drop, from their container row's flags.
+  // Must drop the WHOLE subtree — otherwise sub-rows (owner.x) re-introduce the
+  // top-level key (owner) that the container row's readOnly/writeOnly should remove.
+  const drop = new Set();
+  for (const r of rows) {
+    const top = r.path.split('.')[0].replace(/\[\]$/, '');
+    if (r.path === top && ((dropReadOnly && r.readOnly) || (dropWriteOnly && r.writeOnly))) drop.add(top);
+  }
+  const map = new Map();
+  for (const r of rows) {
+    const top = r.path.split('.')[0].replace(/\[\]$/, '');
+    if (!top || top.includes('|') || top === '(root)' || drop.has(top)) continue;
+    if (!map.has(top)) map.set(top, r);
+  }
+  return map;
+}
+
+// Advisory content-loss detector: which spec-description sentences are NOT
+// reflected in the SDK JSDoc. Targets TRUNCATION (omitted sentences), not
+// rewording — a reworded sentence reuses its salient words (high overlap, not
+// flagged); a dropped one has its words absent (flagged). NOT verbatim equality:
+// SDK-specific notes and doc corrections are fine (additions never flag; the
+// agent judges intentional omissions). Returns dropped sentence snippets.
+const STOP = new Set('the a an to of for and or in on is are be this that with as it you your we will can if by at from not but have has been their les use used'.split(' '));
+const norm = (s) => s.toLowerCase().replace(/`/g, '').replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+function coverageGaps(spec, doc) {
+  if (!spec || !doc) return [];
+  const docWords = new Set(norm(doc).split(' '));
+  const gaps = [];
+  for (const sent of spec.split(/(?<=[.!?])\s+|\n+/).map(s => s.trim()).filter(Boolean)) {
+    const words = norm(sent).split(' ').filter(w => w.length > 2 && !STOP.has(w));
+    if (words.length < 4) continue;                                  // skip trivial sentences
+    const hit = words.filter(w => docWords.has(w)).length / words.length;
+    if (hit < 0.5) gaps.push(sent.replace(/\s+/g, ' ').slice(0, 90));
+  }
+  return gaps;
+}
+
+try {
+  const [operationId, sdkFile, sdkTypeName] = process.argv.slice(2);
+  if (!operationId || !sdkFile || !sdkTypeName) { console.error('usage: diff.mjs <operationId> <sdkFile.ts> <SdkTypeName>'); process.exit(1); }
+
+  const meta = run('extract-spec.mjs', ['--index', '--json']).find(o => o.operationId === operationId);
+  if (!meta) { console.error(`operationId not found: ${operationId} (run: node extract-spec.mjs --index)`); process.exit(1); }
+
+  const sdk = loadSdk(sdkFile);
+  const iface = sdk.interfaces.find(i => i.name === sdkTypeName);
+  const talias = sdk.types.find(t => t.name === sdkTypeName);
+  if (!iface && !talias) { console.error(`type "${sdkTypeName}" not found in ${sdkFile}`); process.exit(1); }
+
+  const mixins = {};
+  for (const i of loadSdk(`${REPO_ROOT}/src/types/parameters.ts`).interfaces) mixins[i.name] = i.fields.map(f => f.name);
+
+  // --- spec side from the type's ROLE (name/file), NOT its declaration kind:
+  // a *Parameters type is the request side even when declared `interface … extends`
+  // (e.g. `interface CreateParameters extends IdempotencyParameter`); a Data
+  // interface is the response side. (`iface`/`talias` only gate existence above.)
+  const isParamsType = /Parameters$/.test(sdkTypeName) || /(^|\/)parameters\.ts$/.test(sdkFile) || /\/binders\//.test(sdkFile);
+  let specTop, side, specResponseRows = null;
+  if (!isParamsType) {
+    side = 'response';
+    specResponseRows = run('extract-spec.mjs', [operationId, '--side', 'response', '--json']);
+    specTop = topLevel(specResponseRows, { dropWriteOnly: true });
+  } else {
+    side = 'request+params';
+    const body = topLevel(run('extract-spec.mjs', [operationId, '--side', 'request', '--json']), { dropReadOnly: true });
+    const params = topLevel(run('extract-spec.mjs', [operationId, '--side', 'params', '--json']));
+    specTop = new Map([...body, ...params]);
+  }
+
+  // --- SDK side: resolve effective fields, following Pick/Omit and named bases
+  // recursively ACROSS files (via imports). Standard mixins are known directly.
+  const unresolved = [];
+  const sdkFields = new Map();
+  const set = (out, name, info) => { if (!out.has(name)) out.set(name, info); };
+  const resolveBase = (file, expr, remove, seen, out, sdk) => {
+    expr = expr.trim();
+    const m = expr.match(/^(Omit|Pick)<\s*([\w$.]+)\s*,\s*(.+)>$/);
+    if (m) {
+      const keys = [...m[3].matchAll(/'([^']+)'/g)].map(x => x[1]);
+      if (m[1] === 'Omit') return resolveName(file, m[2], new Set([...remove, ...keys]), seen, out, sdk);
+      const tmp = new Map(); resolveName(file, m[2], new Set(), seen, tmp, sdk);
+      for (const [k, v] of tmp) if (keys.includes(k) && !remove.has(k)) set(out, k, v);
+      return;
+    }
+    resolveName(file, expr.replace(/<.*/, ''), remove, seen, out, sdk);
+  };
+  function resolveName(file, name, remove, seen, out, sdk) {
+    if (mixins[name]) { for (const f of mixins[name]) if (!remove.has(f)) set(out, f, { via: name }); return; }
+    if (name === 'Model') { for (const f of ['id', 'resource']) if (!remove.has(f)) set(out, f, { via: 'Model' }); return; }
+    if (name === 'Links') { if (!remove.has('_links')) set(out, '_links', { via: 'Links' }); return; }
+    if (sdk.types.some(t => t.name === name) || sdk.interfaces.some(i => i.name === name)) return resolveType(file, name, remove, seen, out);
+    const imp = sdk.imports.find(i => i.local === name);
+    if (imp) { const f = resolveModule(file, imp.module); if (f) return resolveType(f, imp.imported, remove, seen, out); }
+    unresolved.push(name);
+  }
+  function resolveType(file, typeName, remove, seen, out) {
+    const key = `${file}#${typeName}`;
+    if (seen.has(key)) return; seen.add(key);
+    const sdk = loadSdk(file);
+    const it = sdk.interfaces.find(i => i.name === typeName);
+    const ta = sdk.types.find(t => t.name === typeName);
+    if (it) {
+      for (const f of it.fields) if (!remove.has(f.name)) set(out, f.name, { via: 'interface', ...f });
+      for (const e of it.extends ?? []) resolveBase(file, e, remove, seen, out, sdk);
+    } else if (ta) {
+      for (const p of ta.picks) for (const n of p.fields) if (!remove.has(n)) set(out, n, { via: `Pick<${p.from}>` });
+      for (const p of ta.pickOptionals) for (const n of p.fields) if (!remove.has(n)) set(out, n, { via: `PickOptional<${p.from}>` });
+      for (const f of ta.inline) if (!remove.has(f.name)) set(out, f.name, { via: 'inline', ...f });
+      for (const b of ta.bases) resolveBase(file, b, remove, seen, out, sdk);
+    } else unresolved.push(typeName);
+  }
+  resolveType(sdkFile, sdkTypeName, new Set(), new Set(), sdkFields);
+
+  // --- diff
+  const WIRING = new Set(['_links', '_embedded']); // handled in the dedicated WIRING section below (sub-entries + helper coverage), not as flat top-level fields
+  const pathParams = new Set([...meta.path.matchAll(/\{(\w+)\}/g)].map(m => m[1])); // {settlementId} etc. — method args, not param fields
+  const missing = [...specTop.keys()].filter(k => !WIRING.has(k) && !sdkFields.has(k));
+  const extra = [...sdkFields.keys()].filter(k => !specTop.has(k) && !WIRING.has(k) && !IGNORE_EXTRA.has(k) && !pathParams.has(k));
+  const both = [...specTop.keys()].filter(k => sdkFields.has(k));
+
+  const o = console.log;
+  o(`\n=== DIFF ${operationId} (${meta.method.toUpperCase()} ${meta.path}) [${side}]  vs  ${sdkTypeName} ===`);
+  o(`spec: ${specTop.size} | SDK: ${sdkFields.size} | overlap: ${both.length}`);
+  if (unresolved.length) o(`(could not resolve base/type — fields below may be provided by: ${[...new Set(unresolved)].join(', ')})`);
+
+  o(`\nMISSING in SDK [${missing.length}]  (in spec, not declared):`);
+  for (const k of missing) { const r = specTop.get(k); o(`  + ${k}: ${r.type}${r.required ? ' (required)' : ''}${r.deprecated ? ' [DEPRECATED]' : ''}${r.writeOnly ? ' [writeOnly]' : ''}`); }
+
+  // For an extra field, the operation description often EXPLAINS the absence
+  // (e.g. testmode → "This endpoint currently does not support test mode yet").
+  // Surface that authoritative caveat so the agent judges over-declaration vs
+  // mere spec-incompleteness — param-absence alone can't tell them apart.
+  let opDescription = '';
+  if (extra.length) { try { opDescription = run('extract-spec.mjs', [operationId, '--meta', '--json']).description || ''; } catch { /* meta optional */ } }
+  const caveatFor = (field) => {
+    if (!opDescription) return '';
+    const clean = opDescription.replace(/^[>\s]*/gm, '').replace(/\*\*/g, '').replace(/[ℹ️\u{1F4D8}\u{1F6AB}⚠]/gu, '').replace(/\s+/g, ' ').trim();
+    // alphanumeric-only key so "test mode" (prose) matches "testmode" (field), incl. compound lowercase names
+    const key = field.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (key.length < 4) return ''; // too short → substring matches would be noise
+    const CAVEAT = /not support|no longer|not available|will be ignored|only (available|relevant)|cannot|does not/i;
+    for (const s of clean.split(/(?<=[.!?])\s+/)) {
+      if (s.length > 15 && CAVEAT.test(s) && s.toLowerCase().replace(/[^a-z0-9]/g, '').includes(key)) return s.trim().slice(0, 160);
+    }
+    return '';
+  };
+
+  o(`\nIN SDK, not in spec [${extra.length}]  (needs-attention: removed? never existed?):`);
+  for (const k of extra) { const c = caveatFor(k); o(`  ? ${k}  (via ${sdkFields.get(k).via})${c ? ` — spec note: "${c}"` : ''}`); }
+
+  o(`\nDOC / @see drift [in both]:`);
+  for (const k of both) {
+    const s = sdkFields.get(k), sp = specTop.get(k), notes = [];
+    if ((s.via === 'interface' || s.via === 'inline') && !s.jsdoc) notes.push('no-JSDoc');
+    if (s.jsdoc?.see?.some(u => /\/reference\/v2\//.test(u))) notes.push('old-@see-format');
+    if (sp.deprecated && !s.jsdoc?.deprecated) notes.push('spec-DEPRECATED but SDK not @deprecated');
+    // content loss (advisory — judge intentional drift vs accidental truncation; see SKILL.md Phase 2).
+    // skip genericDesc fields: shared-component boilerplate (amount/url) the SDK intentionally doesn't repeat.
+    const gaps = s.jsdoc?.comment && !sp.genericDesc ? coverageGaps(sp.description, s.jsdoc.comment) : [];
+    if (gaps.length) notes.push(`JSDoc may drop ${gaps.length} spec sentence(s): "${gaps[0]}${gaps.length > 1 ? ' …' : ''}"`);
+    if (notes.length) o(`  ! ${k}: ${notes.join('; ')}`);
+  }
+
+  // --- WIRING (_links / _embedded) — response side only.
+  // Phase 1 = does the link/embed PROPERTY exist (vs spec)?  Phase 3 = is there a
+  // HELPER for every link (an invariant over the current state — indifferent to
+  // whether the entry is newly added or pre-existing). Base self/documentation
+  // are universal HAL links, never helper-exposed → excluded from coverage.
+  if (side === 'response' && specResponseRows) {
+    const cap = (s) => s[0].toUpperCase() + s.slice(1);
+    const BASE_LINKS = new Set(['self', 'documentation']);
+    const specLinks = new Set(), specEmbeds = new Set();
+    for (const r of specResponseRows) {
+      let m = r.path.match(/^_links\.([^.]+)$/); if (m) specLinks.add(m[1]);
+      m = r.path.match(/^_embedded\.([^.[]+)/); if (m) specEmbeds.add(m[1]);
+    }
+    const linksType = (sdkFields.get('_links')?.type || '').replace(/<.*/, '').trim();
+    const sdkLinks = linksType ? linkMembers(sdkFile, linksType) : new Set();
+    const dir = dirname(sdkFile);
+    const helperFiles = (existsSync(dir) ? readdirSync(dir) : []).filter(f => /Helper\.ts$/.test(f));
+    const helperMethods = new Set();
+    for (const hf of helperFiles) for (const mth of loadSdk(`${dir}/${hf}`).methods ?? []) helperMethods.add(mth.name);
+    const escRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // link names are identifiers in practice, but escape defensively
+    const hasHelper = (n) => [...helperMethods].some(mm => new RegExp(`^(get|has)${escRe(n)}(url)?$`, 'i').test(mm));
+
+    const missingProps = [...specLinks].filter(n => !BASE_LINKS.has(n) && !sdkLinks.has(n));
+    const uncovered = [...new Set([...specLinks, ...sdkLinks])].filter(n => !BASE_LINKS.has(n) && !hasHelper(n));
+    const helperLoc = helperFiles.length ? helperFiles.join(', ') : `NONE in ${dir.replace(REPO_ROOT + '/', '')}/ — must be created`;
+
+    if (missingProps.length || uncovered.length || specEmbeds.size) {
+      o(`\nWIRING — _links / _embedded:`);
+      for (const n of missingProps) o(`  [P1] _links.${n}: in spec, not on ${linksType || 'the Links interface'} → add the property (+ JSDoc)`);
+      for (const n of uncovered) o(`  [P3] _links.${n}: no helper (expected get/has${cap(n)}[Url]) — Helper class: ${helperLoc}`);
+      for (const n of specEmbeds) o(`  [embed] _embedded.${n}: verify the 4-file embed wiring + helper (paired with _links.${n}); see references/wiring.md`);
+    }
+  }
+} catch (e) {
+  if (e.clean) { console.error(`[diff] failed: ${e.message}`); process.exit(2); }
+  throw e;
+}

--- a/.claude/skills/sync-api/scripts/extract-sdk.mjs
+++ b/.claude/skills/sync-api/scripts/extract-sdk.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * extract-sdk.mjs — structural field map of an SDK .ts file, via the TypeScript
+ * AST PARSER (no type-checking). Deliberately does NOT flatten: it preserves the
+ * Pick / PickOptional / inline / heritage distinction the skill's Phase-1
+ * reasoning depends on, and surfaces duplicate fields (defined via Pick AND
+ * inline) and missing JSDoc.
+ *
+ * Usage:
+ *   node extract-sdk.mjs <file.ts>            human-readable
+ *   node extract-sdk.mjs <file.ts> --json      structured JSON (for diff.mjs)
+ */
+import { createRequire } from 'node:module';
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd: dirname(fileURLToPath(import.meta.url)) }).toString().trim();
+const require = createRequire(import.meta.url);
+const ts = require(`${REPO_ROOT}/node_modules/typescript/lib/typescript.js`);
+
+const file = process.argv[2];
+if (!file || file.startsWith('--')) { console.error('usage: extract-sdk.mjs <file.ts> [--json]'); process.exit(1); }
+if (!existsSync(file)) { console.error(`extract-sdk: file not found: ${file}`); process.exit(1); }
+const text = readFileSync(file, 'utf8');
+const src = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+const lineOf = (n) => src.getLineAndCharacterOfPosition(n.getStart(src)).line + 1;
+
+function jsdocOf(node) {
+  const docs = node.jsDoc;
+  if (!docs?.length) return undefined;
+  const d = docs[docs.length - 1];
+  const raw = d.getFullText(src);                       // raw comment text (URLs intact)
+  const comment = typeof d.comment === 'string' ? d.comment
+    : Array.isArray(d.comment) ? d.comment.map(c => c.text ?? '').join('') : '';
+  const see = [...raw.matchAll(/@see\s+(\S+)/g)].map(m => m[1]);
+  const deprecated = /@deprecated/.test(raw);
+  return { comment: comment.trim(), see, deprecated, hasDoc: true };
+}
+function members(typeNode) {
+  return (typeNode.members ?? []).filter(ts.isPropertySignature).map(m => {
+    const typeText = m.type ? m.type.getText(src) : 'any';
+    return { name: m.name.getText(src), optional: !!m.questionToken, type: typeText,
+      nullable: /\bNullable<|\|\s*null\b/.test(typeText), line: lineOf(m), jsdoc: jsdocOf(m) };
+  });
+}
+function pickFields(arg) {
+  const out = [];
+  const collect = (n) => { if (ts.isLiteralTypeNode(n) && ts.isStringLiteral(n.literal)) out.push(n.literal.text); else if (ts.isUnionTypeNode(n)) n.types.forEach(collect); };
+  if (arg) collect(arg);
+  return out;
+}
+
+const result = { file, imports: [], interfaces: [], types: [], methods: [] };
+for (const stmt of src.statements) {
+  if (ts.isImportDeclaration(stmt) && stmt.importClause?.namedBindings && ts.isNamedImports(stmt.importClause.namedBindings)) {
+    const module = stmt.moduleSpecifier.text;
+    for (const el of stmt.importClause.namedBindings.elements) {
+      result.imports.push({ local: el.name.text, imported: (el.propertyName ?? el.name).text, module });
+    }
+  } else if (ts.isClassDeclaration(stmt)) {
+    // binder methods carry the JSDoc to compare against the operation description (Phase 2).
+    // JSDoc sits on the first overload signature; dedupe by name, keep the one with a doc.
+    for (const m of stmt.members) {
+      if (!ts.isMethodDeclaration(m) || !m.name) continue;
+      const name = m.name.getText(src);
+      const jsdoc = jsdocOf(m);
+      const existing = result.methods.find(x => x.name === name);
+      if (existing) { if (jsdoc && !existing.jsdoc) existing.jsdoc = jsdoc; }
+      else result.methods.push({ name, line: lineOf(m), jsdoc });
+    }
+  } else if (ts.isInterfaceDeclaration(stmt)) {
+    const ext = (stmt.heritageClauses ?? []).flatMap(h => h.types.map(t => t.getText(src)));
+    result.interfaces.push({ name: stmt.name.text, line: lineOf(stmt), extends: ext, fields: members(stmt) });
+  } else if (ts.isTypeAliasDeclaration(stmt)) {
+    const entry = { name: stmt.name.text, line: lineOf(stmt), picks: [], pickOptionals: [], bases: [], inline: [] };
+    const parts = ts.isIntersectionTypeNode(stmt.type) ? stmt.type.types : [stmt.type];
+    for (const p of parts) {
+      if (ts.isTypeReferenceNode(p)) {
+        const tn = p.typeName.getText(src);
+        if (tn === 'Pick') entry.picks.push({ from: p.typeArguments?.[0]?.getText(src), fields: pickFields(p.typeArguments?.[1]) });
+        else if (tn === 'PickOptional') entry.pickOptionals.push({ from: p.typeArguments?.[0]?.getText(src), fields: pickFields(p.typeArguments?.[1]) });
+        else if (tn === 'Omit') entry.bases.push(`Omit<${p.typeArguments?.map(a => a.getText(src)).join(', ')}>`);
+        else entry.bases.push(tn);
+      } else if (ts.isTypeLiteralNode(p)) entry.inline.push(...members(p));
+    }
+    // duplicate detection: field in a Pick AND inline
+    const pickNames = new Set([...entry.picks, ...entry.pickOptionals].flatMap(p => p.fields));
+    entry.duplicates = entry.inline.map(f => f.name).filter(n => pickNames.has(n));
+    result.types.push(entry);
+  }
+}
+
+// NOTE: write then exit only after the stream drains — process.exit() right
+// after stdout.write() truncates large piped output (>~64KB pipe buffer).
+if (process.argv.includes('--json')) {
+  process.stdout.write(JSON.stringify(result), () => process.exit(0));
+} else {
+  console.log(`=== ${file} ===`);
+  for (const i of result.interfaces) {
+    console.log(`interface ${i.name}${i.extends.length ? ` extends ${i.extends.join(', ')}` : ''} (L${i.line}) — ${i.fields.length} fields`);
+    for (const f of i.fields) console.log(`  ${f.name}${f.optional ? '?' : ''}: ${f.type}${f.nullable ? ' [nullable]' : ''} ${f.jsdoc ? (f.jsdoc.deprecated ? '«jsdoc @deprecated»' : '«jsdoc»') : '✗NO-JSDOC'}${f.jsdoc?.see?.length ? ' see:' + f.jsdoc.see.join(',') : ''}`);
+  }
+  for (const t of result.types) {
+    console.log(`type ${t.name} (L${t.line})${t.duplicates.length ? `  ⚠️ DUPLICATES: ${t.duplicates.join(', ')}` : ''}`);
+    for (const p of t.picks) console.log(`  Pick<${p.from}>: ${p.fields.join(', ')}`);
+    for (const p of t.pickOptionals) console.log(`  PickOptional<${p.from}>: ${p.fields.join(', ')}`);
+    if (t.bases.length) console.log(`  bases: ${t.bases.join(' & ')}`);
+    for (const f of t.inline) console.log(`  inline ${f.name}${f.optional ? '?' : ''}: ${f.type}${f.nullable ? ' [nullable]' : ''} ${f.jsdoc ? '«jsdoc»' : '✗NO-JSDOC'}`);
+  }
+}

--- a/.claude/skills/sync-api/scripts/extract-spec.mjs
+++ b/.claude/skills/sync-api/scripts/extract-spec.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+/**
+ * extract-spec.mjs — turn Mollie's master OpenAPI spec into a compact, lossless
+ * per-operation field digest, or list every operation.
+ *
+ * Source of truth is `mollie/openapi` specs.yaml (operationId == endpoint key,
+ * complete + deterministic). All $refs are local. Descriptions are preserved
+ * VERBATIM — a completeness self-check fails the run (exit 3) if any description
+ * in the spec is dropped from the digest, so silent loss is impossible.
+ *
+ * Usage:
+ *   node extract-spec.mjs --index                 list every operation (METHOD path -> operationId)
+ *   node extract-spec.mjs <operationId>           human-readable digest report
+ *   node extract-spec.mjs <operationId> --json     digest rows as JSON (for diff.mjs)
+ *   node extract-spec.mjs <operationId> --show      include the rendered digest
+ *   flags: --refresh (force re-fetch), --spec <path> (use a local spec file)
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, statSync, renameSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import YAML from 'yaml';
+
+const RAW_URL = 'https://raw.githubusercontent.com/mollie/openapi/main/specs.yaml';
+const REPO_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], { cwd: dirname(fileURLToPath(import.meta.url)) }).toString().trim();
+const CACHE_DIR = `${REPO_ROOT}/.tmp/sync-api`;
+const CACHE_SPEC = `${CACHE_DIR}/specs.yaml`;
+const CACHE_ETAG = `${CACHE_DIR}/specs.etag`;
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const opt = (name) => { const i = args.indexOf(name); return i >= 0 ? args[i + 1] : undefined; };
+
+// ---- fetch + cache ---------------------------------------------------------
+// Freshness uses a conditional GET (If-None-Match/ETag) against the raw CDN —
+// NOT api.github.com, which is rate-limited (60/hr unauthenticated) and more
+// likely blocked in sandboxes. A 304 confirms the cache without re-downloading.
+const CHECKED = `${CACHE_DIR}/.checked`;     // mtime = last freshness check
+const CHECK_TTL = 15 * 60 * 1000;            // skip the check within this window (keeps batches fast & quiet)
+function conditionalGet(useEtag) {
+  const etag = useEtag && existsSync(CACHE_ETAG) ? readFileSync(CACHE_ETAG, 'utf8').trim() : null;
+  // per-process scratch paths: the skill fans out parallel per-resource agents,
+  // so shared scratch files would race (and could promote a half-written body).
+  const hdr = `${CACHE_DIR}/.hdr.${process.pid}`, body = `${CACHE_DIR}/.body.${process.pid}`;
+  const a = ['-sS', '--max-time', '15', '-L', '-D', hdr, '-o', body, '-w', '%{http_code}', '-H', 'User-Agent: sync-api'];
+  if (etag) a.push('-H', `If-None-Match: ${etag}`);
+  a.push(RAW_URL);
+  let code;
+  try { code = execFileSync('curl', a, { maxBuffer: 1 << 28 }).toString().trim(); }
+  catch (e) { rmSync(hdr, { force: true }); rmSync(body, { force: true }); throw e; } // clean scratch on curl failure before propagating
+  const headers = existsSync(hdr) ? readFileSync(hdr, 'utf8') : '';
+  rmSync(hdr, { force: true });                  // header scratch consumed — don't leave it behind
+  const newEtag = (headers.match(/^etag:\s*(.+?)\s*$/im) || [])[1]; // capture the full validator verbatim — strong `"…"` AND weak `W/"…"`
+  return { code, body, newEtag };
+}
+function loadSpec() {
+  const local = opt('--spec');
+  if (local) return YAML.parse(readFileSync(local, 'utf8'));
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const haveCache = existsSync(CACHE_SPEC);
+  const checkedAge = existsSync(CHECKED) ? Date.now() - statSync(CHECKED).mtimeMs : Infinity;
+  const refresh = flag('--refresh');
+  if (!refresh && haveCache && checkedAge < CHECK_TTL) return YAML.parse(readFileSync(CACHE_SPEC, 'utf8'));
+
+  const mark = () => writeFileSync(CHECKED, '');
+  let res;
+  try { res = conditionalGet(!refresh); } catch { /* offline / sandbox-blocked */ }
+
+  if (res && res.code === '304' && haveCache) {                       // unchanged
+    rmSync(res.body, { force: true });           // body empty on 304; clean up regardless
+    if (res.newEtag) writeFileSync(CACHE_ETAG, res.newEtag);
+    mark();
+    return YAML.parse(readFileSync(CACHE_SPEC, 'utf8'));
+  }
+  if (res && res.code === '200') {                                    // new / changed
+    const text = readFileSync(res.body, 'utf8');
+    if (text.includes('openapi:') || text.includes('paths:')) {
+      renameSync(res.body, CACHE_SPEC);          // atomic promote — no lingering duplicate
+      if (res.newEtag) writeFileSync(CACHE_ETAG, res.newEtag);
+      mark();
+      process.stderr.write('[extract-spec] fetched latest spec\n');
+      return YAML.parse(text);
+    }
+  }
+  if (res?.body) rmSync(res.body, { force: true });                   // unexpected status — don't leave scratch
+  if (haveCache) {                                                    // offline/blocked → cache fallback
+    const fetched = statSync(CACHE_SPEC).mtime.toISOString().slice(0, 10);
+    process.stderr.write(`[extract-spec] could not reach raw.githubusercontent.com (sandbox/offline); using cached spec from ${fetched} — run with --refresh from a network-enabled context\n`);
+    mark();
+    return YAML.parse(readFileSync(CACHE_SPEC, 'utf8'));
+  }
+  throw new Error('no cached spec and could not fetch — run once from a network-enabled context (curl raw.githubusercontent.com must be allowed)');
+}
+
+const spec = loadSpec();
+
+// ---- $ref resolution (local pointers only) --------------------------------
+function resolveRef(ref) {
+  if (!ref.startsWith('#/')) throw new Error(`external ref unsupported: ${ref}`);
+  return ref.slice(2).split('/').reduce((node, key) => {
+    if (node == null) throw new Error(`unresolved ref: ${ref}`);
+    return node[key.replace(/~1/g, '/').replace(/~0/g, '~')];
+  }, spec);
+}
+function deref(node, seen) {
+  let n = node;
+  const chain = new Set(); // refs followed within THIS call — catches a cyclic alias chain (A → B → A)
+  while (n && typeof n === 'object' && n.$ref) {
+    if (seen.has(n.$ref) || chain.has(n.$ref)) return { __circular: n.$ref }; // ancestor cycle OR self-cycle
+    chain.add(n.$ref);
+    n = resolveRef(n.$ref);
+  }
+  return n;
+}
+
+// ---- operation index ------------------------------------------------------
+const METHODS = ['get', 'post', 'patch', 'put', 'delete'];
+function indexOperations() {
+  const ops = [];
+  for (const [path, item] of Object.entries(spec.paths ?? {})) {
+    for (const m of METHODS) if (item[m]?.operationId) ops.push({ operationId: item[m].operationId, method: m, path, op: item[m] });
+  }
+  return ops;
+}
+
+// An operation exposes up to three comparable sides:
+//   response — 200/201 body         → SDK Data interface
+//   request  — requestBody (may be a $ref to a requestBodies component) → SDK *Parameters
+//   params   — query parameters     → SDK *Parameters
+// Returns null when a side is absent (e.g. 204 No Content, GET with no body) —
+// callers treat that as "nothing to compare", not an error.
+function getSchema(op, side) {
+  if (side === 'request') {
+    let rb = op.requestBody;
+    if (rb?.$ref) rb = resolveRef(rb.$ref);
+    const c = rb?.content ?? {};
+    return (c['application/json'] ?? Object.values(c)[0])?.schema ?? null;
+  }
+  if (side === 'params') {
+    // a $ref'd parameter may carry sibling overrides (description, schema with enum/x-enumDescriptions);
+    // merge siblings OVER the resolved component so the operation-level override wins.
+    const params = (op.parameters ?? []).map(p => (p.$ref ? { ...resolveRef(p.$ref), ...p } : p)).filter(p => p?.in === 'query');
+    if (!params.length) return null;
+    const properties = {}, required = [];
+    for (const p of params) { properties[p.name] = { ...(p.schema ?? {}), description: p.description ?? p.schema?.description }; if (p.required) required.push(p.name); }
+    return { type: 'object', properties, required };
+  }
+  const r = op.responses ?? {};
+  const key = ['200', '201', 200, 201].find(k => r[k]);
+  const c = r[key]?.content ?? {};
+  return (c['application/hal+json'] ?? c['application/json'] ?? Object.values(c)[0])?.schema ?? null;
+}
+
+// ---- description resolution + allOf merge (collision-safe) ----------------
+// Descriptions live in 3 places: as a sibling of `allOf`, inside an `allOf`
+// member, or on a $ref target. Collisions across composition branches are
+// preserved (joined) so no variant description is ever silently dropped.
+function descriptionsOf(node, seen) {
+  const out = [];
+  if (!node || typeof node !== 'object') return out;
+  if (node.description) out.push(node.description);
+  if (Array.isArray(node.allOf)) {
+    for (const m of node.allOf) { if (m?.description) out.push(m.description); }
+    if (!out.length) for (const m of node.allOf) { const r = deref(m, seen); if (r?.description) { out.push(r.description); break; } }
+  }
+  if (Array.isArray(node.__descs)) out.push(...node.__descs);
+  return [...new Set(out)];
+}
+// Does this PROPERTY node carry its own (field-level) description, vs. only
+// inheriting a reusable component's description via $ref? Used to mark generic
+// boilerplate (e.g. the shared `amount`/`url` description) the SDK intentionally
+// does not repeat per-field, so the JSDoc-coverage check can skip it.
+function hasOwnDescription(node) {
+  if (!node || typeof node !== 'object') return false;
+  if (node.description) return true;
+  if (Array.isArray(node.__descs) && node.__descs.length) return true;
+  if (Array.isArray(node.allOf) && node.allOf.some(m => m?.description)) return true;
+  return false;
+}
+function effectiveDescription(node, seen) {
+  const ds = descriptionsOf(node, seen);
+  return ds.length ? ds.join('\n\n— or —\n\n') : undefined;
+}
+function mergeAllOf(node, seen) {
+  const out = { type: undefined, properties: {}, required: [] };
+  const mergeProps = (props, ownerDesc) => {
+    for (const [k, v] of Object.entries(props ?? {})) {
+      if (out.properties[k]) {
+        // collision: preserve any distinct description from the incoming branch
+        const prev = out.properties[k];
+        const add = [...descriptionsOf(prev, seen), ...descriptionsOf(v, seen)];
+        v.__descs = [...new Set([...(prev.__descs ?? []), ...add])];
+      }
+      out.properties[k] = v;
+    }
+  };
+  for (const m of node.allOf) {
+    const innerSeen = m.$ref ? new Set(seen).add(m.$ref) : seen;
+    const r = deref(m, seen) ?? {};
+    if (r.__circular) { out.__circular = r.__circular; continue; }
+    if (Array.isArray(r.allOf)) {           // nested allOf (e.g. settlement-capture → capture → entity-capture)
+      const inner = mergeAllOf(r, innerSeen);
+      if (inner.type && !out.type) out.type = inner.type;
+      mergeProps(inner.properties);
+      out.required.push(...inner.required);
+      if (inner.__circular) out.__circular = inner.__circular;
+      continue;
+    }
+    if (r.type && !out.type) out.type = r.type;
+    mergeProps(r.properties);
+    if (Array.isArray(r.required)) out.required.push(...r.required);
+  }
+  mergeProps(node.properties);
+  if (Array.isArray(node.required)) out.required.push(...node.required);
+  if (!out.type && Object.keys(out.properties).length) out.type = 'object';
+  return out;
+}
+
+function typeOf(node, seen) {
+  if (!node) return 'unknown';
+  if (node.$ref) return node.$ref.split('/').pop();
+  if (Array.isArray(node.allOf)) {
+    const ref = node.allOf.find(m => m.$ref);
+    if (ref) return ref.$ref.split('/').pop();
+    return mergeAllOf(node, seen).type ?? 'object';
+  }
+  if (Array.isArray(node.type)) return node.type.filter(t => t !== 'null').join('|') || 'null';
+  return node.type ?? (node.properties ? 'object' : node.enum ? 'enum' : 'unknown');
+}
+const isNullable = (node) => !!node && (node.nullable === true || (Array.isArray(node.type) && node.type.includes('null')));
+
+// ---- flatten --------------------------------------------------------------
+const rows = [];
+// `raw` is the pre-deref node (a property may be `{$ref, description}` or carry
+// collision __descs); `node` is the resolved schema. Merge descriptions from
+// both — OpenAPI 3.1 $ref siblings (e.g. emailDetails) would otherwise be lost.
+function emit(path, raw, node, requiredSet, seen, typeOverride) {
+  const name = path.split('.').pop().replace(/\[\]$/, '');
+  const row = { path, type: typeOverride ?? typeOf(node, seen) };
+  if (requiredSet?.has(name)) row.required = true;
+  if (isNullable(raw) || isNullable(node)) row.nullable = true;
+  if (raw.readOnly || node.readOnly) row.readOnly = true;
+  if (raw.writeOnly || node.writeOnly) row.writeOnly = true;
+  const enumVals = node.enum ?? raw.enum ?? node.allOf?.map(m => deref(m, seen)?.enum).find(Boolean);
+  if (enumVals) row.enum = enumVals;
+  const xde = node['x-deprecated-enum'] ?? raw['x-deprecated-enum'];
+  if (xde) row.xDeprecatedEnum = xde;
+  const xed = node['x-enumDescriptions'] ?? raw['x-enumDescriptions'];
+  if (xed) row.xEnumDescriptions = xed;
+  if (node.deprecated || raw.deprecated) row.deprecated = true;
+  const descs = [...new Set([...descriptionsOf(raw, seen), ...descriptionsOf(node, seen)])];
+  if (descs.length) row.description = descs.join('\n\n— or —\n\n');
+  // generic = description comes only from a shared $ref'd component, not the field itself
+  if (descs.length && !hasOwnDescription(raw)) row.genericDesc = true;
+  rows.push(row);
+}
+function walk(rawNode, path, requiredSet, seen) {
+  const node = deref(rawNode, seen);
+  if (!node || typeof node !== 'object') return;
+  if (node.__circular) { rows.push({ path, type: `[circular:${node.__circular.split('/').pop()}]` }); return; }
+  const next = rawNode.$ref ? new Set(seen).add(rawNode.$ref) : seen;
+
+  const union = node.oneOf ?? node.anyOf;
+  if (union) {
+    emit(path || '(root)', rawNode, node, requiredSet, next, (node.oneOf ? 'oneOf' : 'anyOf') + `(${union.length})`);
+    union.forEach((b, i) => walk(b, `${path}|v${i}`, new Set(), next));
+    return;
+  }
+  if (Array.isArray(node.allOf)) {
+    const merged = mergeAllOf(node, next);
+    if (merged.type === 'object' && Object.keys(merged.properties).length) {
+      if (path) emit(path, rawNode, node, requiredSet, next, 'object');
+      const req = new Set(merged.required);
+      for (const [k, v] of Object.entries(merged.properties)) walk(v, path ? `${path}.${k}` : k, req, next);
+      return;
+    }
+    emit(path, rawNode, node, requiredSet, next);
+    return;
+  }
+  const t = Array.isArray(node.type) ? node.type.filter(x => x !== 'null')[0] : node.type;
+  const addl = node.additionalProperties && typeof node.additionalProperties === 'object' ? node.additionalProperties : null;
+  if (t === 'object' || node.properties || addl) {
+    if (path) emit(path, rawNode, node, requiredSet, next, 'object');
+    const req = new Set(node.required ?? []);
+    for (const [k, v] of Object.entries(node.properties ?? {})) walk(v, path ? `${path}.${k}` : k, req, next);
+    if (addl) walk(addl, `${path}{*}`, new Set(), next); // map type (e.g. settlement periods: year -> month -> period)
+    return;
+  }
+  if (t === 'array' && node.items) { if (path) emit(path, rawNode, node, requiredSet, next, 'array'); walk(node.items, `${path}[]`, new Set(), next); return; }
+  emit(path, rawNode, node, requiredSet, next);
+}
+
+// ---- completeness self-check (HARD GATE) ----------------------------------
+// isRefRoot = we just followed a $ref into a reusable component. Its OWN root
+// description is an overridable fallback (e.g. the generic `amount` description),
+// emitted by the walker only when a referencing field has no description of its
+// own — so it must NOT be required. Field-level descriptions (inside properties,
+// allOf members, items) are still required, preserving drop detection.
+function collectDescriptions(node, acc, refs, isRefRoot = false) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) { node.forEach(n => collectDescriptions(n, acc, refs, false)); return; }
+  if (node.$ref) { if (!refs.has(node.$ref)) collectDescriptions(resolveRef(node.$ref), acc, new Set(refs).add(node.$ref), true); return; }
+  for (const [k, v] of Object.entries(node)) {
+    if (k === 'example' || k === 'examples') continue;
+    if (k === 'description' && typeof v === 'string') { if (!isRefRoot) acc.add(v); }
+    else collectDescriptions(v, acc, refs, false);
+  }
+}
+
+// ---- run ------------------------------------------------------------------
+const target = args.find(a => !a.startsWith('--') && a !== opt('--spec'));
+
+if (flag('--index') || target === undefined) {
+  const ops = indexOperations();
+  // index JSON is small (~8KB, no truncation risk) so a synchronous exit is safe here;
+  // the large per-operation digest at script-end uses the drain-callback exit instead.
+  if (flag('--json')) { process.stdout.write(JSON.stringify(ops.map(({ op, ...o }) => o))); process.exit(0); }
+  console.log(`operations: ${ops.length}`);
+  console.log(ops.map(o => `${o.method.toUpperCase().padEnd(6)} ${o.path}  -> ${o.operationId}`).join('\n'));
+  process.exit(0);
+}
+
+const ops = indexOperations();
+const op = ops.find(o => o.operationId === target);
+if (!op) { console.error(`operationId not found: ${target} (use --index to list)`); process.exit(1); }
+
+// --meta: the operation's own summary/description/deprecated — the anchor for
+// comparing a binder method's JSDoc against the endpoint description (Phase 2).
+if (flag('--meta')) {
+  const m = { operationId: target, method: op.method.toUpperCase(), path: op.path, summary: op.op.summary ?? null, description: op.op.description ?? null, deprecated: !!op.op.deprecated };
+  if (flag('--json')) { process.stdout.write(JSON.stringify(m)); process.exit(0); }
+  console.log(`=== ${target} (${m.method} ${op.path}) [meta] ===`);
+  if (m.deprecated) console.log('⚠️ DEPRECATED (operation-level deprecated: true)');
+  if (m.summary) console.log(`summary: ${m.summary}`);
+  console.log(`description:\n${m.description ?? '(none)'}`);
+  process.exit(0);
+}
+// --side: explicit, else auto (mutations → request body, others → response).
+const side = opt('--side') ?? (['post', 'patch', 'put'].includes(op.method) ? 'request' : 'response');
+const schema = getSchema(op.op, side);
+
+// A missing side is a clean no-op (204 No Content, GET with no body / no query params) — exit 0.
+if (!schema) {
+  if (flag('--json')) { process.stdout.write('[]'); process.exit(0); }
+  console.log(`=== ${target} (${op.method.toUpperCase()} ${op.path}) [${side}] ===`);
+  console.log(`no ${side} schema (nothing to compare on this side)`);
+  process.exit(0);
+}
+
+walk(schema, '', new Set(), new Set());
+
+// self-check
+const allDesc = new Set();
+collectDescriptions(schema, allDesc, new Set());
+const emittedBlob = rows.map(r => r.description).filter(Boolean).join('\n');
+const missing = [...allDesc].filter(d => !emittedBlob.includes(d.trim())); // full string — a partial/truncated emit must not pass the lossless check
+
+if (flag('--json')) {
+  if (missing.length) { process.stderr.write(`[extract-spec] FAIL: ${missing.length} descriptions dropped for ${target}\n`); process.exit(3); }
+  // write-then-exit-on-drain: process.exit() right after write() truncates large piped output
+  process.stdout.write(JSON.stringify(rows), () => process.exit(0));
+} else {
+  console.log(`=== ${target} (${op.method.toUpperCase()} ${op.path}) [${side}] ===`);
+  console.log(`fields: ${rows.length} | descriptions: ${allDesc.size} emitted, ${missing.length} missing`);
+  if (missing.length) { console.log('--- ⚠️ DROPPED DESCRIPTIONS (self-check FAIL) ---'); missing.forEach(d => console.log(`  ✗ ${d.slice(0, 100).replace(/\n/g, ' ')}`)); }
+  if (flag('--show')) console.log('--- DIGEST ---\n' + rows.map(r => JSON.stringify(r)).join('\n'));
+  process.exit(missing.length ? 3 : 0);
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-/coverage/
-/dist/
-/node_modules/
+/coverage
+/dist
+/node_modules
 /.idea/
 /.vscode/
 /.env
@@ -9,3 +9,8 @@
 .DS_Store
 /mk-ca-bundle.pl
 /*.code-workspace
+/.tmp/
+
+.claude/settings.json
+.claude/settings.local.json
+.claude/worktrees/

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "nock-record": "^0.3.9",
     "prettier": "^3.8.4",
     "rollup": "^3.29.5",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "yaml": "^2.9.0"
   },
   "resolutions": {
     "eslint-plugin-import": "^2.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,6 +6296,11 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"


### PR DESCRIPTION
## What

Adds a Claude Code skill (`.claude/skills/sync-api`) that reconciles the SDK against Mollie's master OpenAPI spec — types, JSDoc, enums, endpoint coverage, and `_links`/`_embedded` helper wiring — with an optional apply step.

## How

Script-driven for determinism, so the model spends its budget on judgment rather than parsing JSON:

- **`extract-spec.mjs`** — fetches/caches the master spec (`mollie/openapi`, ETag-validated), resolves `$ref`s, and emits compact per-field digests with descriptions preserved **verbatim** and self-checked for loss.
- **`extract-sdk.mjs`** — reads the SDK's structure via the TypeScript AST: `Pick`/`PickOptional`/inline/heritage, JSDoc, `@see`, duplicate fields, binder methods.
- **`diff.mjs`** — a deterministic delta (missing / extra / type+doc drift / description-coverage / `_links` property + helper-coverage), filtered for request vs response semantics.

The model then handles only what needs judgment — Pick-vs-inline, nullable-vs-optional, breaking changes, description coverage, helper coverage — and applies fixes in phase order behind a `tsc`/lint gate, prompting to isolate in a worktree when the tree is dirty.

## Scope

- `.claude/skills/sync-api/` — `SKILL.md` + `references/` + `scripts/`
- `.claude/CLAUDE.md`, `.claude/ARCHITECTURE.md` — project docs the skill references
- `yaml` devDependency (used by the spec extractor)
- `.gitignore` — the skill's `.tmp` cache + local worktrees

Already exercised across every endpoint; surfaced ~20 sync PRs.
