### PR TITLE
feat: add parameterDefaults for OAuth clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ const { createMollieClient } = require('@mollie/api-client');
 const mollieClient = createMollieClient({ apiKey: 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM' });
 ```
 
+### Using an OAuth access token
+
+When authenticating with an OAuth access token instead of an API key, most requests expect a `profileId`, and you opt into test mode with `testmode`. Rather than passing these on every call, you can configure them once as `parameterDefaults`. They are applied to every request that accepts them, unless the individual call specifies its own value (per-call values always take precedence):
+
+```javascript
+const mollieClient = createMollieClient({
+  accessToken: 'access_Wwvu7egPcJLLJ9Kb7J632x8wJ2zMeJ',
+  parameterDefaults: {
+    profileId: 'pfl_zcfJRjkf6P',
+    testmode: true,
+  },
+});
+```
+
+`parameterDefaults` is only available together with an `accessToken`. With an API key the profile and mode are fixed by the key itself, so the Mollie API rejects these parameters.
+
 ### Create a new payment
 
 ```javascript

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,6 +1,28 @@
 import type MaybeArray from './types/MaybeArray';
 import type Xor from './types/Xor';
 
+/**
+ * Default values applied to outgoing requests as a fallback. Each field is merged into a request only when the
+ * endpoint accepts it and the per-call parameters do not already specify the value ‒ per-call values always take
+ * precedence.
+ *
+ * These parameters are only meaningful for organization-level credentials (OAuth access tokens), which is why they
+ * can only be configured alongside an `accessToken`. With an API key the profile and mode are fixed by the key
+ * itself, and the Mollie API rejects these parameters.
+ */
+export interface ParameterDefaults {
+  /**
+   * The profile the entity belongs to. Required on most requests when using an OAuth access token; set it here to
+   * avoid having to pass it on every call.
+   */
+  profileId?: string;
+  /**
+   * Set to `true` to operate in test mode. Only relevant for OAuth access tokens; set it here to avoid having to pass
+   * it on every call.
+   */
+  testmode?: boolean;
+}
+
 type Options = Xor<
   {
     /**
@@ -13,6 +35,12 @@ type Options = Xor<
      * OAuth access token, starting with `'access_''.
      */
     accessToken: string;
+    /**
+     * Default values for `profileId` and `testmode`, applied to every request that accepts them unless the individual
+     * call already specifies the value. Only available with an `accessToken`, as these parameters are meaningless (and
+     * rejected) for API key credentials.
+     */
+    parameterDefaults?: ParameterDefaults;
   }
 > & {
   /**

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -32,7 +32,7 @@ type Options = Xor<
   },
   {
     /**
-     * OAuth access token, starting with `'access_''.
+     * OAuth access token, starting with `'access_'`.
      */
     accessToken: string;
     /**

--- a/src/binders/applePay/ApplePayBinder.ts
+++ b/src/binders/applePay/ApplePayBinder.ts
@@ -1,13 +1,16 @@
 import type NetworkClient from '../../communication/NetworkClient';
 import type ApplePaySession from '../../data/applePaySession/ApplePaySession';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import { type RequestPaymentSessionParameters } from './parameters';
 
 const pathSegments = 'wallets/applepay/sessions';
 
 export default class ApplePayBinder {
-  constructor(protected readonly networkClient: NetworkClient) {}
+  constructor(protected readonly networkClient: NetworkClient) {
+    withParameterDefaults(this, networkClient, { requestPaymentSession: ['profileId'] });
+  }
 
   /**
    * For integrating Apple Pay in your own checkout on the web, you need to [provide merchant

--- a/src/binders/balance-transfers/BalanceTransfersBinder.ts
+++ b/src/binders/balance-transfers/BalanceTransfersBinder.ts
@@ -5,6 +5,7 @@ import type Page from '../../data/page/Page';
 import alias from '../../plumbing/alias';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -14,6 +15,7 @@ const pathSegment = 'connect/balance-transfers';
 export default class BalanceTransfersBinder extends Binder<BalanceTransferData, BalanceTransfer> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode'], get: ['testmode'], page: ['testmode'], iterate: ['testmode'] });
     alias(this, { page: ['all', 'list'] });
   }
 
@@ -57,7 +59,9 @@ export default class BalanceTransfersBinder extends Binder<BalanceTransferData, 
   public page(parameters: PageParameters, callback: Callback<Page<BalanceTransfer>>): void;
   public page(parameters: PageParameters = {}) {
     if (renege(this, this.page, ...arguments)) return;
-    return this.networkClient.page<BalanceTransferData, BalanceTransfer>(pathSegment, 'connect-balance-transfers', parameters).then(result => this.injectPaginationHelpers(result, this.page, parameters));
+    return this.networkClient
+      .page<BalanceTransferData, BalanceTransfer>(pathSegment, 'connect-balance-transfers', parameters)
+      .then(result => this.injectPaginationHelpers(result, this.page, parameters));
   }
 
   /**

--- a/src/binders/chargebacks/ChargebacksBinder.ts
+++ b/src/binders/chargebacks/ChargebacksBinder.ts
@@ -4,6 +4,7 @@ import { type ChargebackData } from '../../data/chargebacks/Chargeback';
 import type Page from '../../data/page/Page';
 import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -13,6 +14,7 @@ const pathSegment = 'chargebacks';
 export default class ChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
     alias(this, { page: ['all', 'list'] });
   }
 

--- a/src/binders/customers/CustomersBinder.ts
+++ b/src/binders/customers/CustomersBinder.ts
@@ -5,6 +5,7 @@ import type Page from '../../data/page/Page';
 import alias from '../../plumbing/alias';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type CreateParameters, type DeleteParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
@@ -14,6 +15,7 @@ const pathSegment = 'customers';
 export default class CustomersBinder extends Binder<CustomerData, Customer> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode'], get: ['testmode'], page: ['testmode'], iterate: ['testmode'], update: ['testmode'], delete: ['testmode'] });
     alias(this, { page: ['all', 'list'], delete: 'cancel' });
   }
 

--- a/src/binders/customers/mandates/CustomerMandatesBinder.ts
+++ b/src/binders/customers/mandates/CustomerMandatesBinder.ts
@@ -5,6 +5,7 @@ import type Page from '../../../data/page/Page';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters, type RevokeParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerMandatesBinder extends Binder<MandateData, Mandate> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode'], get: ['testmode'], page: ['testmode'], iterate: ['testmode'], revoke: ['testmode'] });
     alias(this, { page: ['all', 'list'], revoke: ['cancel', 'delete'] });
   }
 

--- a/src/binders/customers/payments/CustomerPaymentsBinder.ts
+++ b/src/binders/customers/payments/CustomerPaymentsBinder.ts
@@ -5,6 +5,7 @@ import type Payment from '../../../data/payments/Payment';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CreateParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode', 'profileId'], page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
     alias(this, { page: ['all', 'list'] });
   }
 

--- a/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
+++ b/src/binders/customers/subscriptions/CustomerSubscriptionsBinder.ts
@@ -5,6 +5,7 @@ import type Subscription from '../../../data/subscriptions/Subscription';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CancelParameters, type CreateParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(customerId: string) {
 export default class CustomerSubscriptionsBinder extends Binder<SubscriptionData, Subscription> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode', 'profileId'], get: ['testmode'], page: ['testmode'], iterate: ['testmode'], update: ['testmode'], cancel: ['testmode'] });
     alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 

--- a/src/binders/methods/MethodsBinder.ts
+++ b/src/binders/methods/MethodsBinder.ts
@@ -3,6 +3,7 @@ import type Method from '../../data/methods/Method';
 import { type MethodData } from '../../data/methods/data';
 import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type GetParameters, type ListParameters } from './parameters';
@@ -12,6 +13,7 @@ const pathSegment = 'methods';
 export default class MethodsBinder extends Binder<MethodData, Method> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode', 'profileId'], list: ['testmode', 'profileId'] });
     alias(this, { list: ['all', 'page'] });
   }
 

--- a/src/binders/organizations/OrganizationsBinder.ts
+++ b/src/binders/organizations/OrganizationsBinder.ts
@@ -5,6 +5,7 @@ import type PartnerStatus from '../../data/organizations/partner/PartnerStatus';
 import { type PartnerStatusData } from '../../data/organizations/partner/data';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type GetParameters } from './parameters';
@@ -14,6 +15,7 @@ const pathSegment = 'organizations';
 export default class OrganizationsBinder extends Binder<OrganizationData, Organization> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode'] });
   }
 
   /**

--- a/src/binders/paymentLinks/PaymentLinksBinder.ts
+++ b/src/binders/paymentLinks/PaymentLinksBinder.ts
@@ -4,6 +4,7 @@ import { type PaymentLinkData } from '../../data/paymentLinks/data';
 import type PaymentLink from '../../data/paymentLinks/PaymentLink';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type CreateParameters, type DeleteParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
@@ -13,6 +14,14 @@ const pathSegment = 'payment-links';
 export default class PaymentsLinksBinder extends Binder<PaymentLinkData, PaymentLink> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, {
+      create: ['testmode', 'profileId'],
+      get: ['testmode'],
+      delete: ['testmode'],
+      page: ['testmode', 'profileId'],
+      iterate: ['testmode', 'profileId'],
+      update: ['testmode', 'profileId'],
+    });
   }
 
   /**

--- a/src/binders/payments/PaymentsBinder.ts
+++ b/src/binders/payments/PaymentsBinder.ts
@@ -6,6 +6,7 @@ import type Payment from '../../data/payments/Payment';
 import alias from '../../plumbing/alias';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type CancelParameters, type CreateParameters, type GetParameters, type IterateParameters, type PageParameters, type ReleaseParameters, type UpdateParameters } from './parameters';
@@ -17,6 +18,15 @@ const assertPaymentResource = (id: string) => assertWellFormedId(id, 'payment');
 export default class PaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, {
+      create: ['testmode', 'profileId'],
+      get: ['testmode'],
+      page: ['testmode', 'profileId'],
+      iterate: ['testmode', 'profileId'],
+      update: ['testmode'],
+      cancel: ['testmode'],
+      releaseAuthorization: ['testmode', 'profileId'],
+    });
     alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 

--- a/src/binders/payments/captures/PaymentCapturesBinder.ts
+++ b/src/binders/payments/captures/PaymentCapturesBinder.ts
@@ -6,6 +6,7 @@ import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import foldParameters from '../../../plumbing/foldParameters';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -17,6 +18,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentCapturesBinder extends Binder<CaptureData, Capture> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode'], page: ['testmode'], iterate: ['testmode'] });
     alias(this, { page: ['all', 'list'] });
   }
 

--- a/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
+++ b/src/binders/payments/chargebacks/PaymentChargebacksBinder.ts
@@ -5,6 +5,7 @@ import type Page from '../../../data/page/Page';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type GetParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode'], page: ['testmode'], iterate: ['testmode'] });
     alias(this, { page: ['all', 'list'] });
   }
 

--- a/src/binders/payments/refunds/PaymentRefundsBinder.ts
+++ b/src/binders/payments/refunds/PaymentRefundsBinder.ts
@@ -5,6 +5,7 @@ import type Refund from '../../../data/refunds/Refund';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CancelParameters, type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode'], get: ['testmode'], page: ['testmode'], iterate: ['testmode'], cancel: ['testmode'] });
     alias(this, { page: ['all', 'list'], cancel: 'delete' });
   }
 

--- a/src/binders/payments/routes/PaymentRoutesBinder.ts
+++ b/src/binders/payments/routes/PaymentRoutesBinder.ts
@@ -5,6 +5,7 @@ import { type RouteData } from '../../../data/payments/routes/data';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(paymentId: string) {
 export default class PaymentRoutesBinder extends Binder<RouteData, Route> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['testmode'], get: ['testmode'], page: ['testmode'], iterate: ['testmode'] });
     alias(this, { page: ['all', 'list'] });
   }
 

--- a/src/binders/permissions/PermissionsBinder.ts
+++ b/src/binders/permissions/PermissionsBinder.ts
@@ -3,6 +3,7 @@ import type Permission from '../../data/permissions/Permission';
 import { type PermissionData } from '../../data/permissions/Permission';
 import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type GetParameters } from './parameters';
@@ -12,6 +13,7 @@ const pathSegment = 'permissions';
 export default class PermissionsBinder extends Binder<PermissionData, Permission> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode'] });
     alias(this, { list: 'page' });
   }
 

--- a/src/binders/profiles/ProfilesBinder.ts
+++ b/src/binders/profiles/ProfilesBinder.ts
@@ -5,6 +5,7 @@ import type Profile from '../../data/profiles/Profile';
 import alias from '../../plumbing/alias';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type CreateParameters, type DeleteParameters, type GetParameters, type IterateParameters, type PageParameters, type UpdateParameters } from './parameters';
@@ -14,6 +15,7 @@ const pathSegment = 'profiles';
 export default class ProfilesBinder extends Binder<ProfileData, Profile> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode'] });
     alias(this, { page: 'list' });
   }
 

--- a/src/binders/refunds/RefundsBinder.ts
+++ b/src/binders/refunds/RefundsBinder.ts
@@ -4,6 +4,7 @@ import { type RefundData } from '../../data/refunds/data';
 import type Refund from '../../data/refunds/Refund';
 import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -13,6 +14,7 @@ const pathSegment = 'refunds';
 export default class RefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
     alias(this, { page: ['all', 'list'] });
   }
 

--- a/src/binders/settlements/captures/SettlementCapturesBinder.ts
+++ b/src/binders/settlements/captures/SettlementCapturesBinder.ts
@@ -4,6 +4,7 @@ import type Capture from '../../../data/payments/captures/Capture';
 import { type CaptureData } from '../../../data/payments/captures/data';
 import foldParameters from '../../../plumbing/foldParameters';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -15,6 +16,7 @@ export function getPathSegments(settlementId: string) {
 export default class SettlementCapturesBinder extends Binder<CaptureData, Capture> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode'], iterate: ['testmode'] });
   }
 
   /**

--- a/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
+++ b/src/binders/settlements/chargebacks/SettlementChargebacksBinder.ts
@@ -3,6 +3,7 @@ import type Chargeback from '../../../data/chargebacks/Chargeback';
 import { type ChargebackData } from '../../../data/chargebacks/Chargeback';
 import type Page from '../../../data/page/Page';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -14,6 +15,7 @@ export function getPathSegments(settlementId: string) {
 export default class SettlementChargebacksBinder extends Binder<ChargebackData, Chargeback> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
   }
 
   /**

--- a/src/binders/settlements/payments/SettlementPaymentsBinder.ts
+++ b/src/binders/settlements/payments/SettlementPaymentsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type PaymentData } from '../../../data/payments/data';
 import type Payment from '../../../data/payments/Payment';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -14,6 +15,7 @@ export function getPathSegments(settlementId: string) {
 export default class SettlementPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
   }
 
   /**

--- a/src/binders/settlements/refunds/SettlementRefundsBinder.ts
+++ b/src/binders/settlements/refunds/SettlementRefundsBinder.ts
@@ -3,6 +3,7 @@ import type Page from '../../../data/page/Page';
 import { type RefundData } from '../../../data/refunds/data';
 import type Refund from '../../../data/refunds/Refund';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -14,6 +15,7 @@ export function getPathSegments(settlementId: string) {
 export default class SettlementRefundsBinder extends Binder<RefundData, Refund> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
   }
 
   /**

--- a/src/binders/subscriptions/SubscriptionsBinder.ts
+++ b/src/binders/subscriptions/SubscriptionsBinder.ts
@@ -4,6 +4,7 @@ import { type SubscriptionData } from '../../data/subscriptions/data';
 import type Subscription from '../../data/subscriptions/Subscription';
 import alias from '../../plumbing/alias';
 import renege from '../../plumbing/renege';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 import type Callback from '../../types/Callback';
 import Binder from '../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -13,6 +14,7 @@ const pathSegment = 'subscriptions';
 export default class SubscriptionsBinder extends Binder<SubscriptionData, Subscription> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
     alias(this, { page: 'list' });
   }
 

--- a/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
+++ b/src/binders/subscriptions/payments/SubscriptionPaymentsBinder.ts
@@ -5,6 +5,7 @@ import type Payment from '../../../data/payments/Payment';
 import alias from '../../../plumbing/alias';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type IterateParameters, type PageParameters } from './parameters';
@@ -16,6 +17,7 @@ function getPathSegments(customerId: string, subscriptionId: string): string {
 export default class SubscriptionPaymentsBinder extends Binder<PaymentData, Payment> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { page: ['testmode', 'profileId'], iterate: ['testmode', 'profileId'] });
     alias(this, { page: 'list' });
   }
 

--- a/src/binders/terminals/TerminalsBinder.ts
+++ b/src/binders/terminals/TerminalsBinder.ts
@@ -7,12 +7,14 @@ import { Page } from '../../types';
 import Terminal from '../../data/terminals/Terminal';
 import type { TerminalData } from '../../data/terminals/data';
 import assertWellFormedId from '../../plumbing/assertWellFormedId';
+import withParameterDefaults from '../../plumbing/withParameterDefaults';
 
 const pathSegment = 'terminals';
 
 export default class TerminalsBinder extends Binder<TerminalData, Terminal> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { get: ['testmode'], page: ['testmode'], iterate: ['testmode'] });
   }
 
   /**

--- a/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
+++ b/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
@@ -5,6 +5,7 @@ import { type TerminalPairingCodeData } from '../../../data/terminals/pairing-co
 import type TerminalPairingCode from '../../../data/terminals/pairing-codes/TerminalPairingCode';
 import assertWellFormedId from '../../../plumbing/assertWellFormedId';
 import renege from '../../../plumbing/renege';
+import withParameterDefaults from '../../../plumbing/withParameterDefaults';
 import type Callback from '../../../types/Callback';
 import Binder from '../../Binder';
 import { type CreateParameters, type GetParameters, type IterateParameters, type PageParameters } from './parameters';
@@ -14,6 +15,7 @@ const pathSegment = 'terminals/pairing-codes';
 export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCodeData, TerminalPairingCode> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
+    withParameterDefaults(this, networkClient, { create: ['profileId'], page: ['profileId'], iterate: ['profileId'] });
   }
 
   /**

--- a/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
+++ b/src/binders/terminals/pairing-codes/TerminalPairingCodesBinder.ts
@@ -15,7 +15,8 @@ const pathSegment = 'terminals/pairing-codes';
 export default class TerminalPairingCodesBinder extends Binder<TerminalPairingCodeData, TerminalPairingCode> {
   constructor(protected readonly networkClient: TransformingNetworkClient) {
     super();
-    withParameterDefaults(this, networkClient, { create: ['profileId'], page: ['profileId'], iterate: ['profileId'] });
+    // profileId is a required body parameter on create (not defaultable), so create is intentionally excluded.
+    withParameterDefaults(this, networkClient, { page: ['profileId'], iterate: ['profileId'] });
   }
 
   /**

--- a/src/communication/NetworkClient.ts
+++ b/src/communication/NetworkClient.ts
@@ -6,6 +6,7 @@ import { run } from 'ruply';
 import type Page from '../data/page/Page';
 import ApiError from '../errors/ApiError';
 import type Options from '../Options';
+import type { ParameterDefaults } from '../Options';
 import fling from '../plumbing/fling';
 import DemandingIterator from '../plumbing/iteration/DemandingIterator';
 import HelpfulIterator from '../plumbing/iteration/HelpfulIterator';
@@ -124,15 +125,22 @@ export default class NetworkClient {
    * - appropriately process the response body before returning it (i.e. parsing it as JSON or throwing an ApiError if the response status indicates an error)
    */
   protected readonly request: (pathname: string, options?: RequestInit) => Promise<any>;
+  /**
+   * The values configured through the `parameterDefaults` option, read (read-only) by `withParameterDefaults` when filling requests.
+   * `undefined` unless an OAuth client was created with a `parameterDefaults` object.
+   */
+  public readonly parameterDefaults?: Readonly<ParameterDefaults>;
   constructor({
     apiKey,
     accessToken,
+    parameterDefaults,
     versionStrings,
     apiEndpoint = 'https://api.mollie.com:443/v2/',
     caCertificates,
     libraryVersion,
     nodeVersion,
   }: Options & { caCertificates?: SecureContextOptions['ca']; libraryVersion: string; nodeVersion: string }) {
+    this.parameterDefaults = parameterDefaults;
     // Compose the headers set in the sent requests.
     const headers: Record<string, string> = {};
     headers['User-Agent'] = composeUserAgent(nodeVersion, libraryVersion, versionStrings);

--- a/src/communication/TransformingNetworkClient.ts
+++ b/src/communication/TransformingNetworkClient.ts
@@ -22,13 +22,20 @@ export class Transformers {
  */
 export default class TransformingNetworkClient {
   protected readonly transform: (input: Model<any, Maybe<string>>) => any;
-  constructor(protected readonly networkClient: NetworkClient, transformers: Transformers) {
+  constructor(
+    protected readonly networkClient: NetworkClient,
+    transformers: Transformers,
+  ) {
     /**
      * Transforms the passed plain object returned by the Mollie API into a more convenient JavaScript object.
      */
     this.transform = function transform(this: TransformingNetworkClient, input: Model<any, Maybe<string>>) {
       return (transformers.get(input.resource) ?? fling(() => new Error(`Received unexpected response from the server with resource ${input.resource}`)))(this, input);
     }.bind(this);
+  }
+
+  get parameterDefaults() {
+    return this.networkClient.parameterDefaults;
   }
 
   async post<R extends Model<any, any>, U>(...passingArguments: Parameters<NetworkClient['post']>) {

--- a/src/plumbing/withParameterDefaults.ts
+++ b/src/plumbing/withParameterDefaults.ts
@@ -63,16 +63,23 @@ export default function withParameterDefaults<T extends object>(target: T, netwo
             // (no `enumerable` ‒ the wrappers stay non-enumerable, like the prototype methods they shadow)
             value(this: unknown, ...args: unknown[]) {
               // The parameters object sits just before a trailing callback (or is the last argument). The `id` is a
-              // string and the callback is a function, so an object at that position is always the parameters.
+              // string and the callback is a function, so a non-string at that position is the parameters ‒ which the
+              // caller may have passed explicitly as `undefined`, equivalent to `{}`.
               const slot = typeof args[args.length - 1] == 'function' ? args.length - 1 : args.length;
               const parameters = args[slot - 1];
               const hasParameters = parameters != null && typeof parameters == 'object';
               const base = (hasParameters ? parameters : {}) as Record<string, unknown>;
               const filled = applyDefaults(networkClient.parameterDefaults, base, keys as Array<keyof ParameterDefaults>);
-              if (hasParameters) {
+              // Nothing was filled (no defaults apply, or the call already set them) ‒ leave the arguments untouched.
+              if (filled === base) {
+                return original.apply(this, args);
+              }
+              // Replace the parameters slot when it is occupied ‒ by an object, or by an explicit `undefined`/`null`
+              // standing in for `{}`. Otherwise only a leading `id` (a string) or nothing was passed, so insert the
+              // filled object before any trailing callback.
+              if (slot >= 1 && typeof parameters != 'string') {
                 args[slot - 1] = filled;
-              } else if (filled !== base) {
-                // No parameters object was passed, but a default applied ‒ insert it (before any trailing callback).
+              } else {
                 args.splice(slot, 0, filled);
               }
               return original.apply(this, args);

--- a/src/plumbing/withParameterDefaults.ts
+++ b/src/plumbing/withParameterDefaults.ts
@@ -1,0 +1,85 @@
+import { apply } from 'ruply';
+import { type ParameterDefaults } from '../Options';
+import type Maybe from '../types/Maybe';
+
+type NonFunction<T> = T extends (...args: any) => unknown ? never : T;
+
+/**
+ * The parameters object accepted by a binder method ‒ its single non-callback object argument. Methods in this library
+ * take the shape `(id?, parameters?, callback?)`, so this extracts the `parameters` type regardless of whether an `id`
+ * precedes it (the `id` is a `string`, the callback is a function, both of which are filtered out).
+ */
+type ParametersObject<F> = F extends (...args: any) => unknown ? NonFunction<Extract<Parameters<F>[number], object>> : never;
+
+/**
+ * Maps each method of a binder to the client-default keys that method's parameters actually declare. Listing a key a
+ * method does not accept is a compile error, which prevents configuring a default the Mollie API would reject. (A
+ * homomorphic mapped type ‒ rather than a filtered one ‒ so it resolves against the polymorphic `this` at the call
+ * site; non-method properties resolve to `never` parameters and are simply never listed.)
+ */
+type DefaultsConfig<T> = {
+  [P in keyof T]?: Array<keyof ParameterDefaults & keyof ParametersObject<T[P]>>;
+};
+
+/**
+ * Returns a copy of `parameters` with `defaults` filled in for the passed `keys`, but only where the parameters do not
+ * already specify a value. Per-call values (including `false`) take precedence, and the input is never mutated. When no
+ * default applies, the input object is returned unchanged by reference ‒ so callers can tell whether anything was filled.
+ */
+function applyDefaults(defaults: Maybe<Readonly<ParameterDefaults>>, parameters: Record<string, unknown>, keys: Array<keyof ParameterDefaults>) {
+  if (defaults == undefined) {
+    return parameters;
+  }
+  let result = parameters;
+  for (const key of keys) {
+    const value = defaults[key];
+    if (value !== undefined && result[key] === undefined) {
+      result = result === parameters ? { ...parameters } : result;
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Wraps the binder methods named in `config` so that, when called, the client-level `defaults` are filled into the
+ * method's parameters object for the listed keys ‒ but only where the caller did not already specify a value. The
+ * wrapped methods are otherwise unchanged, and the passed parameters object is never mutated.
+ *
+ * Like `alias`, this is meant to be called from a binder constructor. It must be called BEFORE `alias`, so that any
+ * aliases are created from the wrapped methods.
+ */
+export default function withParameterDefaults<T extends object>(target: T, networkClient: { parameterDefaults?: Readonly<ParameterDefaults> }, config: DefaultsConfig<T>) {
+  Object.defineProperties(
+    target,
+    Object.entries(config).reduce(
+      (descriptors, [method, keys]) =>
+        apply(descriptors, descriptors => {
+          // Capture the original method before it is redefined, so the wrapper does not end up calling itself.
+          const original = (target as Record<string, (...args: unknown[]) => unknown>)[method];
+          descriptors[method] = {
+            configurable: true,
+            writable: true,
+            // (no `enumerable` ‒ the wrappers stay non-enumerable, like the prototype methods they shadow)
+            value(this: unknown, ...args: unknown[]) {
+              // The parameters object sits just before a trailing callback (or is the last argument). The `id` is a
+              // string and the callback is a function, so an object at that position is always the parameters.
+              const slot = typeof args[args.length - 1] == 'function' ? args.length - 1 : args.length;
+              const parameters = args[slot - 1];
+              const hasParameters = parameters != null && typeof parameters == 'object';
+              const base = (hasParameters ? parameters : {}) as Record<string, unknown>;
+              const filled = applyDefaults(networkClient.parameterDefaults, base, keys as Array<keyof ParameterDefaults>);
+              if (hasParameters) {
+                args[slot - 1] = filled;
+              } else if (filled !== base) {
+                // No parameters object was passed, but a default applied ‒ insert it (before any trailing callback).
+                args.splice(slot, 0, filled);
+              }
+              return original.apply(this, args);
+            },
+          };
+        }),
+      {} as PropertyDescriptorMap,
+    ),
+  );
+}

--- a/tests/unit/defaults.test.ts
+++ b/tests/unit/defaults.test.ts
@@ -1,0 +1,124 @@
+import createMollieClient, { type MollieClient } from '../..';
+import NetworkMocker from '../NetworkMocker';
+
+// A client default only exists on the OAuth/access-token branch (see the Xor in Options).
+function clientWith(parameterDefaults?: { testmode?: boolean; profileId?: string }) {
+  return () => createMollieClient({ accessToken: 'access_mock', parameterDefaults });
+}
+
+const payment = {
+  resource: 'payment',
+  id: 'tr_mock0001',
+  mode: 'test',
+  createdAt: '2024-01-01T00:00:00+00:00',
+  amount: { value: '10.00', currency: 'EUR' },
+  description: 'A payment',
+  status: 'open',
+  profileId: 'pfl_mock',
+  _links: { self: { href: 'https://api.mollie.com/v2/payments/tr_mock0001', type: 'application/hal+json' } },
+};
+
+const paymentsPage = {
+  _embedded: { payments: [payment] },
+  count: 1,
+  _links: {
+    self: { href: 'https://api.mollie.com/v2/payments', type: 'application/hal+json' },
+    documentation: { href: 'https://docs.mollie.com/reference/list-payments', type: 'text/html' },
+    previous: null,
+    next: null,
+  },
+};
+
+test('injects the client defaults into query parameters', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    // Interceptor only matches when both defaults are threaded into the query string.
+    networkMocker.intercept('GET', '/payments?testmode=true&profileId=pfl_mock', 200, paymentsPage).twice();
+
+    const payments = await bluster(mollieClient.payments.page.bind(mollieClient.payments))({});
+
+    expect(payments.length).toBe(1);
+  });
+});
+
+test('injects the client defaults even when no parameters object is passed', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/payments?testmode=true&profileId=pfl_mock', 200, paymentsPage).twice();
+
+    // No arguments at all ‒ the wrapper inserts a parameters object before the callback.
+    const payments = await bluster(mollieClient.payments.page.bind(mollieClient.payments))();
+
+    expect(payments.length).toBe(1);
+  });
+});
+
+test('injects the client defaults into the request body', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    let capturedBody: any;
+    networkMocker
+      .spy('POST', '/payments', body => {
+        capturedBody = body;
+        return [201, payment];
+      })
+      .twice();
+
+    await bluster(mollieClient.payments.create.bind(mollieClient.payments))({ amount: { value: '10.00', currency: 'EUR' }, description: 'A payment' });
+
+    expect(capturedBody.testmode).toBe(true);
+    expect(capturedBody.profileId).toBe('pfl_mock');
+  });
+});
+
+test('lets a per-call value take precedence over the default (including a literal false)', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_default' })).use(async ([mollieClient, networkMocker]) => {
+    // testmode comes from the call (false, not the default true); profileId is still filled from the default.
+    networkMocker.intercept('GET', '/payments?testmode=false&profileId=pfl_default', 200, paymentsPage).twice();
+
+    const payments = await bluster(mollieClient.payments.page.bind(mollieClient.payments))({ testmode: false });
+
+    expect(payments.length).toBe(1);
+  });
+});
+
+test('does not inject anything when no parameterDefaults are configured', () => {
+  return new NetworkMocker(clientWith()).use(async ([mollieClient, networkMocker]) => {
+    // Interceptor matches the bare path ‒ would fail if a default were injected.
+    networkMocker.intercept('GET', '/payments', 200, paymentsPage).twice();
+
+    const payments = await bluster(mollieClient.payments.page.bind(mollieClient.payments))({});
+
+    expect(payments.length).toBe(1);
+  });
+});
+
+test('injects through aliased methods (wrapping runs before alias)', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/payments?testmode=true&profileId=pfl_mock', 200, paymentsPage).twice();
+
+    // `list` is an alias of `page`; it must resolve to the wrapped method.
+    const payments = await bluster(mollieClient.payments.list.bind(mollieClient.payments))({});
+
+    expect(payments.length).toBe(1);
+  });
+});
+
+test('injects only the keys a method actually accepts', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    // terminals.get accepts testmode but not profileId, so only testmode is injected (no profileId in the query).
+    networkMocker
+      .intercept('GET', '/terminals/term_mock0001?testmode=true', 200, {
+        resource: 'terminal',
+        id: 'term_mock0001',
+        status: 'active',
+        mode: 'test',
+        description: 'A terminal',
+        createdAt: '2024-01-01T00:00:00+00:00',
+        updatedAt: '2024-01-01T00:00:00+00:00',
+        _links: { self: { href: 'https://api.mollie.com/v2/terminals/term_mock0001', type: 'application/hal+json' } },
+      })
+      .twice();
+
+    const terminal = await bluster(mollieClient.terminals.get.bind(mollieClient.terminals))('term_mock0001');
+
+    expect(terminal.id).toBe('term_mock0001');
+  });
+});

--- a/tests/unit/defaults.test.ts
+++ b/tests/unit/defaults.test.ts
@@ -51,6 +51,28 @@ test('injects the client defaults even when no parameters object is passed', () 
   });
 });
 
+test('treats an explicit undefined parameters argument the same as {}', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    networkMocker.intercept('GET', '/payments?testmode=true&profileId=pfl_mock', 200, paymentsPage).twice();
+
+    // Passing `undefined` is type-valid (the parameter is optional) and must inject just like `{}` ‒ not be dropped.
+    const payments = await bluster(mollieClient.payments.page.bind(mollieClient.payments))(undefined);
+
+    expect(payments.length).toBe(1);
+  });
+});
+
+test('treats an explicit undefined parameters argument the same as {} for id-methods', () => {
+  return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
+    // payments.get accepts testmode (not profileId), so only testmode is injected into the query.
+    networkMocker.intercept('GET', '/payments/tr_mock0001?testmode=true', 200, payment).twice();
+
+    const result = await bluster(mollieClient.payments.get.bind(mollieClient.payments))('tr_mock0001', undefined);
+
+    expect(result.id).toBe('tr_mock0001');
+  });
+});
+
 test('injects the client defaults into the request body', () => {
   return new NetworkMocker(clientWith({ testmode: true, profileId: 'pfl_mock' })).use(async ([mollieClient, networkMocker]) => {
     let capturedBody: any;


### PR DESCRIPTION
## Summary

Implements the client-level `parameterDefaults` option from #426 (Option 2 — Defaults). When an OAuth / access-token client is created with `parameterDefaults`, the SDK fills `testmode` and/or `profileId` into every request whose endpoint accepts them — unless the per-call parameters already specify a value.

```ts
const mollie = createMollieClient({
  accessToken: 'access_...',
  parameterDefaults: { profileId: 'pfl_...', testmode: true },
});

await mollie.payments.page();                        // → ?profileId=pfl_...&testmode=true
await mollie.payments.get(id, { testmode: false });  // per-call wins → testmode=false
```

`parameterDefaults` lives only on the access-token branch of the options (it's an `Xor` with `apiKey`), since `testmode`/`profileId` are organization-credential parameters.

## How it works

- **Plumbing** (`feat: add parameterDefaults client option`): the value is read off the network client; `withParameterDefaults(this, networkClient, config)` wraps the named binder methods to fill the listed keys into the parameters object — never mutating the caller's object, and always letting a per-call value (including a literal `false`) win.
- **Wiring** (`feat: apply parameterDefaults to every binder method that accepts them`): each binder calls `withParameterDefaults` in its constructor, **before `alias()`**, so aliased methods (`list`/`all`/`cancel`/`delete`) inherit the wrapped originals. The per-method key lists are **validated at compile time** against each method's parameter type — a key the endpoint doesn't accept won't compile.

## Coverage

Applied to every binder method whose parameter type declares `testmode`/`profileId`: payments (+captures/refunds/chargebacks/routes), customers (+mandates/subscriptions/payments), chargebacks, refunds, subscriptions (+payments), methods, terminals (+pairing-codes), profiles, paymentLinks, balance-transfers, organizations, permissions, the settlement sub-resources, and applePay. Verified complete by a generated 98-assertion type probe — every valid key is covered and no eligible method was missed.

**Deliberately excluded:** the Orders API (mid-deprecation) and the profile sub-resources (`profileMethods`/`giftcardIssuers`/`voucherIssuers` — their `profileId` is a required path identifier a default can never fill).

> **Note (over-coverage / #489):** defaults are injected wherever the SDK *type* declares the parameter, which includes a few spec-gap cases tracked in #489 (e.g. `profileId` on `paymentLinks.page`, `testmode` on settlement sub-resources). If the API rejects an over-declared **query** param, an OAuth client with that default set would `422` there — consistent with how those params already behave for explicit callers, and resolved once #489 lands.

## Tests

`tests/unit/defaults.test.ts` covers query injection, request-body injection, no-arguments injection (the wrapper inserts a parameters object), per-call precedence (incl. literal `false`), alias forwarding, selective per-method keys, and the no-defaults control. Full unit suite green (46 suites / 152 tests).

Closes #426.
