### PR TITLE
feat: declare testmode/profileId on endpoints that accept them

### DIFF
--- a/src/binders/customers/payments/parameters.ts
+++ b/src/binders/customers/payments/parameters.ts
@@ -1,4 +1,4 @@
-import type { PaginationParameters, SortParameter, ThrottlingParameter } from '../../../types/parameters';
+import type { PaginationParameters, SortParameter, TestModeParameter, ThrottlingParameter } from '../../../types/parameters';
 import type { CreateParameters as PaymentCreateParameters } from '../../payments/parameters';
 
 interface ContextParameters {
@@ -7,6 +7,19 @@ interface ContextParameters {
 
 export type CreateParameters = Omit<PaymentCreateParameters, 'customerId'> & ContextParameters;
 
-export type PageParameters = ContextParameters & PaginationParameters & SortParameter;
+export type PageParameters = ContextParameters &
+  PaginationParameters &
+  SortParameter &
+  TestModeParameter & {
+    /**
+     * The identifier referring to the [profile](get-profile) you wish to retrieve the resources for.
+     *
+     * Most API credentials are linked to a single profile. In these cases the `profileId` must not be sent. For organization-level credentials such as OAuth access tokens however, the `profileId`
+     * parameter is required.
+     *
+     * @see https://docs.mollie.com/reference/list-customer-payments?path=profileId#parameters
+     */
+    profileId?: string;
+  };
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/src/binders/organizations/OrganizationsBinder.ts
+++ b/src/binders/organizations/OrganizationsBinder.ts
@@ -25,6 +25,9 @@ export default class OrganizationsBinder extends Binder<OrganizationData, Organi
   // Four overloads (rather than the params-only pair used by other binders) so the released
   // `get(id, callback)` signature keeps compiling while `testmode` is also accepted.
   public get(id: string): Promise<Organization>;
+  /**
+   * @deprecated Passing a callback as the second argument is deprecated and will be removed in the next major version. Use the returned promise instead, or pass `parameters` before the callback.
+   */
   public get(id: string, callback: Callback<Organization>): void;
   public get(id: string, parameters: GetParameters): Promise<Organization>;
   public get(id: string, parameters: GetParameters, callback: Callback<Organization>): void;

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -6,7 +6,7 @@ import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
+import { type CreateParameters, type DeleteParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
 
 const pathSegment = 'payment-links';
 
@@ -89,11 +89,11 @@ export default class PaymentsLinksBinder extends Binder<PaymentLinkData, Payment
    *
    * @see https://docs.mollie.com/reference/delete-payment-link
    */
-  public delete(id: string): Promise<true>;
-  public delete(id: string, callback: Callback<true>): void;
-  public delete(id: string) {
+  public delete(id: string, parameters?: DeleteParameters): Promise<true>;
+  public delete(id: string, parameters: DeleteParameters, callback: Callback<true>): void;
+  public delete(id: string, parameters?: DeleteParameters) {
     if (renege(this, this.delete, ...arguments)) return;
     assertWellFormedId(id, 'payment-link');
-    return this.networkClient.delete<PaymentLinkData, true>(`${pathSegment}/${id}`);
+    return this.networkClient.delete<PaymentLinkData, true>(`${pathSegment}/${id}`, parameters);
   }
 }

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -90,10 +90,14 @@ export default class PaymentsLinksBinder extends Binder<PaymentLinkData, Payment
    * @see https://docs.mollie.com/reference/delete-payment-link
    */
   public delete(id: string, parameters?: DeleteParameters): Promise<true>;
+  /**
+   * @deprecated Passing a callback as the second argument is deprecated and will be removed in the next major version. Use the returned promise instead, or pass `parameters` before the callback.
+   */
+  public delete(id: string, callback: Callback<true>): void;
   public delete(id: string, parameters: DeleteParameters, callback: Callback<true>): void;
-  public delete(id: string, parameters?: DeleteParameters) {
+  public delete(id: string, parameters?: DeleteParameters | Callback<true>) {
     if (renege(this, this.delete, ...arguments)) return;
     assertWellFormedId(id, 'payment-link');
-    return this.networkClient.delete<PaymentLinkData, true>(`${pathSegment}/${id}`, parameters);
+    return this.networkClient.delete<PaymentLinkData, true>(`${pathSegment}/${id}`, parameters as DeleteParameters);
   }
 }

--- a/src/binders/paymentLinks/parameters.ts
+++ b/src/binders/paymentLinks/parameters.ts
@@ -27,6 +27,8 @@ export type CreateParameters = Pick<PaymentLinkData, 'description'> &
 
 export type GetParameters = ContextParameters;
 
+export type DeleteParameters = ContextParameters & IdempotencyParameter;
+
 export type PageParameters = ContextParameters &
   PaginationParameters & {
     profileId?: string;

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -22,6 +22,9 @@ export default class PermissionsBinder extends Binder<PermissionData, Permission
    * @see https://docs.mollie.com/reference/get-permission
    */
   public get(id: string, parameters?: GetParameters): Promise<Permission>;
+  /**
+   * @deprecated Passing a callback as the second argument is deprecated and will be removed in the next major version. Use the returned promise instead, or pass `parameters` before the callback.
+   */
   public get(id: string, callback: Callback<Permission>): void;
   public get(id: string, parameters: GetParameters, callback: Callback<Permission>): void;
   public get(id: string, parameters?: GetParameters | Callback<Permission>) {

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -7,7 +7,7 @@ import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { type CreateParameters, type DeleteParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
+import { type CreateParameters, type DeleteParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
 
 const pathSegment = 'profiles';
 
@@ -37,12 +37,12 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * @since 3.2.0
    * @see https://docs.mollie.com/reference/get-profile
    */
-  public get(id: string): Promise<Profile>;
-  public get(id: string, callback: Callback<Profile>): void;
-  public get(id: string) {
+  public get(id: string, parameters?: GetParameters): Promise<Profile>;
+  public get(id: string, parameters: GetParameters, callback: Callback<Profile>): void;
+  public get(id: string, parameters?: GetParameters) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'profile');
-    return this.networkClient.get<ProfileData, Profile>(`${pathSegment}/${id}`);
+    return this.networkClient.get<ProfileData, Profile>(`${pathSegment}/${id}`, parameters);
   }
 
   /**

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -38,11 +38,15 @@ export default class ProfilesBinder extends Binder<ProfileData, Profile> {
    * @see https://docs.mollie.com/reference/get-profile
    */
   public get(id: string, parameters?: GetParameters): Promise<Profile>;
+  /**
+   * @deprecated Passing a callback as the second argument is deprecated and will be removed in the next major version. Use the returned promise instead, or pass `parameters` before the callback.
+   */
+  public get(id: string, callback: Callback<Profile>): void;
   public get(id: string, parameters: GetParameters, callback: Callback<Profile>): void;
-  public get(id: string, parameters?: GetParameters) {
+  public get(id: string, parameters?: GetParameters | Callback<Profile>) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'profile');
-    return this.networkClient.get<ProfileData, Profile>(`${pathSegment}/${id}`, parameters);
+    return this.networkClient.get<ProfileData, Profile>(`${pathSegment}/${id}`, parameters as GetParameters);
   }
 
   /**

--- a/src/binders/profiles/parameters.ts
+++ b/src/binders/profiles/parameters.ts
@@ -1,10 +1,12 @@
 import { type ProfileData } from '../../data/profiles/data';
-import { type IdempotencyParameter, type PaginationParameters, type ThrottlingParameter } from '../../types/parameters';
+import { type IdempotencyParameter, type PaginationParameters, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 import type PickOptional from '../../types/PickOptional';
 
 export type CreateParameters = Pick<ProfileData, 'name' | 'website' | 'email' | 'phone'> &
   PickOptional<ProfileData, 'description' | 'countriesOfActivity' | 'businessCategory' | 'categoryCode' | 'mode'> &
   IdempotencyParameter;
+
+export type GetParameters = TestModeParameter;
 
 export type PageParameters = PaginationParameters;
 

--- a/src/binders/terminals/TerminalsBinder.ts
+++ b/src/binders/terminals/TerminalsBinder.ts
@@ -24,11 +24,15 @@ export default class TerminalsBinder extends Binder<TerminalData, Terminal> {
    * @see https://docs.mollie.com/reference/get-terminal
    */
   public get(id: string, parameters?: GetParameters): Promise<Terminal>;
+  /**
+   * @deprecated Passing a callback as the second argument is deprecated and will be removed in the next major version. Use the returned promise instead, or pass `parameters` before the callback.
+   */
+  public get(id: string, callback: Callback<Terminal>): void;
   public get(id: string, parameters: GetParameters, callback: Callback<Terminal>): void;
-  public get(id: string, parameters?: GetParameters) {
+  public get(id: string, parameters?: GetParameters | Callback<Terminal>) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'terminal');
-    return this.networkClient.get(`${pathSegment}/${id}`, parameters);
+    return this.networkClient.get(`${pathSegment}/${id}`, parameters as GetParameters);
   }
 
   /**

--- a/src/binders/terminals/TerminalsBinder.ts
+++ b/src/binders/terminals/TerminalsBinder.ts
@@ -2,7 +2,7 @@ import type TransformingNetworkClient from '../../communication/TransformingNetw
 import renege from '../../plumbing/renege';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
-import { type PageParameters, IterateParameters } from './parameters';
+import { type GetParameters, type PageParameters, IterateParameters } from './parameters';
 import { Page } from '../../types';
 import Terminal from '../../data/terminals/Terminal';
 import type { TerminalData } from '../../data/terminals/data';
@@ -23,12 +23,12 @@ export default class TerminalsBinder extends Binder<TerminalData, Terminal> {
    * @since 4.3.0
    * @see https://docs.mollie.com/reference/get-terminal
    */
-  public get(id: string): Promise<Terminal>;
-  public get(id: string, callback: Callback<Terminal>): void;
-  public get(id: string) {
+  public get(id: string, parameters?: GetParameters): Promise<Terminal>;
+  public get(id: string, parameters: GetParameters, callback: Callback<Terminal>): void;
+  public get(id: string, parameters?: GetParameters) {
     if (renege(this, this.get, ...arguments)) return;
     assertWellFormedId(id, 'terminal');
-    return this.networkClient.get(`${pathSegment}/${id}`);
+    return this.networkClient.get(`${pathSegment}/${id}`, parameters);
   }
 
   /**

--- a/src/binders/terminals/parameters.ts
+++ b/src/binders/terminals/parameters.ts
@@ -1,5 +1,7 @@
 import { type PaginationParameters, type SortParameter, type TestModeParameter, type ThrottlingParameter } from '../../types/parameters';
 
+export type GetParameters = TestModeParameter;
+
 export type PageParameters = PaginationParameters & SortParameter & TestModeParameter;
 
 export type IterateParameters = Omit<PageParameters, 'limit'> & ThrottlingParameter;

--- a/tests/unit/resources/customers/payments.test.ts
+++ b/tests/unit/resources/customers/payments.test.ts
@@ -231,3 +231,48 @@ test('listCustomerPayouts', () => {
     });
   });
 });
+
+test('listCustomerPaymentsTestmodeAndProfileId', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    // The interceptor only matches when the request carries `?testmode=true&profileId=...`, so it fails if either parameter is dropped instead of being threaded into the query string.
+    networkMocker.intercept('GET', '/customers/cst_FhQJRw4s2n/payments?testmode=true&profileId=pfl_7N5qjbu42V', 200, {
+      _embedded: {
+        payments: [
+          {
+            resource: 'payment',
+            id: 'tr_admNa2tFfa',
+            mode: 'test',
+            createdAt: '2018-03-19T15:00:50+00:00',
+            amount: { value: '100.00', currency: 'EUR' },
+            description: 'Payment no 1',
+            method: null,
+            metadata: null,
+            status: 'open',
+            isCancelable: false,
+            expiresAt: '2018-03-19T15:15:50+00:00',
+            details: null,
+            locale: 'nl_NL',
+            profileId: 'pfl_7N5qjbu42V',
+            sequenceType: 'oneoff',
+            redirectUrl: 'https://www.example.org/',
+            _links: {
+              self: { href: 'https://api.mollie.com/v2/payments/tr_admNa2tFfa', type: 'application/hal+json' },
+            },
+          },
+        ],
+      },
+      _links: {
+        self: { href: 'https://api.mollie.com/v2/customers/cst_FhQJRw4s2n/payments?testmode=true&profileId=pfl_7N5qjbu42V', type: 'application/hal+json' },
+        previous: null,
+        next: null,
+      },
+      count: 1,
+    }).twice();
+
+    const payments = await bluster(mollieClient.customerPayments.page.bind(mollieClient.customerPayments))({ customerId: 'cst_FhQJRw4s2n', testmode: true, profileId: 'pfl_7N5qjbu42V' });
+
+    expect(payments.length).toBe(1);
+    expect(payments[0].id).toBe('tr_admNa2tFfa');
+    expect(payments[0].profileId).toBe('pfl_7N5qjbu42V');
+  });
+});

--- a/tests/unit/resources/paymentLinks.test.ts
+++ b/tests/unit/resources/paymentLinks.test.ts
@@ -1,0 +1,40 @@
+import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
+
+test('deletePaymentLink', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    let capturedBody: unknown;
+
+    networkMocker
+      .spy('DELETE', '/payment-links/pl_4Y0eZitmBnQ6IDoMqZQKh', body => {
+        capturedBody = body;
+        return [204, ''];
+      })
+      .twice();
+
+    const result = await bluster(mollieClient.paymentLinks.delete.bind(mollieClient.paymentLinks))('pl_4Y0eZitmBnQ6IDoMqZQKh');
+
+    expect(result).toBe(true);
+    // No parameters passed ⇒ empty body; no stray fields are injected.
+    expect(capturedBody).toEqual({});
+  });
+});
+
+test('deletePaymentLinkTestmode', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    let capturedBody: unknown;
+
+    // `delete` sends its context in the request body (not the query string), so assert the body carries
+    // testmode ‒ it fails if the parameter is dropped instead of being threaded into the request.
+    networkMocker
+      .spy('DELETE', '/payment-links/pl_4Y0eZitmBnQ6IDoMqZQKh', body => {
+        capturedBody = body;
+        return [204, ''];
+      })
+      .twice();
+
+    const result = await bluster(mollieClient.paymentLinks.delete.bind(mollieClient.paymentLinks))('pl_4Y0eZitmBnQ6IDoMqZQKh', { testmode: true });
+
+    expect(result).toBe(true);
+    expect(capturedBody).toEqual({ testmode: true });
+  });
+});

--- a/tests/unit/resources/profiles.test.ts
+++ b/tests/unit/resources/profiles.test.ts
@@ -79,6 +79,33 @@ test('getProfile', () => {
   });
 });
 
+test('getProfileTestmode', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    // The interceptor only matches when the request carries `?testmode=true`, so it fails if the parameter is dropped instead of being threaded into the query string.
+    networkMocker.intercept('GET', '/profiles/pfl_ahe8z8OPut?testmode=true', 200, {
+      resource: 'profile',
+      id: 'pfl_ahe8z8OPut',
+      mode: 'test',
+      name: 'My website name',
+      website: 'http://www.mywebsite.com',
+      email: 'info@mywebsite.com',
+      phone: '31123456789',
+      categoryCode: 5399,
+      status: 'verified',
+      review: { status: 'pending' },
+      createdAt: '2016-01-11T13:03:55+00:00',
+      _links: {
+        self: { href: 'https://api.mollie.com/v2/profiles/pfl_ahe8z8OPut', type: 'application/hal+json' },
+      },
+    }).twice();
+
+    const profile = await bluster(mollieClient.profiles.get.bind(mollieClient.profiles))('pfl_ahe8z8OPut', { testmode: true });
+
+    expect(profile.id).toBe('pfl_ahe8z8OPut');
+    expect(profile.mode).toBe('test');
+  });
+});
+
 test('listProfiles', () => {
   return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
     networkMocker.intercept('GET', '/profiles', 200, {

--- a/tests/unit/resources/terminals.test.ts
+++ b/tests/unit/resources/terminals.test.ts
@@ -1,0 +1,48 @@
+import NetworkMocker, { getApiKeyClientProvider } from '../../NetworkMocker';
+
+const terminalResponse = {
+  resource: 'terminal',
+  id: 'term_7MgL4wea46qkRcoTZjWEH',
+  profileId: 'pfl_QkEhN94Ba',
+  status: 'active',
+  brand: 'PAX',
+  model: 'A920',
+  serialNumber: '1234567890',
+  currency: 'EUR',
+  description: 'Terminal #1',
+  mode: 'live',
+  createdAt: '2022-02-12T11:58:35+00:00',
+  updatedAt: '2022-11-15T13:32:11+00:00',
+  _links: {
+    self: { href: 'https://api.mollie.com/v2/terminals/term_7MgL4wea46qkRcoTZjWEH', type: 'application/hal+json' },
+    documentation: { href: 'https://docs.mollie.com/reference/get-terminal', type: 'text/html' },
+  },
+};
+
+test('getTerminal', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/terminals/term_7MgL4wea46qkRcoTZjWEH', 200, terminalResponse).twice();
+
+    const terminal = await bluster(mollieClient.terminals.get.bind(mollieClient.terminals))('term_7MgL4wea46qkRcoTZjWEH');
+
+    expect(terminal.id).toBe('term_7MgL4wea46qkRcoTZjWEH');
+    expect(terminal.status).toBe('active');
+    expect(terminal.brand).toBe('PAX');
+    expect(terminal.model).toBe('A920');
+
+    expect(terminal._links.self).toEqual({ href: 'https://api.mollie.com/v2/terminals/term_7MgL4wea46qkRcoTZjWEH', type: 'application/hal+json' });
+  });
+});
+
+test('getTerminalTestmode', () => {
+  return new NetworkMocker(getApiKeyClientProvider()).use(async ([mollieClient, networkMocker]) => {
+    // The interceptor only matches when the request carries `?testmode=true`, so it fails if the
+    // parameter is dropped instead of being threaded into the query string.
+    networkMocker.intercept('GET', '/terminals/term_7MgL4wea46qkRcoTZjWEH?testmode=true', 200, { ...terminalResponse, mode: 'test' }).twice();
+
+    const terminal = await bluster(mollieClient.terminals.get.bind(mollieClient.terminals))('term_7MgL4wea46qkRcoTZjWEH', { testmode: true });
+
+    expect(terminal.id).toBe('term_7MgL4wea46qkRcoTZjWEH');
+    expect(terminal.mode).toBe('test');
+  });
+});


### PR DESCRIPTION
## Summary

Several endpoints accept the organization-credential parameters `testmode` and/or `profileId` per the Mollie OpenAPI spec, but the SDK did not declare them — so OAuth / organization-token callers had no way to send them. This adds the missing parameters:

| Endpoint | Added | Transport |
|---|---|---|
| `terminals.get` | `testmode` | query |
| `profiles.get` | `testmode` | query |
| `paymentLinks.delete` | `testmode` | body |
| `customerPayments.page` / `.iterate` | `testmode` + `profileId` | query |

Each is modelled via the shared `TestModeParameter` and an inline `profileId` (matching the existing list endpoints), and threaded through the binder signatures as an added optional parameter plus callback overload. All additions are optional, so this is non-breaking.

## Docs reference

- get-terminal: https://docs.mollie.com/reference/get-terminal
- get-profile: https://docs.mollie.com/reference/get-profile
- delete-payment-link: https://docs.mollie.com/reference/delete-payment-link
- list-customer-payments: https://docs.mollie.com/reference/list-customer-payments

## Tests

A request-forwarding test per endpoint, mirroring the existing `getPermissionTestmode` pattern: the Nock interceptor only matches when the parameter is present in the request, so a dropped parameter fails the test. For `paymentLinks.delete` — which sends its context in the body, not the query string — the test captures and asserts the request body instead. New unit suites for `terminals` and `paymentLinks`; additions to `profiles` and `customerPayments`.

## Context

Prerequisite for the client-level `parameterDefaults` feature (#426): that enhancer can only inject `testmode` / `profileId` into requests whose parameter types declare them, so the parameter coverage has to be correct first. The over-coverage counterparts (params the SDK declares that the spec omits) are tracked separately in #489.

## Verification

- `yarn build` ✓ (Rollup bundle + tsc declarations)
- `yarn jest tests/unit` ✓ — 45 suites, 143 tests
- `eslint` ✓ and `prettier --check` ✓ on touched files
