### PR TITLE
Release v4.6.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,10 +40,12 @@ Consumers should never access underscore-prefixed properties directly (the `_` p
 
 Publishing is automated via `.github/workflows/publish.yml` (npm Trusted Publishing / OIDC) — it runs when a GitHub Release is published. There is **no manual `npm publish`** and no npm token.
 
-1. Update `CHANGELOG.md`
-2. `npm version <major|minor|patch>` (bumps `package.json`, commits, creates the `vX.Y.Z` tag)
-3. `git push --follow-tags`
-4. Publish a GitHub Release for the tag → the workflow verifies the tag matches `package.json`, builds, runs unit tests, and publishes with provenance (prereleases like `-rc.N` go to their own dist-tag, not `latest`).
+`master` is protected, so the version bump rides in through a release PR like any other change — it can't be pushed directly. **Verify before bumping**, and treat publishing the Release as the irreversible final step.
+
+1. **Verify** on up-to-date `master` (all release content merged): `yarn build`, `yarn test` (the **full** suite — the workflow only runs `yarn test:unit`, so integration is covered only here), `yarn lint`, and `CHANGELOG.md` updated.
+2. On a release branch: `npm version <major|minor|patch>` (bumps `package.json`, commits, creates the `vX.Y.Z` tag). Push the **branch** and open the release PR.
+3. **Push the tag only once the PR is approved** (`git push origin vX.Y.Z`) — pushing it earlier risks a stale tag (delete-and-re-tag) if review forces changes. Merge with a merge-commit to keep the tag on `master`.
+4. Once merged, publish a GitHub Release for the tag → the workflow re-verifies the tag matches `package.json`, builds, runs unit tests, and publishes with provenance (prereleases like `-rc.N` go to their own dist-tag, not `latest`).
 
 See `CONTRIBUTING.md` for the maintainer-facing version of this.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,11 @@
 # configured on the package (org `mollie`, repo `mollie-api-node`, and this
 # workflow's filename). Provenance attestations are generated on every publish.
 #
-# Cutting a release: bump the version (`npm version <major|minor|patch>`), push
-# the commit and its tag, then publish a GitHub Release for that tag — that is
-# what triggers this workflow. Who may publish a release is governed by the
-# repository's tag/release ruleset.
+# Cutting a release: bump the version on a release branch (`npm version
+# <major|minor|patch>`) and merge it via PR (master is protected); push the tag
+# once the PR is approved, then publish a GitHub Release for that tag — that is
+# what triggers this workflow. See CONTRIBUTING.md for the full checklist. Who
+# may publish a release is governed by the repository's tag/release ruleset.
 name: Publish to npm
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@
 
 Please see [the migration guide](MIGRATION.md) for guidance about updating to a newer major version.
 
+### v4.6.0 - 2026-06-30
+  - Add Invoices API support ([#506](https://github.com/mollie/mollie-api-node/pull/506))
+  - Add terminal pairing codes endpoints ([#508](https://github.com/mollie/mollie-api-node/pull/508))
+  - Add `paymentRoutes.get` and a route `getPayment()` helper to complete Routes API coverage ([#511](https://github.com/mollie/mollie-api-node/pull/511))
+  - Support running on non-Node.js server runtimes (Bun, Deno, Cloudflare Workers) via a browser-environment guard and a `dangerouslyAllowBrowser` option ([#490](https://github.com/mollie/mollie-api-node/pull/490))
+  - Add a `parameterDefaults` option for OAuth clients to auto-fill `testmode` and `profileId` on every request that accepts them ([#517](https://github.com/mollie/mollie-api-node/pull/517))
+  - Add `storeCredentials` parameter to payment and order create ([#480](https://github.com/mollie/mollie-api-node/pull/480))
+  - Add `testmode` and `profileId` parameters to the endpoints that accept them, and deprecate the callback-as-second-argument overloads ([#514](https://github.com/mollie/mollie-api-node/pull/514))
+  - Support `testmode` on `permissions.get` ([#503](https://github.com/mollie/mollie-api-node/pull/503))
+  - Add `profileId` parameter to the Apple Pay payment session request ([#512](https://github.com/mollie/mollie-api-node/pull/512))
+  - Add `legalEntity`, `registrationOffice`, and `incorporationDate` parameters to the Create client link endpoint ([#495](https://github.com/mollie/mollie-api-node/pull/495))
+  - Add `metadata` support to connect balance transfers ([#492](https://github.com/mollie/mollie-api-node/pull/492))
+  - Add `mode` and `updatedAt` fields to the `Terminal` response type ([#507](https://github.com/mollie/mollie-api-node/pull/507))
+  - Sync Payments types with the Mollie API spec, adding the `getSettlement`, `getCustomer`, `getMandate`, `getSubscription`, `getTerminal`, and `getMobileAppCheckoutUrl` helpers plus new request parameters ([#510](https://github.com/mollie/mollie-api-node/pull/510))
+  - Sync `payments` enums and JSDoc with the Mollie API spec, adding the `additional`/`consume` voucher line categories and deprecating the legacy Klarna methods, `payconiq`, and `settlementAmount` ([#516](https://github.com/mollie/mollie-api-node/pull/516))
+  - Sync settlements with the Mollie API spec, adding `balanceId`, `invoiceId`, a `getInvoice()` helper, and the `SettlementStatus` enum ([#509](https://github.com/mollie/mollie-api-node/pull/509))
+  - Sync the `subscriptions` resource with the Mollie API spec, adding `getMandate()` and the `profileId` list parameter ([#504](https://github.com/mollie/mollie-api-node/pull/504))
+  - Sync the Profiles resource with the Mollie API spec, adding `description`, `countriesOfActivity`, and `profile.getDashboardUrl()` ([#505](https://github.com/mollie/mollie-api-node/pull/505))
+  - Sync the `organizations` resource with the Mollie API spec, adding the `email` field, a `getDashboardUrl()` helper, and `testmode` support ([#502](https://github.com/mollie/mollie-api-node/pull/502))
+  - Sync `refunds` types and docs with the Mollie API spec, adding `mode`, `externalReference`, routing reversals, and the `embed` parameter ([#484](https://github.com/mollie/mollie-api-node/pull/484))
+  - Sync `onboarding` types with the Mollie API spec, adding `businessCategory` and the `british` `vatRegulation`, and deprecating the `submit` method ([#500](https://github.com/mollie/mollie-api-node/pull/500))
+  - Sync `paymentLinks` types and docs with the Mollie API spec, adding `lines`, `billingAddress`, and `shippingAddress` to `UpdateParameters` ([#501](https://github.com/mollie/mollie-api-node/pull/501))
+  - Sync Methods API types and docs with the Mollie API spec, adding the `googlepay` payment method, `en_GB`/`fr_LU`/`de_LU` locales, and the `sequenceType` get-method parameter ([#488](https://github.com/mollie/mollie-api-node/pull/488))
+  - Sync `chargebacks` types with the Mollie API spec, adding the `settlementId` field and `testmode` parameter support ([#487](https://github.com/mollie/mollie-api-node/pull/487))
+  - Sync JSDoc and documentation links with the Mollie API reference across the capabilities, OAuth, and customer resources ([#494](https://github.com/mollie/mollie-api-node/pull/494)/[#496](https://github.com/mollie/mollie-api-node/pull/496)/[#498](https://github.com/mollie/mollie-api-node/pull/498))
+  - Fix capture payment embedding by sending the `embed` query parameter instead of the silently-ignored `include` ([#483](https://github.com/mollie/mollie-api-node/pull/483))
+  - Deprecate the Orders API binders and methods ([#486](https://github.com/mollie/mollie-api-node/pull/486))
+  - Automate npm publishing via GitHub Actions Trusted Publishing (OIDC) ([#485](https://github.com/mollie/mollie-api-node/pull/485))
+  - Update dev dependencies and re-resolve `form-data` to clear a CRLF-injection advisory ([#482](https://github.com/mollie/mollie-api-node/pull/482))
+
 ### v4.5.0 - 2026-04-01
   - Add `sort` parameter to list endpoints ([#474](https://github.com/mollie/mollie-api-node/pull/474))
   - Add `TestModeParameter` type and apply consistently across all binders ([#475](https://github.com/mollie/mollie-api-node/pull/475))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,17 +44,37 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 
 Releases are published to npm **automatically** by [`.github/workflows/publish.yml`](.github/workflows/publish.yml) when a GitHub Release is published. Authentication uses [npm Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) — there is no npm token, and there is no manual `npm publish` step.
 
-To cut a release:
+> ⚠️ **Publishing the GitHub Release is the point of no return.** It immediately triggers the publish workflow, so it must be the *last* step. Do all verification *before* you bump the version — by the time you create the Release, everything must already be green.
 
-1. Update `CHANGELOG.md`.
-2. `npm version <major|minor|patch>` — bumps `package.json`, creates a commit and a `vX.Y.Z` tag.
-3. `git push --follow-tags` — pushes the commit and the tag.
-4. Publish a [GitHub Release](https://github.com/mollie/mollie-api-node/releases) for the new tag. **This is what triggers publishing.**
+### 1. Verify — before touching the version
 
-The workflow then:
+Start from an up-to-date `master` with everything that belongs in the release already merged, then confirm locally:
+
+- `yarn build` succeeds.
+- `yarn test` passes — the **full** suite. The integration tests hit the live API and need `API_KEY` set; the publish workflow only runs `yarn test:unit`, so integration coverage is exercised *only* if you run it here.
+- `yarn lint` is clean.
+- `CHANGELOG.md` has an entry for the new version.
+
+### 2. Bump the version — via a release PR
+
+`master` is protected, so the bump rides in through a PR like any other change; it cannot be pushed directly.
+
+- On a release branch (e.g. `chore/release-x-y-z`), run `npm version <major|minor|patch>` — bumps `package.json` and creates the release commit and a local `vX.Y.Z` tag.
+- Push the **branch only** (not the tag yet) and open the release PR; get it approved.
+
+### 3. Push the tag, then merge
+
+- **Push the tag only once the PR is approved:** `git push origin vX.Y.Z`. Pushing it earlier risks a stale tag — if review forces any change to the PR, the tag would point at outdated content, and you would have to delete the remote tag, re-tag, and push again.
+- Merge the PR. Use a **merge commit** if you want the tag to stay an ancestor of `master`; squash/rebase rewrites the commit and leaves the tag off-master (fine for publishing either way).
+
+### 4. Publish the GitHub Release — this triggers publishing
+
+Publish a [GitHub Release](https://github.com/mollie/mollie-api-node/releases) for the new tag. This starts the workflow, which then:
 
 - verifies the release tag matches the `package.json` version (and fails loudly if not),
 - builds the package and runs the unit tests,
 - publishes to npm with provenance, routing prereleases (e.g. `4.4.0-rc.1`) to their own dist-tag (`rc`, `beta`, …) so they never become the default `latest` install.
+
+These workflow checks are a last-resort guard, not a substitute for step 1: if they fail, nothing is published — but the Release and tag already exist, leaving a half-cut release to undo. Keep real verification in step 1.
 
 Permission to create the tag / publish the release is governed by the repository's tag/release ruleset.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mollie/api-client",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "license": "BSD-3-Clause",
   "description": "Official Mollie API client for Node",
   "repository": {

--- a/src/data/invoices/InvoiceHelper.ts
+++ b/src/data/invoices/InvoiceHelper.ts
@@ -15,6 +15,7 @@ export default class InvoiceHelper extends Helper<InvoiceData, Invoice> {
   /**
    * Returns the URL to the PDF version of the invoice, or `null` if it is not available.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/get-invoice?path=_links/pdf#response
    */
   public getPdfUrl(): Nullable<string> {

--- a/src/data/organizations/OrganizationHelper.ts
+++ b/src/data/organizations/OrganizationHelper.ts
@@ -15,6 +15,7 @@ export default class OrganizationHelper extends Helper<OrganizationData, Organiz
   /**
    * Returns the direct link to the organization in the Mollie Dashboard.
    *
+   * @since 4.6.0
    * @see https://docs.mollie.com/reference/get-organization?path=_links/dashboard#response
    */
   public getDashboardUrl(): Nullable<string> {

--- a/src/data/profiles/data.ts
+++ b/src/data/profiles/data.ts
@@ -94,6 +94,7 @@ export interface ProfileData extends Model<'profile'> {
    * -   `9399` Government services
    * -   `0` Other
    *
+   * @deprecated Use {@link businessCategory} instead. The numeric category code is no longer part of the Profiles API.
    * @see https://docs.mollie.com/reference/get-profile?path=categoryCode#response
    */
   categoryCode: number;


### PR DESCRIPTION
## Summary

Prepares the v4.6.0 release. Full flat list in `CHANGELOG.md`; categorized notes for the GitHub Release body are drafted in `RELEASE_NOTES_v4.6.0.md`.

**New APIs**
- Add Invoices API support (#506)
- Add terminal pairing codes endpoints (#508)
- Complete Routes API coverage: `paymentRoutes.get` + a route `getPayment()` helper (#511)

**Runtime & compatibility**
- Run on non-Node.js runtimes (Bun, Deno, Cloudflare Workers) + `dangerouslyAllowBrowser` (#490)

**Enhancements**
- `parameterDefaults` option for OAuth clients (#517)
- `storeCredentials` on payment/order create (#480)
- `testmode`/`profileId` on the remaining endpoints; deprecate callback-as-second-argument overloads (#514)
- `testmode` on `permissions.get` (#503); `profileId` on the Apple Pay session (#512)
- `legalEntity`/`registrationOffice`/`incorporationDate` on Create client link (#495)
- `metadata` on connect balance transfers (#492); `mode`/`updatedAt` on the `Terminal` type (#507)

**Type & documentation sync**
- payments (#510, #516), settlements (#509), subscriptions (#504), profiles (#505), organizations (#502), refunds (#484), onboarding (#500), paymentLinks (#501), methods (#488), chargebacks (#487), capabilities/OAuth/customers (#494, #496, #498)

**Fixes**
- Capture payment embedding via `embed` instead of the ignored `include` (#483)

**Deprecations**
- Deprecate the Orders API (#486)

**Maintenance**
- npm Trusted Publishing / OIDC (#485); dev-deps + `form-data` advisory (#482)

**Release prep (this PR)**
- Update changelog, add missing `@since 4.6.0` tags, deprecate the numeric profiles `categoryCode`, clarify the release-process docs, and bump to 4.6.0.
