### PR TITLE
fix(payments): sync types, enums, and JSDoc with current Mollie API

### DIFF
--- a/src/binders/payments/parameters.ts
+++ b/src/binders/payments/parameters.ts
@@ -30,7 +30,8 @@ export type CreateParameters = Pick<
      * You can also specify the methods in an array. By doing so we will still show the payment method selection screen but will only show the methods specified in the array. For example, you can use
      * this functionality to only show payment methods from a specific country to your customer `['bancontact', 'belfius']`.
      *
-     * Possible values: `applepay` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `kbc` `mybank` `paypal` `paysafecard` `przelewy24` `sofort`
+     * Possible values: `alma` `applepay` `bacs` `bancomatpay` `bancontact` `banktransfer` `belfius` `billie` `bizum` `blik` `creditcard` `directdebit` `eps` `giftcard` `ideal` `in3` `kbc` `klarna`
+     * `mbway` `mobilepay` `multibanco` `mybank` `paybybank` `paypal` `paysafecard` `pointofsale` `przelewy24` `riverty` `satispay` `swish` `trustly` `twint` `vipps` `voucher`
      *
      * @see https://docs.mollie.com/reference/create-payment?path=method#parameters
      */

--- a/src/data/global.ts
+++ b/src/data/global.ts
@@ -45,14 +45,18 @@ export enum PaymentMethod {
   in3 = 'in3',
   kbc = 'kbc',
   klarna = 'klarna',
+  /** @deprecated Use `klarna` instead. */
   klarnapaylater = 'klarnapaylater',
+  /** @deprecated Use `klarna` instead. */
   klarnapaynow = 'klarnapaynow',
+  /** @deprecated Use `klarna` instead. */
   klarnasliceit = 'klarnasliceit',
   mbway = 'mbway',
   mobilepay = 'mobilepay',
   multibanco = 'multibanco',
   mybank = 'mybank',
   paybybank = 'paybybank',
+  /** @deprecated No longer available. */
   payconiq = 'payconiq',
   paypal = 'paypal',
   paysafecard = 'paysafecard',

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -195,8 +195,8 @@ export interface PaymentData extends Model<'payment'> {
    *
    * If the payment is only partially paid with a gift card, the method remains `giftcard`.
    *
-   * Possible values: `null` `bancontact` `banktransfer` `belfius` `creditcard` `directdebit` `eps` `giftcard` `giropay` `ideal` `in3` `kbc` `klarnapaylater` `klarnapaynow` `klarnasliceit` `mybank`
-   * `paypal` `paysafecard` `przelewy24` `sofort`
+   * Possible values: `null` `alma` `applepay` `bacs` `bancomatpay` `bancontact` `banktransfer` `belfius` `billie` `bizum` `blik` `creditcard` `directdebit` `eps` `giftcard` `ideal` `in3` `kbc` `klarna`
+   * `mbway` `mobilepay` `multibanco` `mybank` `paybybank` `paypal` `paysafecard` `pointofsale` `przelewy24` `riverty` `satispay` `swish` `trustly` `twint` `vipps` `voucher`
    *
    * @see https://docs.mollie.com/reference/get-payment?path=method#response
    */

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -1305,7 +1305,7 @@ export interface PaymentRoutingInfo {
   /**
    * Indicates the response contains a route object. Will always contain the string `route` for this resource.
    */
-  resource?: string;
+  resource?: 'route';
   /**
    * The identifier uniquely referring to this route, for example `rt_5B8cwPMGnU`. Mollie assigns this identifier at route creation time.
    */

--- a/src/data/payments/data.ts
+++ b/src/data/payments/data.ts
@@ -291,6 +291,7 @@ export interface PaymentData extends Model<'payment'> {
    *
    * Any amounts not settled by Mollie will not be reflected in this amount, e.g. PayPal or gift cards. If no amount is settled by Mollie the `settlementAmount` is omitted from the response.
    *
+   * @deprecated This field will be removed on January 1st, 2027. Use the [Settlements API](https://docs.mollie.com/reference/list-settlements) or the [List balance transactions](https://docs.mollie.com/reference/list-balance-transactions) endpoint for settlement data instead.
    * @see https://docs.mollie.com/reference/get-payment?path=settlementAmount#response
    */
   settlementAmount?: Amount;
@@ -1226,7 +1227,7 @@ export interface PaymentLine {
   /**
    * An array with the voucher categories, in case of a line eligible for a voucher. See the Integrating Vouchers guide for more information.
    *
-   * Possible values: `meal` `eco` `gift` `sport_culture`
+   * Possible values: `meal` `eco` `gift` `sport_culture` `additional` `consume`
    *
    * @see https://docs.mollie.com/reference/get-payment?path=lines/categories#lines
    */
@@ -1296,9 +1297,29 @@ export enum PaymentLineCategory {
   eco = 'eco',
   gift = 'gift',
   sport_culture = 'sport_culture',
+  additional = 'additional',
+  consume = 'consume',
 }
 
 export interface PaymentRoutingInfo {
+  /**
+   * Indicates the response contains a route object. Will always contain the string `route` for this resource.
+   */
+  resource?: string;
+  /**
+   * The identifier uniquely referring to this route, for example `rt_5B8cwPMGnU`. Mollie assigns this identifier at route creation time.
+   */
+  id?: string;
+  /**
+   * Whether this route was created in live mode or in test mode.
+   *
+   * Possible values: `live` `test`
+   */
+  mode?: ApiMode;
+  /**
+   * The route's date and time of creation, in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
+   */
+  createdAt?: string;
   /**
    * The portion of the total payment amount being routed. Currently only EUR payments can be routed.
    *
@@ -1330,6 +1351,19 @@ export interface PaymentRoutingInfo {
    * If no date is given, the funds become available to the connected merchant as soon as the payment succeeds.
    */
   releaseDate?: string;
+  /**
+   * An object with several relevant URLs. Only present in the response.
+   */
+  _links?: {
+    /**
+     * The API resource URL of the route itself.
+     */
+    self: Url;
+    /**
+     * The API resource URL of the payment this route belongs to.
+     */
+    payment: Url;
+  };
 }
 
 export enum RoutingType {


### PR DESCRIPTION
## What

Reconciles the **payments** resource with the current Mollie API spec. These five fields had drifted from the docs and were missed by the most recent sync pass (surfaced by diffing a long-stale `payment binder sync` stash against `master` and re-verifying each item against the live reference docs).

| # | Location | Change |
|---|----------|--------|
| 1 | `CreateParameters.method` (`parameters.ts`) | Refresh the `Possible values` JSDoc list to the current method set — drops historic `giropay`/`sofort` (already modelled as `HistoricPaymentMethod`), adds the methods introduced since. |
| 2 | `PaymentMethod` enum (`global.ts`) | Mark `klarnapaylater` / `klarnapaynow` / `klarnasliceit` as `@deprecated` in favour of `klarna`, and `payconiq` as no longer available. |
| 3 | `PaymentLineCategory` enum + JSDoc (`data.ts`) | Add the `additional` and `consume` voucher categories. |
| 4 | `PaymentRoutingInfo` (`data.ts`) | Model the route object's response-only fields: `resource`, `id`, `mode`, `createdAt`, `_links { self, payment }`. |
| 5 | `settlementAmount` (`data.ts`) | Mark `@deprecated`; the API removes it on **2027-01-01** in favour of the Settlements / balance transactions endpoints. |

## Why

Keeps the SDK's request/response types and JSDoc in step with what the API actually accepts and returns. The stale `method` list and missing enum members were the most consumer-visible drift.

## Docs references

- Create payment — https://docs.mollie.com/reference/create-payment (`method` possible values)
- Get payment — https://docs.mollie.com/reference/get-payment (`settlementAmount`, `routing` object, line `categories`, method deprecations)
- List settlements — https://docs.mollie.com/reference/list-settlements
- List balance transactions — https://docs.mollie.com/reference/list-balance-transactions

## Notes

- All changes are **additive or JSDoc-only — no breaking changes**, so this is a normal sync rather than a v5/milestone-5.0.0 item.
- `src/` typechecks clean.
